### PR TITLE
Change the CRD version from v1 to v1beta1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ That's it, your API `route` should be created for you. You don't need to explicl
 2. Login to a cluster on your command-line.
 3. `OPERATOR_NAME=gitops-operator operator-sdk run local --watch-namespace=openshift-pipelines-app-delivery`
 
+**Note:** Please check that you're using [operator-sdk]( https://github.com/operator-framework/operator-sdk/releases/tag/v0.17.2) version 0.17 or earlier. Since the community-operators do not support `v1` version of `CustomResourceDefinition`, the operator is using `v1beta1` version of `CustomResourceDefinition`.
 
 ## Tests
 

--- a/deploy/crds/pipelines.openshift.io_gitopsservices_crd.yaml
+++ b/deploy/crds/pipelines.openshift.io_gitopsservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: gitopsservices.pipelines.openshift.io
@@ -10,32 +10,33 @@ spec:
     plural: gitopsservices
     singular: gitopsservice
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: GitopsService is the Schema for the gitopsservices API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: GitopsServiceSpec defines the desired state of GitopsService
+          type: object
+        status:
+          description: GitopsServiceStatus defines the observed state of GitopsService
+          type: object
+      type: object
+  version: v1alpha1
   versions:
   - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: GitopsService is the Schema for the gitopsservices API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: GitopsServiceSpec defines the desired state of GitopsService
-            type: object
-          status:
-            description: GitopsServiceStatus defines the observed state of GitopsService
-            type: object
-        type: object
     served: true
     storage: true
-    subresources:
-      status: {}

--- a/deploy/olm-catalog/gitops-operator/manifests/pipelines.openshift.io_gitopsservices_crd.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/pipelines.openshift.io_gitopsservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: gitopsservices.pipelines.openshift.io
@@ -10,32 +10,33 @@ spec:
     plural: gitopsservices
     singular: gitopsservice
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: GitopsService is the Schema for the gitopsservices API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: GitopsServiceSpec defines the desired state of GitopsService
+          type: object
+        status:
+          description: GitopsServiceStatus defines the observed state of GitopsService
+          type: object
+      type: object
+  version: v1alpha1
   versions:
   - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: GitopsService is the Schema for the gitopsservices API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: GitopsServiceSpec defines the desired state of GitopsService
-            type: object
-          status:
-            description: GitopsServiceStatus defines the observed state of GitopsService
-            type: object
-        type: object
     served: true
     storage: true
-    subresources:
-      status: {}


### PR DESCRIPTION
Currently, the community operators don't support CRD version `apiextensions.k8s.io/v1`. We need to change the version back to `apiextensions.k8s.io/v1beta1` which was the case with earlier versions of `operator-sdk` (<18.0). I updated the CRDs with the following approach:

1. Install `operator-sdk` v0.17.0 locally.
2. Use `operator-sdk generate crds` to update the CRDs
3. Verify if the operator is working as expected

PR to add GItOps operator to OperatorHub: https://github.com/operator-framework/community-operators/pull/2293

Note: I did try to downgrade the `operator-sdk` version. Later inspected the ArgoCD operator and figured out it uses the latest version of `operator-sdk` and the only modified files are CRDs.