### PR TITLE
Read images from env variable to support disconnected cluster

### DIFF
--- a/pkg/controller/gitopsservice/gitopsservice_controller.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller.go
@@ -2,6 +2,7 @@ package gitopsservice
 
 import (
 	"context"
+	"os"
 
 	appsv1 "k8s.io/api/apps/v1"
 
@@ -31,7 +32,8 @@ var log = logf.Log.WithName("controller_gitopsservice")
 // defaults must some somewhere else..
 var (
 	port                int32  = 8080
-	image               string = "quay.io/redhat-developer/gitops-backend:v0.0.1"
+	backendImage        string = "quay.io/redhat-developer/gitops-backend:v0.0.1"
+	backendImageEnvName        = "BACKEND_IMAGE"
 	namespace                  = "openshift-pipelines-app-delivery"
 	name                       = "cluster"
 	insecureEnvVar             = "INSECURE"
@@ -219,6 +221,10 @@ func objectMeta(resourceName string, namespace string, opts ...func(*metav1.Obje
 }
 
 func newDeploymentForCR(cr *pipelinesv1alpha1.GitopsService) *appsv1.Deployment {
+	image := os.Getenv(backendImageEnvName)
+	if image == "" {
+		image = backendImage
+	}
 	podSpec := corev1.PodSpec{
 		Containers: []corev1.Container{
 			{

--- a/pkg/controller/gitopsservice/gitopsservice_controller_test.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller_test.go
@@ -1,0 +1,40 @@
+package gitopsservice
+
+import (
+	"os"
+	"testing"
+
+	pipelinesv1alpha1 "github.com/redhat-developer/gitops-operator/pkg/apis/pipelines/v1alpha1"
+)
+
+func TestImageFromEnvVariable(t *testing.T) {
+	cr := &pipelinesv1alpha1.GitopsService{}
+
+	t.Run("Image present as env variable", func(t *testing.T) {
+		image := "quay.io/org/test"
+		os.Setenv(backendImageEnvName, image)
+
+		deployment := newDeploymentForCR(cr)
+
+		got := deployment.Spec.Template.Spec.Containers[0].Image
+		if got != image {
+			t.Errorf("Image mismatch: got %s, want %s", got, image)
+		}
+		assertNoError(t, os.Unsetenv(backendImageEnvName))
+	})
+	t.Run("env variable for image not found", func(t *testing.T) {
+		deployment := newDeploymentForCR(cr)
+
+		got := deployment.Spec.Template.Spec.Containers[0].Image
+		if got != backendImage {
+			t.Errorf("Image mismatch: got %s, want %s", got, backendImage)
+		}
+	})
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/controller/gitopsservice/gitopsservice_controller_test.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller_test.go
@@ -13,6 +13,7 @@ func TestImageFromEnvVariable(t *testing.T) {
 	t.Run("Image present as env variable", func(t *testing.T) {
 		image := "quay.io/org/test"
 		os.Setenv(backendImageEnvName, image)
+		defer os.Unsetenv(backendImageEnvName)
 
 		deployment := newDeploymentForCR(cr)
 
@@ -20,7 +21,6 @@ func TestImageFromEnvVariable(t *testing.T) {
 		if got != image {
 			t.Errorf("Image mismatch: got %s, want %s", got, image)
 		}
-		assertNoError(t, os.Unsetenv(backendImageEnvName))
 	})
 	t.Run("env variable for image not found", func(t *testing.T) {
 		deployment := newDeploymentForCR(cr)
@@ -30,11 +30,4 @@ func TestImageFromEnvVariable(t *testing.T) {
 			t.Errorf("Image mismatch: got %s, want %s", got, backendImage)
 		}
 	})
-}
-
-func assertNoError(t *testing.T, err error) {
-	t.Helper()
-	if err != nil {
-		t.Fatal(err)
-	}
 }


### PR DESCRIPTION
Users in disconnected clusters rely on mirror registry and manage images using env variables. Read the image for backend service from an env variable to support disconnected environments.  