### PR TITLE
Fix Argo CD installation namespace for a 4.6 cluster

### DIFF
--- a/pkg/controller/argocd/argocd.go
+++ b/pkg/controller/argocd/argocd.go
@@ -1,13 +1,9 @@
 package argocd
 
 import (
-	"strings"
-
 	argoapp "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
-	"github.com/redhat-developer/gitops-operator/pkg/controller/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
 
@@ -47,16 +43,4 @@ func NewCR(name, ns string) (*argoapp.ArgoCD, error) {
 			},
 		},
 	}, nil
-}
-
-// GetArgoCDNamespace returns the argocd installation namespace based on OpenShift Cluster version
-func GetArgoCDNamespace(client client.Client) (string, error) {
-	version, err := util.GetClusterVersion(client)
-	if err != nil {
-		return "", err
-	}
-	if strings.HasPrefix(version, "4.6") {
-		return depracatedArgoCDNS, nil
-	}
-	return argocdNS, nil
 }

--- a/pkg/controller/argocd/argocd_controller.go
+++ b/pkg/controller/argocd/argocd_controller.go
@@ -95,7 +95,7 @@ func filterPredicate(assert func(namespace, name string) bool) predicate.Funcs {
 }
 
 func filterArgoCDRoute(namespace, name string) bool {
-	return (namespace == argocdNS || namespace == depracatedArgoCDNS) && argocdRouteName == name
+	return namespace == argocdNS && argocdRouteName == name
 }
 
 // blank assignment to verify that ReconcileArgoCDRoute implements reconcile.Reconciler
@@ -120,14 +120,9 @@ func (r *ReconcileArgoCDRoute) Reconcile(request reconcile.Request) (reconcile.R
 
 	ctx := context.Background()
 
-	argocdNS, err := GetArgoCDNamespace(r.client)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
 	// Fetch ArgoCD server route
 	argoCDRoute := &routev1.Route{}
-	err = r.client.Get(ctx, types.NamespacedName{Name: argocdRouteName, Namespace: argocdNS}, argoCDRoute)
+	err := r.client.Get(ctx, types.NamespacedName{Name: argocdRouteName, Namespace: argocdNS}, argoCDRoute)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			reqLogger.Info("ArgoCD server route not found", "Route.Namespace", argocdNS)

--- a/pkg/controller/gitopsservice/gitopsservice_controller.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller.go
@@ -163,7 +163,7 @@ func (r *ReconcileGitopsService) Reconcile(request reconcile.Request) (reconcile
 		return reconcile.Result{}, err
 	}
 
-	namespace, err := GetGitOpsServiceNamespace(r.client)
+	namespace, err := GetBackendNamespace(r.client)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -270,8 +270,8 @@ func (r *ReconcileGitopsService) Reconcile(request reconcile.Request) (reconcile
 	return r.reconcileCLIServer(instance, request)
 }
 
-// GetGitOpsServiceNamespace returns the backend service namespace based on OpenShift Cluster version
-func GetGitOpsServiceNamespace(client client.Client) (string, error) {
+// GetBackendNamespace returns the backend service namespace based on OpenShift Cluster version
+func GetBackendNamespace(client client.Client) (string, error) {
 	version, err := util.GetClusterVersion(client)
 	if err != nil {
 		return "", err

--- a/pkg/controller/gitopsservice/gitopsservice_controller.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 
 	argoapp "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	routev1 "github.com/openshift/api/route/v1"
 
-	configv1 "github.com/openshift/api/config/v1"
 	pipelinesv1alpha1 "github.com/redhat-developer/gitops-operator/pkg/apis/pipelines/v1alpha1"
 	argocd "github.com/redhat-developer/gitops-operator/pkg/controller/argocd"
+	"github.com/redhat-developer/gitops-operator/pkg/controller/util"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -162,7 +163,7 @@ func (r *ReconcileGitopsService) Reconcile(request reconcile.Request) (reconcile
 		return reconcile.Result{}, err
 	}
 
-	namespace, err := argocd.GetArgoCDNamespace(r.client)
+	namespace, err := GetGitOpsServiceNamespace(r.client)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -183,7 +184,20 @@ func (r *ReconcileGitopsService) Reconcile(request reconcile.Request) (reconcile
 	}
 
 	argoCDIdentifier := fmt.Sprintf("argocd-%s", request.Name)
-	defaultArgoCDInstance, err := argocd.NewCR(argoCDIdentifier, namespace)
+	defaultArgoCDInstance, err := argocd.NewCR(argoCDIdentifier, serviceNamespace)
+
+	// The operator decides the namespace based on the version of the cluster it is installed in
+	// 4.6 Cluster: Backend in openshift-pipelines-app-delivery namespace and argocd in openshift-gitops namespace
+	// 4.7 Cluster: Both backend and argocd instance in openshift-gitops namespace
+	argocdNS := newNamespace(defaultArgoCDInstance.Namespace)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: argocdNS.Name}, &corev1.Namespace{})
+	if err != nil && errors.IsNotFound(err) {
+		reqLogger.Info("Creating a new Namespace", "Name", argocdNS.Name)
+		err = r.client.Create(context.TODO(), argocdNS)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
 
 	// Set GitopsService instance as the owner and controller
 	if err := controllerutil.SetControllerReference(instance, defaultArgoCDInstance, r.scheme); err != nil {
@@ -191,7 +205,7 @@ func (r *ReconcileGitopsService) Reconcile(request reconcile.Request) (reconcile
 	}
 
 	existingArgoCD := &argoapp.ArgoCD{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: defaultArgoCDInstance.Name, Namespace: namespace}, existingArgoCD)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: defaultArgoCDInstance.Name, Namespace: defaultArgoCDInstance.Namespace}, existingArgoCD)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new ArgoCD instance", "Namespace", defaultArgoCDInstance.Namespace, "Name", defaultArgoCDInstance.Name)
 		err = r.client.Create(context.TODO(), defaultArgoCDInstance)
@@ -256,16 +270,16 @@ func (r *ReconcileGitopsService) Reconcile(request reconcile.Request) (reconcile
 	return r.reconcileCLIServer(instance, request)
 }
 
-func getClusterVersion(client client.Client) (string, error) {
-	clusterVersion := &configv1.ClusterVersion{}
-	err := client.Get(context.TODO(), types.NamespacedName{Name: clusterVersionName}, clusterVersion)
+// GetGitOpsServiceNamespace returns the backend service namespace based on OpenShift Cluster version
+func GetGitOpsServiceNamespace(client client.Client) (string, error) {
+	version, err := util.GetClusterVersion(client)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return "", nil
-		}
 		return "", err
 	}
-	return clusterVersion.Status.Desired.Version, nil
+	if strings.HasPrefix(version, "4.6") {
+		return depracatedServiceNamespace, nil
+	}
+	return serviceNamespace, nil
 }
 
 func objectMeta(resourceName string, namespace string, opts ...func(*metav1.ObjectMeta)) metav1.ObjectMeta {

--- a/pkg/controller/gitopsservice/gitopsservice_controller_test.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller_test.go
@@ -153,7 +153,7 @@ func TestReconcile_GitOpsNamespace(t *testing.T) {
 	}
 }
 
-func TestGetGitOpsServiceNamespace(t *testing.T) {
+func TestGetBackendNamespace(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	s := scheme.Scheme
 	addKnownTypesToScheme(s)
@@ -168,19 +168,19 @@ func TestGetGitOpsServiceNamespace(t *testing.T) {
 
 	t.Run("Using a 4.7 Cluster", func(t *testing.T) {
 		fakeClient := fake.NewFakeClient(util.NewClusterVersion("4.7.1"), newGitopsService())
-		namespace, err := GetGitOpsServiceNamespace(fakeClient)
+		namespace, err := GetBackendNamespace(fakeClient)
 		assertNamespace(t, err, namespace, serviceNamespace)
 	})
 
 	t.Run("Using a 4.6 Cluster", func(t *testing.T) {
 		fakeClient := fake.NewFakeClient(util.NewClusterVersion("4.6.1"), newGitopsService())
-		namespace, err := GetGitOpsServiceNamespace(fakeClient)
+		namespace, err := GetBackendNamespace(fakeClient)
 		assertNamespace(t, err, namespace, depracatedServiceNamespace)
 	})
 
 	t.Run("Using a 4.X Cluster", func(t *testing.T) {
 		fakeClient := fake.NewFakeClient(util.NewClusterVersion("4.X.1"), newGitopsService())
-		namespace, err := GetGitOpsServiceNamespace(fakeClient)
+		namespace, err := GetBackendNamespace(fakeClient)
 		assertNamespace(t, err, namespace, serviceNamespace)
 	})
 }

--- a/pkg/controller/gitopsservice/gitopsservice_controller_test.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	argoapp "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	pipelinesv1alpha1 "github.com/redhat-developer/gitops-operator/pkg/apis/pipelines/v1alpha1"
@@ -77,6 +78,7 @@ func TestReconcile(t *testing.T) {
 	_, err := reconciler.Reconcile(newRequest("test", "test"))
 	assertNoError(t, err)
 
+	// Check if backend resources are created in openshift-gitops namespace
 	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceNamespace}, &corev1.Namespace{})
 	assertNoError(t, err)
 
@@ -87,6 +89,10 @@ func TestReconcile(t *testing.T) {
 	assertNoError(t, err)
 
 	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}, &routev1.Route{})
+	assertNoError(t, err)
+
+	// Check if argocd instance is created in openshift-gitops namespace
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "argocd-test", Namespace: serviceNamespace}, &argoapp.ArgoCD{})
 	assertNoError(t, err)
 }
 
@@ -101,7 +107,27 @@ func TestReconcile_AppDeliveryNamespace(t *testing.T) {
 	_, err := reconciler.Reconcile(newRequest("test", "test"))
 	assertNoError(t, err)
 
+	// Check if both openshift-gitops and openshift-pipelines-app-delivey namespace is created
 	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: depracatedServiceNamespace}, &corev1.Namespace{})
+	assertNoError(t, err)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceNamespace}, &corev1.Namespace{})
+	assertNoError(t, err)
+
+	// Check if backend resources are created in openshift-pipelines-app-delivery namespace
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: depracatedServiceNamespace}, &corev1.Namespace{})
+	assertNoError(t, err)
+
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceName, Namespace: depracatedServiceNamespace}, &appsv1.Deployment{})
+	assertNoError(t, err)
+
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceName, Namespace: depracatedServiceNamespace}, &corev1.Service{})
+	assertNoError(t, err)
+
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceName, Namespace: depracatedServiceNamespace}, &routev1.Route{})
+	assertNoError(t, err)
+
+	// Check if argocd instance is created in openshift-gitops namespace
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "argocd-test", Namespace: serviceNamespace}, &argoapp.ArgoCD{})
 	assertNoError(t, err)
 }
 
@@ -116,14 +142,54 @@ func TestReconcile_GitOpsNamespace(t *testing.T) {
 	_, err := reconciler.Reconcile(newRequest("test", "test"))
 	assertNoError(t, err)
 
+	// Check if only openshift-gitops namespace is created
 	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceNamespace}, &corev1.Namespace{})
 	assertNoError(t, err)
+
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: depracatedServiceNamespace}, &corev1.Namespace{})
+	wantErr := `namespaces "openshift-pipelines-app-delivery" not found`
+	if err == nil {
+		t.Fatalf("was expecting an error %s, but got nil", wantErr)
+	}
+}
+
+func TestGetGitOpsServiceNamespace(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	s := scheme.Scheme
+	addKnownTypesToScheme(s)
+
+	assertNamespace := func(t *testing.T, err error, got, want string) {
+		t.Helper()
+		assertNoError(t, err)
+		if got != want {
+			t.Fatalf("namespace mismatch: got %s, want %s", got, want)
+		}
+	}
+
+	t.Run("Using a 4.7 Cluster", func(t *testing.T) {
+		fakeClient := fake.NewFakeClient(util.NewClusterVersion("4.7.1"), newGitopsService())
+		namespace, err := GetGitOpsServiceNamespace(fakeClient)
+		assertNamespace(t, err, namespace, serviceNamespace)
+	})
+
+	t.Run("Using a 4.6 Cluster", func(t *testing.T) {
+		fakeClient := fake.NewFakeClient(util.NewClusterVersion("4.6.1"), newGitopsService())
+		namespace, err := GetGitOpsServiceNamespace(fakeClient)
+		assertNamespace(t, err, namespace, depracatedServiceNamespace)
+	})
+
+	t.Run("Using a 4.X Cluster", func(t *testing.T) {
+		fakeClient := fake.NewFakeClient(util.NewClusterVersion("4.X.1"), newGitopsService())
+		namespace, err := GetGitOpsServiceNamespace(fakeClient)
+		assertNamespace(t, err, namespace, serviceNamespace)
+	})
 }
 
 func addKnownTypesToScheme(scheme *runtime.Scheme) {
 	scheme.AddKnownTypes(configv1.GroupVersion, &configv1.ClusterVersion{})
 	scheme.AddKnownTypes(pipelinesv1alpha1.SchemeGroupVersion, &pipelinesv1alpha1.GitopsService{})
 	scheme.AddKnownTypes(routev1.GroupVersion, &routev1.Route{})
+	scheme.AddKnownTypes(argoapp.SchemeGroupVersion, &argoapp.ArgoCD{})
 }
 
 func newReconcileGitOpsService(client client.Client, scheme *runtime.Scheme) *ReconcileGitopsService {

--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	"github.com/redhat-developer/gitops-operator/pkg/apis"
 	operator "github.com/redhat-developer/gitops-operator/pkg/apis/pipelines/v1alpha1"
-	"github.com/redhat-developer/gitops-operator/pkg/controller/argocd"
+	"github.com/redhat-developer/gitops-operator/pkg/controller/gitopsservice"
 )
 
 var (
@@ -60,7 +60,7 @@ func validateGitOpsBackend(t *testing.T) {
 
 	name := "cluster"
 	f := framework.Global
-	namespace, err := argocd.GetArgoCDNamespace(f.Client.Client)
+	namespace, err := gitopsservice.GetGitOpsServiceNamespace(f.Client.Client)
 	assertNoError(t, err)
 
 	// check backend deployment

--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -82,11 +82,8 @@ func validateConsoleLink(t *testing.T) {
 	framework.AddToFrameworkScheme(configv1.AddToScheme, &configv1.ClusterVersion{})
 	f := framework.Global
 
-	argoCDNamespace, err := argocd.GetArgoCDNamespace(f.Client.Client)
-	assertNoError(t, err)
-
 	route := &routev1.Route{}
-	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: argoCDRouteName, Namespace: argoCDNamespace}, route)
+	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: argoCDRouteName, Namespace: argoCDNamespace}, route)
 	assertNoError(t, err)
 
 	// check ConsoleLink
@@ -122,11 +119,8 @@ func validateArgoCDInstallation(t *testing.T) {
 
 	f := framework.Global
 
-	argoCDNamespace, err := argocd.GetArgoCDNamespace(f.Client.Client)
-	assertNoError(t, err)
-
 	// Check if argocd namespace is created
-	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: argoCDNamespace}, &corev1.Namespace{})
+	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: argoCDNamespace}, &corev1.Namespace{})
 	assertNoError(t, err)
 
 	// Check if ArgoCD instance is created
@@ -162,4 +156,3 @@ func assertNoError(t *testing.T, err error) {
 		t.Fatal(err)
 	}
 }
-

--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -60,7 +60,7 @@ func validateGitOpsBackend(t *testing.T) {
 
 	name := "cluster"
 	f := framework.Global
-	namespace, err := gitopsservice.GetGitOpsServiceNamespace(f.Client.Client)
+	namespace, err := gitopsservice.GetBackendNamespace(f.Client.Client)
 	assertNoError(t, err)
 
 	// check backend deployment


### PR DESCRIPTION
The operator will decide the namespace based on the version of the cluster it is running in.

Expected behavior
4.6 Cluster: Backend service in `openshift-pipelines-app-delivery` and argocd in `openshift-gitops` namespace
4.7 Cluster: Both backend service and argocd in `openshift-gitops` namespace

How to test:
1. Install argocd operator
2. Observe if argocd is installed in `openshift-gitops` namespace
3. If it's a 4.6 cluster, the backend will be deployed in `openshift-pipelines-app-delivery` namespace else it'll get deployed in `openshift-gitops` namespace