### PR TITLE
Change TLS termination type to reencrypt

### DIFF
--- a/pkg/controller/gitopsservice/gitopsservice_controller.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller.go
@@ -315,7 +315,7 @@ func newRouteForCR(cr *pipelinesv1alpha1.GitopsService) *routev1.Route {
 			TargetPort: intstr.IntOrString{IntVal: port},
 		},
 		TLS: &routev1.TLSConfig{
-			Termination:                   routev1.TLSTerminationEdge,
+			Termination:                   routev1.TLSTerminationReencrypt,
 			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 		},
 	}


### PR DESCRIPTION
Currently, the route is configured to use TLS termination of type `edge`. This is causing an error when the client is skipping TLS verification
Error:
```
Client sent an HTTP request to an HTTPS server.
``` 
This PR changes the termination type to `reencrypt` , which will make sure the request sent to the backend service is of type `https`