### PR TITLE
Pick up latest ArgoCD operator changes for managing cluster resources

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -39,6 +39,7 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 
 	argocd "github.com/argoproj-labs/argocd-operator/pkg/apis"
+	_ "github.com/argoproj-labs/argocd-operator/pkg/reconciler/openshift"
 
 	routev1 "github.com/openshift/api/route/v1"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.13
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210129122332-948578ed3922
+	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210129140555-ecd523a33d34
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.4.0
 	github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.13
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210122172254-9e257ece7953
+	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210129122332-948578ed3922
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.4.0
 	github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210122172254-9e257ece7953 h1:JyoYcz623nkNAbpCx2HzZLATVkAyw4lOwfzr/QmsUGk=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210122172254-9e257ece7953/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210129122332-948578ed3922 h1:9gQqW30r/q2bFNqJ7qW9/s9ndf3b4owX5MxUPHoICFM=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210129122332-948578ed3922/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210129122332-948578ed3922 h1:9gQqW30r/q2bFNqJ7qW9/s9ndf3b4owX5MxUPHoICFM=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210129122332-948578ed3922/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210129140555-ecd523a33d34 h1:p6MYwWAEiFQnw1Fnz4USe+6zNyP/cxNHeWaAL04TocU=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210129140555-ecd523a33d34/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
This PR picks up the latest changes from ArgoCD operator - "Set env var to configure ArgoCD for Cluster Config"


No changes in the manifest files needed.