### PR TITLE
Rename "Application Stages" to "OpenShift GitOps"

### DIFF
--- a/pkg/controller/argocd/argocd_controller.go
+++ b/pkg/controller/argocd/argocd_controller.go
@@ -170,7 +170,7 @@ func newConsoleLink(href, text string) *console.ConsoleLink {
 			},
 			Location: console.ApplicationMenu,
 			ApplicationMenu: &console.ApplicationMenuSpec{
-				Section:  "Application Stages",
+				Section:  "OpenShift GitOps",
 				ImageURL: image,
 			},
 		},


### PR DESCRIPTION
The ConsoleLink Header doesn't make much sense if called "Application Stages" anymore since the ArgoCD instance is also intended to be used for cluster configuration.