### PR TITLE
Watch for argocd route in the right namespace

### DIFF
--- a/pkg/controller/argocd/argocd.go
+++ b/pkg/controller/argocd/argocd.go
@@ -1,9 +1,13 @@
 package argocd
 
 import (
+	"strings"
+
 	argoapp "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
+	"github.com/redhat-developer/gitops-operator/pkg/controller/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
 
@@ -43,4 +47,16 @@ func NewCR(name, ns string) (*argoapp.ArgoCD, error) {
 			},
 		},
 	}, nil
+}
+
+// GetArgoCDNamespace returns the argocd installation namespace based on OpenShift Cluster version
+func GetArgoCDNamespace(client client.Client) (string, error) {
+	version, err := util.GetClusterVersion(client)
+	if err != nil {
+		return "", err
+	}
+	if strings.HasPrefix(version, "4.6") {
+		return depracatedArgoCDNS, nil
+	}
+	return argocdNS, nil
 }

--- a/pkg/controller/argocd/argocd_controller.go
+++ b/pkg/controller/argocd/argocd_controller.go
@@ -32,10 +32,11 @@ import (
 var logs = logf.Log.WithName("controller_argocd_route")
 
 const (
-	argocdNS        = "openshift-gitops"
-	consoleLinkName = "argocd"
-	argocdRouteName = "argocd-cluster-server"
-	iconFilePath    = "/argo.png"
+	argocdNS           = "openshift-gitops"
+	depracatedArgoCDNS = "openshift-pipelines-app-delivery"
+	consoleLinkName    = "argocd"
+	argocdRouteName    = "argocd-cluster-server"
+	iconFilePath       = "/argo.png"
 )
 
 //go:generate statik --src ./img -f
@@ -94,7 +95,7 @@ func filterPredicate(assert func(namespace, name string) bool) predicate.Funcs {
 }
 
 func filterArgoCDRoute(namespace, name string) bool {
-	return namespace == argocdNS && argocdRouteName == name
+	return (namespace == argocdNS || namespace == depracatedArgoCDNS) && argocdRouteName == name
 }
 
 // blank assignment to verify that ReconcileArgoCDRoute implements reconcile.Reconciler
@@ -119,9 +120,14 @@ func (r *ReconcileArgoCDRoute) Reconcile(request reconcile.Request) (reconcile.R
 
 	ctx := context.Background()
 
+	argocdNS, err := GetArgoCDNamespace(r.client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Fetch ArgoCD server route
 	argoCDRoute := &routev1.Route{}
-	err := r.client.Get(ctx, types.NamespacedName{Name: argocdRouteName, Namespace: argocdNS}, argoCDRoute)
+	err = r.client.Get(ctx, types.NamespacedName{Name: argocdRouteName, Namespace: argocdNS}, argoCDRoute)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			reqLogger.Info("ArgoCD server route not found", "Route.Namespace", argocdNS)

--- a/pkg/controller/argocd/argocd_controller_test.go
+++ b/pkg/controller/argocd/argocd_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	configv1 "github.com/openshift/api/config/v1"
 	console "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -106,6 +107,7 @@ func assertNoError(t *testing.T, err error) {
 func addKnownTypesToScheme(scheme *runtime.Scheme) {
 	scheme.AddKnownTypes(routev1.GroupVersion, &routev1.Route{})
 	scheme.AddKnownTypes(console.GroupVersion, &console.ConsoleLink{})
+	scheme.AddKnownTypes(configv1.GroupVersion, &configv1.ClusterVersion{})
 }
 
 func newRequest(namespace, name string) reconcile.Request {

--- a/pkg/controller/gitopsservice/gitopsservice_controller.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 
@@ -162,14 +161,9 @@ func (r *ReconcileGitopsService) Reconcile(request reconcile.Request) (reconcile
 		return reconcile.Result{}, err
 	}
 
-	clusterVersion, err := getClusterVersion(r.client)
+	namespace, err := argocd.GetArgoCDNamespace(r.client)
 	if err != nil {
 		return reconcile.Result{}, err
-	}
-
-	namespace := serviceNamespace
-	if strings.HasPrefix(clusterVersion, "4.6") {
-		namespace = depracatedServiceNamespace
 	}
 
 	namespaceRef := newNamespace(namespace)
@@ -196,7 +190,7 @@ func (r *ReconcileGitopsService) Reconcile(request reconcile.Request) (reconcile
 	}
 
 	existingArgoCD := &argoapp.ArgoCD{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: defaultArgoCDInstance.Name, Namespace: serviceNamespace}, existingArgoCD)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: defaultArgoCDInstance.Name, Namespace: namespace}, existingArgoCD)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new ArgoCD instance", "Namespace", defaultArgoCDInstance.Namespace, "Name", defaultArgoCDInstance.Name)
 		err = r.client.Create(context.TODO(), defaultArgoCDInstance)

--- a/pkg/controller/gitopsservice/gitopsservice_controller_test.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller_test.go
@@ -8,9 +8,9 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	pipelinesv1alpha1 "github.com/redhat-developer/gitops-operator/pkg/apis/pipelines/v1alpha1"
+	"github.com/redhat-developer/gitops-operator/pkg/controller/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -73,7 +73,7 @@ func TestReconcile_AppDeliveryNamespace(t *testing.T) {
 	s := scheme.Scheme
 	addKnownTypesToScheme(s)
 
-	fakeClient := fake.NewFakeClient(newClusterVersion("4.6.15"), newGitopsService())
+	fakeClient := fake.NewFakeClient(util.NewClusterVersion("4.6.15"), newGitopsService())
 	reconciler := newReconcileGitOpsService(fakeClient, s)
 
 	_, err := reconciler.Reconcile(newRequest("test", "test"))
@@ -88,7 +88,7 @@ func TestReconcile_GitOpsNamespace(t *testing.T) {
 	s := scheme.Scheme
 	addKnownTypesToScheme(s)
 
-	fakeClient := fake.NewFakeClient(newClusterVersion("4.7.1"), newGitopsService())
+	fakeClient := fake.NewFakeClient(util.NewClusterVersion("4.7.1"), newGitopsService())
 	reconciler := newReconcileGitOpsService(fakeClient, s)
 
 	_, err := reconciler.Reconcile(newRequest("test", "test"))
@@ -96,46 +96,6 @@ func TestReconcile_GitOpsNamespace(t *testing.T) {
 
 	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceNamespace}, &corev1.Namespace{})
 	assertNoError(t, err)
-}
-
-func TestGetClusterVersion(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
-	s := scheme.Scheme
-	addKnownTypesToScheme(s)
-
-	t.Run("Valid Cluster Version", func(t *testing.T) {
-		version := "4.7.1"
-		fakeClient := fake.NewFakeClient(newClusterVersion(version))
-		clusterVersion, err := getClusterVersion(fakeClient)
-		assertNoError(t, err)
-		if clusterVersion != version {
-			t.Fatalf("got %s, want %s", clusterVersion, version)
-		}
-	})
-	t.Run("Cluster Version not found", func(t *testing.T) {
-		fakeClient := fake.NewFakeClient()
-		clusterVersion, err := getClusterVersion(fakeClient)
-		assertNoError(t, err)
-		if clusterVersion != "" {
-			t.Fatalf("got %s, want %s", clusterVersion, "")
-		}
-	})
-}
-
-func newClusterVersion(version string) *configv1.ClusterVersion {
-	return &configv1.ClusterVersion{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: clusterVersionName,
-		},
-		Spec: configv1.ClusterVersionSpec{
-			Channel: "stable",
-		},
-		Status: configv1.ClusterVersionStatus{
-			Desired: configv1.Update{
-				Version: version,
-			},
-		},
-	}
 }
 
 func addKnownTypesToScheme(scheme *runtime.Scheme) {

--- a/pkg/controller/util/util.go
+++ b/pkg/controller/util/util.go
@@ -1,0 +1,45 @@
+package util
+
+import (
+	"context"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	clusterVersionName = "version"
+)
+
+// GetClusterVersion returns the OpenShift Cluster version in which the operator is installed
+func GetClusterVersion(client client.Client) (string, error) {
+	clusterVersion := &configv1.ClusterVersion{}
+	err := client.Get(context.TODO(), types.NamespacedName{Name: clusterVersionName}, clusterVersion)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return clusterVersion.Status.Desired.Version, nil
+}
+
+// NewClusterVersion returns a cluster version object
+func NewClusterVersion(version string) *configv1.ClusterVersion {
+	return &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterVersionName,
+		},
+		Spec: configv1.ClusterVersionSpec{
+			Channel: "stable",
+		},
+		Status: configv1.ClusterVersionStatus{
+			Desired: configv1.Update{
+				Version: version,
+			},
+		},
+	}
+}

--- a/pkg/controller/util/util_test.go
+++ b/pkg/controller/util/util_test.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetClusterVersion(t *testing.T) {
+	s := scheme.Scheme
+	addKnownTypesToScheme(s)
+
+	t.Run("Valid Cluster Version", func(t *testing.T) {
+		version := "4.7.1"
+		fakeClient := fake.NewFakeClient(NewClusterVersion(version))
+		clusterVersion, err := GetClusterVersion(fakeClient)
+		assertNoError(t, err)
+		if clusterVersion != version {
+			t.Fatalf("got %s, want %s", clusterVersion, version)
+		}
+	})
+	t.Run("Cluster Version not found", func(t *testing.T) {
+		fakeClient := fake.NewFakeClient()
+		clusterVersion, err := GetClusterVersion(fakeClient)
+		assertNoError(t, err)
+		if clusterVersion != "" {
+			t.Fatalf("got %s, want %s", clusterVersion, "")
+		}
+	})
+}
+
+func addKnownTypesToScheme(scheme *runtime.Scheme) {
+	scheme.AddKnownTypes(configv1.GroupVersion, &configv1.ClusterVersion{})
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -4,8 +4,8 @@ set -x
 
 E2E_TEST_NS="gitops-test"
 E2E_TEST_DIR=./test/e2e
-ARGOCD_NS="argocd"
-GITOPS_BACKEND_NS="openshift-gitops"
+ARGOCD_NS="openshift-gitops"
+DEPRACATED_ARGOCD_NS="openshift-pipelines-app-delivery"
 CONSOLE_LINK="argocd"
 
 echo "Checking if operator-sdk is installed"
@@ -30,5 +30,5 @@ operator-sdk test local $E2E_TEST_DIR --operator-namespace $E2E_TEST_NS --watch-
 echo "Cleaning e2e test resources"
 oc delete project $E2E_TEST_NS
 oc delete project $ARGOCD_NS
-oc delete project $GITOPS_BACKEND_NS
+oc delete project $DEPRACATED_ARGOCD_NS
 oc delete consolelink $CONSOLE_LINK


### PR DESCRIPTION
The gitops operator will create an argocd instance with route enabled in `openshift-pipelines-app-delivery`(4.6 cluster) or `openshift-gitops`(4.7 cluster) namespace. The operator must watch for the argocd route in the right namespace based on cluster version.

How to test:
1. Run the operator locally `make run-local`
2. Check for the backend service and argocd instance created in `openshift-pipelines-app-delivery`(4.6 cluster) or `openshift-gitops`(4.7 cluster) namespace.
3. Check if a console link is created
4. Verify e2e tests `make test-e2e`

Breaking Changes/Risk: kam generates argocd resources in argocd namespace. The namespace updates in the operator will not support kam. We need to update kam to generate resources in the right namespace


Note: This PR is pointing to #29 