### PR TITLE
Add permission to create console download link resource

### DIFF
--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -387,6 +387,18 @@ spec:
           verbs:
           - get
           - list
+          - watch
+        - apiGroups:
+          - console.openshift.io
+          resources:
+          - consoleclidownloads
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
         serviceAccountName: gitops-operator
     strategy: deployment
   installModes:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -130,3 +130,15 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - console.openshift.io
+  resources:
+  - consoleclidownloads
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch


### PR DESCRIPTION
Add the permissions to create and manage console download links
```
Reconciler error","controller":"gitopsservice-controller","request":"/cluster","error":"consoleclidownloads.console.openshift.io is forbidden: User \"system:serviceaccount:openshift-operators:gitops-operator\" cannot create resource \"consoleclidownloads\" in API group \"console.openshift.io\" at the cluster scope
```

How to test:
1. Install the operator
2. GitOps application manager link should be present in the list

![Screenshot from 2021-02-05 00-14-28](https://user-images.githubusercontent.com/21128732/106940595-c0ce0c00-6747-11eb-9074-ce32164912e3.png)

