### PR TITLE
Use Red Hat provided redis image as default

### DIFF
--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -160,6 +160,8 @@ spec:
                   value: gitops-operator
                 - name: DISABLE_DEX
                   value: "true"
+                - name: ARGOCD_REDIS_IMAGE
+                  value: "registry.redhat.io/rhel8/redis-5"
                 image: quay.io/redhat-developer/gitops-backend-operator:v0.0.3
                 imagePullPolicy: Always
                 name: gitops-operator


### PR DESCRIPTION
This is in accordance to PR https://github.com/argoproj-labs/argocd-operator/pull/238.

GitOps operator by default should use a Red Hat provided redis image. 