### PR TITLE
pick up upstream fixes for dex reconcile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.13
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210205153727-cd8ed15cc61b
+	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210211102851-2e5f5e98588c
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210205153727-cd8ed15cc61b h1:yv9ntQ1jrBD5bIBN0In8v0d88Ijypq8rHfW3s9Pwu7c=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210205153727-cd8ed15cc61b/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210211102851-2e5f5e98588c h1:SHkwbuJgmmSIw4KsUWdFoQvdFFV2/1drVAIcw0gmYdE=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210211102851-2e5f5e98588c/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
Picks up the following fixes from upstream ArgoCD Operator - 

- https://github.com/argoproj-labs/argocd-operator/pull/243
- https://github.com/argoproj-labs/argocd-operator/pull/243

Issue:
The issue that this PR addresses is that the operator was creating Role, Role-Binding and Service-Account for Dex even when the service was disabled for OOTB ArgoCD instance. 

Tests: 
Performed manual test by deploying the GitOps Operator with above fixes and verified that specified resources were not created for the OOTB ArgoCD Instance anymore. 