### PR TITLE
Fix default kam CLI image

### DIFF
--- a/pkg/controller/gitopsservice/kam.go
+++ b/pkg/controller/gitopsservice/kam.go
@@ -21,7 +21,7 @@ import (
 
 const cliName = "kam"
 const cliLongName = "GitOps Application Manager"
-const cliImage = "registry.redhat.io/openshift-gitops-1-tech-preview/kam-delivery-rhel8:1.0-tech-preview"
+const cliImage = "quay.io/redhat-developer/kam:v0.0.19"
 const cliImageEnvName = "KAM_IMAGE"
 const kubeAppLabelName = "app.kubernetes.io/name"
 


### PR DESCRIPTION
The current kam image deployed throws an `imagePullBackOff` error. Update the default kam CLI image to use the public quay image