### PR TITLE
Pick up fix for using red hat redis image arg list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.13
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210129140555-ecd523a33d34
+	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210202172630-8dc58b3d1588
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,6 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210129140555-ecd523a33d34 h1:p6MYwWAEiFQnw1Fnz4USe+6zNyP/cxNHeWaAL04TocU=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210129140555-ecd523a33d34/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
 github.com/argoproj-labs/argocd-operator v0.0.15-0.20210202172630-8dc58b3d1588 h1:rjefSsEWFaQKj8G6xYAluXIv7Lo4eFTWks5YKqo7IL0=
 github.com/argoproj-labs/argocd-operator v0.0.15-0.20210202172630-8dc58b3d1588/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/argoproj-labs/argocd-operator v0.0.15-0.20210129140555-ecd523a33d34 h1:p6MYwWAEiFQnw1Fnz4USe+6zNyP/cxNHeWaAL04TocU=
 github.com/argoproj-labs/argocd-operator v0.0.15-0.20210129140555-ecd523a33d34/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210202172630-8dc58b3d1588 h1:rjefSsEWFaQKj8G6xYAluXIv7Lo4eFTWks5YKqo7IL0=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210202172630-8dc58b3d1588/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
Pick up fix for using red hat redis image arg list which is addressed by  ttps://github.com/argoproj-labs/argocd-operator/pull/238