### PR TITLE
Add controller to enable metrics/alerts for argocd instances

### DIFF
--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -234,6 +234,7 @@ spec:
           - monitoring.coreos.com
           resources:
           - prometheuses
+          - prometheusrules
           - servicemonitors
           verbs:
           - '*'

--- a/pkg/controller/add_argocd_metrics.go
+++ b/pkg/controller/add_argocd_metrics.go
@@ -1,0 +1,10 @@
+package controller
+
+import (
+	"github.com/redhat-developer/gitops-operator/pkg/controller/argocdmetrics"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, argocdmetrics.Add)
+}

--- a/pkg/controller/argocdmetrics/argocd_metrics_controller_test.go
+++ b/pkg/controller/argocdmetrics/argocd_metrics_controller_test.go
@@ -1,0 +1,274 @@
+package argocdmetrics
+
+import (
+	"context"
+	"fmt"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"testing"
+)
+
+func newScheme() *runtime.Scheme {
+	s := scheme.Scheme
+	s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Namespace{})
+	s.AddKnownTypes(monitoringv1.SchemeGroupVersion, &monitoringv1.ServiceMonitor{})
+	s.AddKnownTypes(monitoringv1.SchemeGroupVersion, &monitoringv1.PrometheusRule{})
+	return s
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertEquals(t *testing.T, actual interface{}, expected interface{}) {
+	t.Helper()
+	if actual != expected {
+		t.Fatal(fmt.Sprintf("expected %+v got %+v", expected, actual))
+	}
+}
+
+func assertNotEquals(t *testing.T, actual interface{}, unexpected interface{}) {
+	t.Helper()
+	if actual == unexpected {
+		t.Fatal(fmt.Sprintf("value should not be equal to \"%+v\"", actual))
+	}
+}
+
+func assertSameElements(t *testing.T, actual []string, expected ...string) {
+	t.Helper()
+	if len(actual) != len(expected) {
+		t.Fatal(fmt.Sprintf("expected %+v got %+v", expected, actual))
+	}
+	actualMap := make(map[string]bool)
+	for _, v := range actual {
+		actualMap[v] = true
+	}
+	for _, v := range expected {
+		if !actualMap[v] {
+			t.Fatal(fmt.Sprintf("actual %+v does not contain element \"%+v\"", actual, v))
+		}
+	}
+}
+
+func newClient(s *runtime.Scheme, namespace string) client.Client {
+	ns := corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+	return fake.NewFakeClientWithScheme(s, &ns)
+}
+
+func newRequest(namespace, name string) reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func newMetricsReconciler(t *testing.T, namespace string) ArgoCDMetricsReconciler {
+	t.Helper()
+	s := newScheme()
+	c := newClient(s, namespace)
+	r := ArgoCDMetricsReconciler{client: c, scheme: s}
+	return r
+}
+
+func TestReconcile_add_namespace_label(t *testing.T) {
+	testCases := []struct {
+		instanceName string
+		namespace    string
+	}{
+		{
+			instanceName: "argocd-cluster",
+			namespace:    "openshift-gitops",
+		},
+		{
+			instanceName: "instance-two",
+			namespace:    "namespace-two",
+		},
+	}
+	for _, tc := range testCases {
+		r := newMetricsReconciler(t, tc.namespace)
+		_, err := r.Reconcile(newRequest(tc.namespace, tc.instanceName))
+		assertNoError(t, err)
+
+		ns := corev1.Namespace{}
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: tc.namespace}, &ns)
+		assertNoError(t, err)
+		value := ns.Labels["openshift.io/cluster-monitoring"]
+		assertEquals(t, value, "true")
+	}
+}
+
+func TestReconcile_add_read_role(t *testing.T) {
+	testCases := []struct {
+		instanceName string
+		namespace    string
+	}{
+		{
+			instanceName: "argocd-cluster",
+			namespace:    "openshift-gitops",
+		},
+		{
+			instanceName: "instance-two",
+			namespace:    "namespace-two",
+		},
+	}
+	for _, tc := range testCases {
+		r := newMetricsReconciler(t, tc.namespace)
+		_, err := r.Reconcile(newRequest(tc.namespace, tc.instanceName))
+		assertNoError(t, err)
+
+		role := rbacv1.Role{}
+		readRoleName := fmt.Sprintf("%s-read", tc.namespace)
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: readRoleName, Namespace: tc.namespace}, &role)
+		assertNoError(t, err)
+
+		assertEquals(t, len(role.Rules), 1)
+		assertEquals(t, role.Rules[0].APIGroups[0], "")
+		assertSameElements(t, role.Rules[0].Resources, "endpoints", "pods", "services")
+		assertSameElements(t, role.Rules[0].Verbs, "get", "list", "watch")
+	}
+}
+
+func TestReconcile_add_read_role_binding(t *testing.T) {
+	testCases := []struct {
+		instanceName string
+		namespace    string
+	}{
+		{
+			instanceName: "argocd-cluster",
+			namespace:    "openshift-gitops",
+		},
+		{
+			instanceName: "instance-two",
+			namespace:    "namespace-two",
+		},
+	}
+	for _, tc := range testCases {
+		r := newMetricsReconciler(t, tc.namespace)
+		_, err := r.Reconcile(newRequest(tc.namespace, tc.instanceName))
+		assertNoError(t, err)
+
+		roleBinding := rbacv1.RoleBinding{}
+		err = r.client.Get(context.TODO(),
+			types.NamespacedName{Name: fmt.Sprintf("%s-prometheus-k8s-read-binding", tc.namespace), Namespace: tc.namespace},
+			&roleBinding)
+		assertNoError(t, err)
+
+		readRoleName := fmt.Sprintf("%s-read", tc.namespace)
+		assertEquals(t, roleBinding.RoleRef, rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     readRoleName,
+		},
+		)
+		assertEquals(t, roleBinding.Subjects[0], rbacv1.Subject{
+			Kind:      "ServiceAccount",
+			Name:      "prometheus-k8s",
+			Namespace: "openshift-monitoring",
+		})
+	}
+}
+
+func TestReconcile_add_service_monitors(t *testing.T) {
+	testCases := []struct {
+		instanceName string
+		namespace    string
+	}{
+		{
+			instanceName: "argocd-cluster",
+			namespace:    "openshift-gitops",
+		},
+		{
+			instanceName: "instance-two",
+			namespace:    "namespace-two",
+		},
+	}
+	for _, tc := range testCases {
+		r := newMetricsReconciler(t, tc.namespace)
+		_, err := r.Reconcile(newRequest(tc.namespace, tc.instanceName))
+		assertNoError(t, err)
+
+		serviceMonitor := monitoringv1.ServiceMonitor{}
+		serviceMonitorName := tc.instanceName
+		matchLabel := fmt.Sprintf("%s-metrics", serviceMonitorName)
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: serviceMonitorName, Namespace: tc.namespace}, &serviceMonitor)
+		assertNoError(t, err)
+		assertEquals(t, len(serviceMonitor.ObjectMeta.Labels), 1)
+		assertEquals(t, serviceMonitor.ObjectMeta.Labels["release"], "prometheus-operator")
+		assertEquals(t, len(serviceMonitor.Spec.Selector.MatchLabels), 1)
+		assertEquals(t, serviceMonitor.Spec.Selector.MatchLabels["app.kubernetes.io/name"], matchLabel)
+		assertEquals(t, len(serviceMonitor.Spec.Endpoints), 1)
+		assertEquals(t, serviceMonitor.Spec.Endpoints[0].Port, "metrics")
+
+		serviceMonitor = monitoringv1.ServiceMonitor{}
+		serviceMonitorName = fmt.Sprintf("%s-server", tc.instanceName)
+		matchLabel = fmt.Sprintf("%s-metrics", serviceMonitorName)
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: serviceMonitorName, Namespace: tc.namespace}, &serviceMonitor)
+		assertNoError(t, err)
+		assertEquals(t, len(serviceMonitor.ObjectMeta.Labels), 1)
+		assertEquals(t, serviceMonitor.ObjectMeta.Labels["release"], "prometheus-operator")
+		assertEquals(t, len(serviceMonitor.Spec.Selector.MatchLabels), 1)
+		assertEquals(t, serviceMonitor.Spec.Selector.MatchLabels["app.kubernetes.io/name"], matchLabel)
+		assertEquals(t, len(serviceMonitor.Spec.Endpoints), 1)
+		assertEquals(t, serviceMonitor.Spec.Endpoints[0].Port, "metrics")
+
+		serviceMonitor = monitoringv1.ServiceMonitor{}
+		serviceMonitorName = fmt.Sprintf("%s-repo-server", tc.instanceName)
+		matchLabel = serviceMonitorName
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: serviceMonitorName, Namespace: tc.namespace}, &serviceMonitor)
+		assertNoError(t, err)
+		assertEquals(t, len(serviceMonitor.ObjectMeta.Labels), 1)
+		assertEquals(t, serviceMonitor.ObjectMeta.Labels["release"], "prometheus-operator")
+		assertEquals(t, len(serviceMonitor.Spec.Selector.MatchLabels), 1)
+		assertEquals(t, serviceMonitor.Spec.Selector.MatchLabels["app.kubernetes.io/name"], matchLabel)
+		assertEquals(t, len(serviceMonitor.Spec.Endpoints), 1)
+		assertEquals(t, serviceMonitor.Spec.Endpoints[0].Port, "metrics")
+	}
+}
+
+func TestReconciler_add_prometheus_rule(t *testing.T) {
+	testCases := []struct {
+		instanceName string
+		namespace    string
+	}{
+		{
+			instanceName: "argocd-cluster",
+			namespace:    "openshift-gitops",
+		},
+		{
+			instanceName: "instance-two",
+			namespace:    "namespace-two",
+		},
+	}
+	for _, tc := range testCases {
+		r := newMetricsReconciler(t, tc.namespace)
+		_, err := r.Reconcile(newRequest(tc.namespace, tc.instanceName))
+		assertNoError(t, err)
+
+		rule := monitoringv1.PrometheusRule{}
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: "gitops-operator-argocd-alerts", Namespace: tc.namespace}, &rule)
+		assertNoError(t, err)
+
+		assertEquals(t, rule.Spec.Groups[0].Rules[0].Alert, "ArgoCDSyncAlert")
+		assertNotEquals(t, rule.Spec.Groups[0].Rules[0].Annotations["message"], "")
+		assertNotEquals(t, rule.Spec.Groups[0].Rules[0].Labels["severity"], "")
+		expr := fmt.Sprintf("argocd_app_info{namespace=\"%s\",sync_status=\"OutOfSync\"} > 0", tc.namespace)
+		assertEquals(t, rule.Spec.Groups[0].Rules[0].Expr.StrVal, expr)
+	}
+}

--- a/pkg/controller/argocdmetrics/argocd_metrics_controller_test.go
+++ b/pkg/controller/argocdmetrics/argocd_metrics_controller_test.go
@@ -3,7 +3,10 @@ package argocdmetrics
 import (
 	"context"
 	"fmt"
+	argoapp "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,56 +21,30 @@ import (
 
 func newScheme() *runtime.Scheme {
 	s := scheme.Scheme
+	s.AddKnownTypes(argoapp.SchemeGroupVersion, &argoapp.ArgoCD{})
 	s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Namespace{})
 	s.AddKnownTypes(monitoringv1.SchemeGroupVersion, &monitoringv1.ServiceMonitor{})
 	s.AddKnownTypes(monitoringv1.SchemeGroupVersion, &monitoringv1.PrometheusRule{})
 	return s
 }
 
-func assertNoError(t *testing.T, err error) {
-	t.Helper()
-	if err != nil {
-		t.Fatal(err)
-	}
-}
+const (
+	argocdKind = "ArgoCD"
+)
 
-func assertEquals(t *testing.T, actual interface{}, expected interface{}) {
-	t.Helper()
-	if actual != expected {
-		t.Fatal(fmt.Sprintf("expected %+v got %+v", expected, actual))
-	}
-}
-
-func assertNotEquals(t *testing.T, actual interface{}, unexpected interface{}) {
-	t.Helper()
-	if actual == unexpected {
-		t.Fatal(fmt.Sprintf("value should not be equal to \"%+v\"", actual))
-	}
-}
-
-func assertSameElements(t *testing.T, actual []string, expected ...string) {
-	t.Helper()
-	if len(actual) != len(expected) {
-		t.Fatal(fmt.Sprintf("expected %+v got %+v", expected, actual))
-	}
-	actualMap := make(map[string]bool)
-	for _, v := range actual {
-		actualMap[v] = true
-	}
-	for _, v := range expected {
-		if !actualMap[v] {
-			t.Fatal(fmt.Sprintf("actual %+v does not contain element \"%+v\"", actual, v))
-		}
-	}
-}
-
-func newClient(s *runtime.Scheme, namespace string) client.Client {
+func newClient(s *runtime.Scheme, namespace, name string) client.Client {
 	ns := corev1.Namespace{
 		ObjectMeta: v1.ObjectMeta{
 			Name: namespace,
 		},
 	}
-	return fake.NewFakeClientWithScheme(s, &ns)
+	argocd := argoapp.ArgoCD{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	return fake.NewFakeClientWithScheme(s, &ns, &argocd)
 }
 
 func newRequest(namespace, name string) reconcile.Request {
@@ -79,10 +56,10 @@ func newRequest(namespace, name string) reconcile.Request {
 	}
 }
 
-func newMetricsReconciler(t *testing.T, namespace string) ArgoCDMetricsReconciler {
+func newMetricsReconciler(t *testing.T, namespace, name string) ArgoCDMetricsReconciler {
 	t.Helper()
 	s := newScheme()
-	c := newClient(s, namespace)
+	c := newClient(s, namespace, name)
 	r := ArgoCDMetricsReconciler{client: c, scheme: s}
 	return r
 }
@@ -102,15 +79,15 @@ func TestReconcile_add_namespace_label(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		r := newMetricsReconciler(t, tc.namespace)
+		r := newMetricsReconciler(t, tc.namespace, tc.instanceName)
 		_, err := r.Reconcile(newRequest(tc.namespace, tc.instanceName))
-		assertNoError(t, err)
+		assert.NilError(t, err)
 
 		ns := corev1.Namespace{}
 		err = r.client.Get(context.TODO(), types.NamespacedName{Name: tc.namespace}, &ns)
-		assertNoError(t, err)
+		assert.NilError(t, err)
 		value := ns.Labels["openshift.io/cluster-monitoring"]
-		assertEquals(t, value, "true")
+		assert.Equal(t, value, "true")
 	}
 }
 
@@ -129,19 +106,31 @@ func TestReconcile_add_read_role(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		r := newMetricsReconciler(t, tc.namespace)
+		r := newMetricsReconciler(t, tc.namespace, tc.instanceName)
 		_, err := r.Reconcile(newRequest(tc.namespace, tc.instanceName))
-		assertNoError(t, err)
+		assert.NilError(t, err)
 
 		role := rbacv1.Role{}
 		readRoleName := fmt.Sprintf("%s-read", tc.namespace)
 		err = r.client.Get(context.TODO(), types.NamespacedName{Name: readRoleName, Namespace: tc.namespace}, &role)
-		assertNoError(t, err)
+		assert.NilError(t, err)
 
-		assertEquals(t, len(role.Rules), 1)
-		assertEquals(t, role.Rules[0].APIGroups[0], "")
-		assertSameElements(t, role.Rules[0].Resources, "endpoints", "pods", "services")
-		assertSameElements(t, role.Rules[0].Verbs, "get", "list", "watch")
+		assert.Assert(t, is.Len(role.OwnerReferences, 1))
+		assert.Equal(t, role.OwnerReferences[0].Kind, argocdKind)
+		assert.Equal(t, role.OwnerReferences[0].Name, tc.instanceName)
+
+		assert.Equal(t, len(role.Rules), 1)
+		assert.Equal(t, role.Rules[0].APIGroups[0], "")
+
+		assert.Assert(t, is.Len(role.Rules[0].Resources, 3))
+		assert.Assert(t, is.Contains(role.Rules[0].Resources, "endpoints"))
+		assert.Assert(t, is.Contains(role.Rules[0].Resources, "pods"))
+		assert.Assert(t, is.Contains(role.Rules[0].Resources, "services"))
+
+		assert.Assert(t, is.Len(role.Rules[0].Verbs, 3))
+		assert.Assert(t, is.Contains(role.Rules[0].Verbs, "get"))
+		assert.Assert(t, is.Contains(role.Rules[0].Verbs, "list"))
+		assert.Assert(t, is.Contains(role.Rules[0].Verbs, "watch"))
 	}
 }
 
@@ -160,24 +149,28 @@ func TestReconcile_add_read_role_binding(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		r := newMetricsReconciler(t, tc.namespace)
+		r := newMetricsReconciler(t, tc.namespace, tc.instanceName)
 		_, err := r.Reconcile(newRequest(tc.namespace, tc.instanceName))
-		assertNoError(t, err)
+		assert.NilError(t, err)
 
 		roleBinding := rbacv1.RoleBinding{}
 		err = r.client.Get(context.TODO(),
 			types.NamespacedName{Name: fmt.Sprintf("%s-prometheus-k8s-read-binding", tc.namespace), Namespace: tc.namespace},
 			&roleBinding)
-		assertNoError(t, err)
+		assert.NilError(t, err)
+
+		assert.Assert(t, is.Len(roleBinding.OwnerReferences, 1))
+		assert.Equal(t, roleBinding.OwnerReferences[0].Kind, argocdKind)
+		assert.Equal(t, roleBinding.OwnerReferences[0].Name, tc.instanceName)
 
 		readRoleName := fmt.Sprintf("%s-read", tc.namespace)
-		assertEquals(t, roleBinding.RoleRef, rbacv1.RoleRef{
+		assert.Equal(t, roleBinding.RoleRef, rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
 			Name:     readRoleName,
 		},
 		)
-		assertEquals(t, roleBinding.Subjects[0], rbacv1.Subject{
+		assert.Equal(t, roleBinding.Subjects[0], rbacv1.Subject{
 			Kind:      "ServiceAccount",
 			Name:      "prometheus-k8s",
 			Namespace: "openshift-monitoring",
@@ -200,45 +193,54 @@ func TestReconcile_add_service_monitors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		r := newMetricsReconciler(t, tc.namespace)
+		r := newMetricsReconciler(t, tc.namespace, tc.instanceName)
 		_, err := r.Reconcile(newRequest(tc.namespace, tc.instanceName))
-		assertNoError(t, err)
+		assert.NilError(t, err)
 
 		serviceMonitor := monitoringv1.ServiceMonitor{}
 		serviceMonitorName := tc.instanceName
 		matchLabel := fmt.Sprintf("%s-metrics", serviceMonitorName)
 		err = r.client.Get(context.TODO(), types.NamespacedName{Name: serviceMonitorName, Namespace: tc.namespace}, &serviceMonitor)
-		assertNoError(t, err)
-		assertEquals(t, len(serviceMonitor.ObjectMeta.Labels), 1)
-		assertEquals(t, serviceMonitor.ObjectMeta.Labels["release"], "prometheus-operator")
-		assertEquals(t, len(serviceMonitor.Spec.Selector.MatchLabels), 1)
-		assertEquals(t, serviceMonitor.Spec.Selector.MatchLabels["app.kubernetes.io/name"], matchLabel)
-		assertEquals(t, len(serviceMonitor.Spec.Endpoints), 1)
-		assertEquals(t, serviceMonitor.Spec.Endpoints[0].Port, "metrics")
+		assert.NilError(t, err)
+		assert.Assert(t, is.Len(serviceMonitor.OwnerReferences, 1))
+		assert.Equal(t, serviceMonitor.OwnerReferences[0].Kind, argocdKind)
+		assert.Equal(t, serviceMonitor.OwnerReferences[0].Name, tc.instanceName)
+		assert.Equal(t, len(serviceMonitor.ObjectMeta.Labels), 1)
+		assert.Equal(t, serviceMonitor.ObjectMeta.Labels["release"], "prometheus-operator")
+		assert.Equal(t, len(serviceMonitor.Spec.Selector.MatchLabels), 1)
+		assert.Equal(t, serviceMonitor.Spec.Selector.MatchLabels["app.kubernetes.io/name"], matchLabel)
+		assert.Equal(t, len(serviceMonitor.Spec.Endpoints), 1)
+		assert.Equal(t, serviceMonitor.Spec.Endpoints[0].Port, "metrics")
 
 		serviceMonitor = monitoringv1.ServiceMonitor{}
 		serviceMonitorName = fmt.Sprintf("%s-server", tc.instanceName)
 		matchLabel = fmt.Sprintf("%s-metrics", serviceMonitorName)
 		err = r.client.Get(context.TODO(), types.NamespacedName{Name: serviceMonitorName, Namespace: tc.namespace}, &serviceMonitor)
-		assertNoError(t, err)
-		assertEquals(t, len(serviceMonitor.ObjectMeta.Labels), 1)
-		assertEquals(t, serviceMonitor.ObjectMeta.Labels["release"], "prometheus-operator")
-		assertEquals(t, len(serviceMonitor.Spec.Selector.MatchLabels), 1)
-		assertEquals(t, serviceMonitor.Spec.Selector.MatchLabels["app.kubernetes.io/name"], matchLabel)
-		assertEquals(t, len(serviceMonitor.Spec.Endpoints), 1)
-		assertEquals(t, serviceMonitor.Spec.Endpoints[0].Port, "metrics")
+		assert.NilError(t, err)
+		assert.Assert(t, is.Len(serviceMonitor.OwnerReferences, 1))
+		assert.Equal(t, serviceMonitor.OwnerReferences[0].Kind, argocdKind)
+		assert.Equal(t, serviceMonitor.OwnerReferences[0].Name, tc.instanceName)
+		assert.Equal(t, len(serviceMonitor.ObjectMeta.Labels), 1)
+		assert.Equal(t, serviceMonitor.ObjectMeta.Labels["release"], "prometheus-operator")
+		assert.Equal(t, len(serviceMonitor.Spec.Selector.MatchLabels), 1)
+		assert.Equal(t, serviceMonitor.Spec.Selector.MatchLabels["app.kubernetes.io/name"], matchLabel)
+		assert.Equal(t, len(serviceMonitor.Spec.Endpoints), 1)
+		assert.Equal(t, serviceMonitor.Spec.Endpoints[0].Port, "metrics")
 
 		serviceMonitor = monitoringv1.ServiceMonitor{}
 		serviceMonitorName = fmt.Sprintf("%s-repo-server", tc.instanceName)
 		matchLabel = serviceMonitorName
 		err = r.client.Get(context.TODO(), types.NamespacedName{Name: serviceMonitorName, Namespace: tc.namespace}, &serviceMonitor)
-		assertNoError(t, err)
-		assertEquals(t, len(serviceMonitor.ObjectMeta.Labels), 1)
-		assertEquals(t, serviceMonitor.ObjectMeta.Labels["release"], "prometheus-operator")
-		assertEquals(t, len(serviceMonitor.Spec.Selector.MatchLabels), 1)
-		assertEquals(t, serviceMonitor.Spec.Selector.MatchLabels["app.kubernetes.io/name"], matchLabel)
-		assertEquals(t, len(serviceMonitor.Spec.Endpoints), 1)
-		assertEquals(t, serviceMonitor.Spec.Endpoints[0].Port, "metrics")
+		assert.NilError(t, err)
+		assert.Assert(t, is.Len(serviceMonitor.OwnerReferences, 1))
+		assert.Equal(t, serviceMonitor.OwnerReferences[0].Kind, argocdKind)
+		assert.Equal(t, serviceMonitor.OwnerReferences[0].Name, tc.instanceName)
+		assert.Equal(t, len(serviceMonitor.ObjectMeta.Labels), 1)
+		assert.Equal(t, serviceMonitor.ObjectMeta.Labels["release"], "prometheus-operator")
+		assert.Equal(t, len(serviceMonitor.Spec.Selector.MatchLabels), 1)
+		assert.Equal(t, serviceMonitor.Spec.Selector.MatchLabels["app.kubernetes.io/name"], matchLabel)
+		assert.Equal(t, len(serviceMonitor.Spec.Endpoints), 1)
+		assert.Equal(t, serviceMonitor.Spec.Endpoints[0].Port, "metrics")
 	}
 }
 
@@ -257,18 +259,22 @@ func TestReconciler_add_prometheus_rule(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		r := newMetricsReconciler(t, tc.namespace)
+		r := newMetricsReconciler(t, tc.namespace, tc.instanceName)
 		_, err := r.Reconcile(newRequest(tc.namespace, tc.instanceName))
-		assertNoError(t, err)
+		assert.NilError(t, err)
 
 		rule := monitoringv1.PrometheusRule{}
 		err = r.client.Get(context.TODO(), types.NamespacedName{Name: "gitops-operator-argocd-alerts", Namespace: tc.namespace}, &rule)
-		assertNoError(t, err)
+		assert.NilError(t, err)
 
-		assertEquals(t, rule.Spec.Groups[0].Rules[0].Alert, "ArgoCDSyncAlert")
-		assertNotEquals(t, rule.Spec.Groups[0].Rules[0].Annotations["message"], "")
-		assertNotEquals(t, rule.Spec.Groups[0].Rules[0].Labels["severity"], "")
+		assert.Assert(t, is.Len(rule.OwnerReferences, 1))
+		assert.Equal(t, rule.OwnerReferences[0].Kind, argocdKind)
+		assert.Equal(t, rule.OwnerReferences[0].Name, tc.instanceName)
+
+		assert.Equal(t, rule.Spec.Groups[0].Rules[0].Alert, "ArgoCDSyncAlert")
+		assert.Assert(t, rule.Spec.Groups[0].Rules[0].Annotations["message"] != "")
+		assert.Assert(t, rule.Spec.Groups[0].Rules[0].Labels["severity"] != "")
 		expr := fmt.Sprintf("argocd_app_info{namespace=\"%s\",sync_status=\"OutOfSync\"} > 0", tc.namespace)
-		assertEquals(t, rule.Spec.Groups[0].Rules[0].Expr.StrVal, expr)
+		assert.Equal(t, rule.Spec.Groups[0].Rules[0].Expr.StrVal, expr)
 	}
 }

--- a/pkg/controller/argocdmetrics/argocdmetrics_controller.go
+++ b/pkg/controller/argocdmetrics/argocdmetrics_controller.go
@@ -1,0 +1,351 @@
+package argocdmetrics
+
+import (
+	"context"
+	"fmt"
+	argoapp "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	readRoleNameFormat        = "%s-read"
+	readRoleBindingNameFormat = "%s-prometheus-k8s-read-binding"
+	alertRuleName             = "gitops-operator-argocd-alerts"
+)
+
+var logs = logf.Log.WithName("controller_argocd_metrics")
+
+type ArgoCDMetricsReconciler struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// blank assignment to verify that ReconcileArgoCDRoute implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ArgoCDMetricsReconciler{}
+
+// Add creates a new ArgoCD Metrics Controller and adds it to the Manager.
+// The Manager will set fields on the Controller and start it when the
+// Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+func add(mgr manager.Manager, reconciler reconcile.Reconciler) error {
+	reqLogger := logs.WithValues()
+
+	reqLogger.Info("Creating ArgoCD metrics controller")
+	c, err := controller.New("argocd-metrics-controller", mgr, controller.Options{Reconciler: reconciler})
+	if err != nil {
+		return err
+	}
+
+	reqLogger.Info("Watching for ArgoCD instance creation")
+	err = c.Watch(&source.Kind{Type: &argoapp.ArgoCD{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ArgoCDMetricsReconciler{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+func (r ArgoCDMetricsReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := logs.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling ArgoCD Metrics")
+
+	namespace := corev1.Namespace{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: request.Namespace}, &namespace)
+	if err != nil {
+		reqLogger.Error(err, "Error getting namespace",
+			"Namespace", request.Namespace)
+		return reconcile.Result{}, err
+	}
+	_, exists := namespace.Labels["openshift.io/cluster-monitoring"]
+	if !exists {
+		if namespace.Labels == nil {
+			namespace.Labels = make(map[string]string)
+		}
+		namespace.Labels["openshift.io/cluster-monitoring"] = "true"
+		err = r.client.Update(context.TODO(), &namespace)
+		if err != nil {
+			reqLogger.Error(err, "Error updating namespace",
+				"Namespace", namespace.Name)
+			return reconcile.Result{}, err
+		}
+	} else {
+		reqLogger.Info("Namespace already has cluster-monitoring label",
+			"Namespace", namespace.Name)
+	}
+
+	// Create role to grant read permission to the openshift metrics stack
+	err = r.createReadRoleIfAbsent(request.Namespace, reqLogger)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Create role binding to grant read permission to the openshift metrics stack
+	err = r.createReadRoleBindingIfAbsent(request.Namespace, reqLogger)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Create ServiceMonitor for ArgoCD application metrics
+	serviceMonitorLabel := fmt.Sprintf("%s-metrics", request.Name)
+	serviceMonitorName := request.Name
+	err = r.createServiceMonitorIfAbsent(request.Namespace, serviceMonitorName, serviceMonitorLabel, reqLogger)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Create ServiceMonitor for ArgoCD API server metrics
+	serviceMonitorLabel = fmt.Sprintf("%s-server-metrics", request.Name)
+	serviceMonitorName = fmt.Sprintf("%s-server", request.Name)
+	err = r.createServiceMonitorIfAbsent(request.Namespace, serviceMonitorName, serviceMonitorLabel, reqLogger)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Create ServiceMonitor for ArgoCD repo server metrics
+	serviceMonitorLabel = fmt.Sprintf("%s-repo-server", request.Name)
+	serviceMonitorName = fmt.Sprintf("%s-repo-server", request.Name)
+	err = r.createServiceMonitorIfAbsent(request.Namespace, serviceMonitorName, serviceMonitorLabel, reqLogger)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Create alert rule
+	err = r.createPrometheusRuleIfAbsent(request.Namespace, reqLogger)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *ArgoCDMetricsReconciler) createReadRoleIfAbsent(namespace string, reqLogger logr.Logger) error {
+	readRole := newReadRole(namespace)
+	existingReadRole := &rbacv1.Role{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: readRole.Name, Namespace: readRole.Namespace}, existingReadRole)
+	if err == nil {
+		reqLogger.Info("Read role already exists",
+			"Namespace", readRole.Namespace, "Name", readRole.Name)
+		return nil
+	}
+	if errors.IsNotFound(err) {
+		reqLogger.Info("Creating new read role",
+			"Namespace", readRole.Namespace, "Name", readRole.Name)
+		err = r.client.Create(context.TODO(), readRole)
+		if err != nil {
+			reqLogger.Info("Error creating a new read role",
+				"Namespace", readRole.Namespace, "Name", readRole.Name)
+			return err
+		}
+		return nil
+	}
+	reqLogger.Info("Error querying for read role",
+		"Name", readRole.Name, "Namespace", readRole.Namespace)
+	return err
+}
+
+func (r ArgoCDMetricsReconciler) createReadRoleBindingIfAbsent(namespace string, reqLogger logr.Logger) error {
+	readRoleBinding := newReadRoleBinding(namespace)
+	existingReadRoleBinding := &rbacv1.RoleBinding{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: readRoleBinding.Name, Namespace: readRoleBinding.Namespace}, existingReadRoleBinding)
+	if err == nil {
+		reqLogger.Info("Read role binding already exists",
+			"Namespace", readRoleBinding.Namespace, "Name", readRoleBinding.Name)
+		return nil
+	}
+	if errors.IsNotFound(err) {
+		reqLogger.Info("Creating new read role binding",
+			"Namespace", readRoleBinding.Namespace, "Name", readRoleBinding.Name)
+		err = r.client.Create(context.TODO(), readRoleBinding)
+		if err != nil {
+			reqLogger.Info("Error creating a new read role binding",
+				"Namespace", readRoleBinding.Namespace, "Name", readRoleBinding.Name)
+			return err
+		}
+		return nil
+	}
+	reqLogger.Info("Error querying for read role binding",
+		"Name", readRoleBinding.Name, "Namespace", readRoleBinding.Namespace)
+	return err
+}
+
+func (r *ArgoCDMetricsReconciler) createServiceMonitorIfAbsent(namespace, name, serviceMonitorLabel string, reqLogger logr.Logger) error {
+	existingServiceMonitor := &monitoringv1.ServiceMonitor{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, existingServiceMonitor)
+	if err == nil {
+		reqLogger.Info("A ServiceMonitor instance already exists",
+			"Namespace", existingServiceMonitor.Namespace, "Name", existingServiceMonitor.Name)
+		return nil
+	}
+	if errors.IsNotFound(err) {
+		serviceMonitor := newServiceMonitor(namespace, name, serviceMonitorLabel)
+		reqLogger.Info("Creating a new ServiceMonitor instance",
+			"Namespace", serviceMonitor.Namespace, "Name", serviceMonitor.Name)
+		err = r.client.Create(context.TODO(), serviceMonitor)
+		if err != nil {
+			reqLogger.Info("Error creating a new ServiceMonitor instance",
+				"Namespace", serviceMonitor.Namespace, "Name", serviceMonitor.Name)
+			return err
+		}
+		return nil
+	}
+	reqLogger.Info("Error querying for ServiceMonitor", "Namespace", namespace, "Name", name)
+	return err
+}
+
+func (r *ArgoCDMetricsReconciler) createPrometheusRuleIfAbsent(namespace string, reqLogger logr.Logger) error {
+	alertRule := newPrometheusRule(namespace)
+	existingAlertRule := &monitoringv1.PrometheusRule{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: alertRule.Name, Namespace: alertRule.Namespace}, existingAlertRule)
+	if err == nil {
+		reqLogger.Info("An alert rule instance already exists",
+			"Namespace", existingAlertRule.Namespace, "Name", existingAlertRule.Name)
+		return nil
+	}
+	if errors.IsNotFound(err) {
+		reqLogger.Info("Creating new alert rule",
+			"Namespace", alertRule.Namespace, "Name", alertRule.Name)
+		err := r.client.Create(context.TODO(), alertRule)
+		if err != nil {
+			reqLogger.Error(err, "Error creating a new alert rule",
+				"Namespace", alertRule.Namespace, "Name", alertRule.Name)
+			return err
+		}
+		return nil
+	}
+	reqLogger.Info("Error querying for existing alert rule",
+		"Namespace", namespace, "Name", alertRuleName)
+	return err
+}
+
+func newReadRole(namespace string) *rbacv1.Role {
+	objectMeta := metav1.ObjectMeta{
+		Name:      fmt.Sprintf(readRoleNameFormat, namespace),
+		Namespace: namespace,
+	}
+	rules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"endpoints", "services", "pods"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+	}
+	return &rbacv1.Role{
+		ObjectMeta: objectMeta,
+		Rules:      rules,
+	}
+}
+
+func newReadRoleBinding(namespace string) *rbacv1.RoleBinding {
+	objectMeta := metav1.ObjectMeta{
+		Name:      fmt.Sprintf(readRoleBindingNameFormat, namespace),
+		Namespace: namespace,
+	}
+	roleRef := rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "Role",
+		Name:     fmt.Sprintf(readRoleNameFormat, namespace),
+	}
+	subjects := []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      "prometheus-k8s",
+			Namespace: "openshift-monitoring",
+		},
+	}
+	return &rbacv1.RoleBinding{
+		ObjectMeta: objectMeta,
+		RoleRef:    roleRef,
+		Subjects:   subjects,
+	}
+}
+
+func newServiceMonitor(namespace, name, matchLabel string) *monitoringv1.ServiceMonitor {
+	objectMeta := metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+		Labels: map[string]string{
+			"release": "prometheus-operator",
+		},
+	}
+	spec := monitoringv1.ServiceMonitorSpec{
+		Selector: metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app.kubernetes.io/name": matchLabel,
+			},
+		},
+		Endpoints: []monitoringv1.Endpoint{
+			{
+				Port: "metrics",
+			},
+		},
+	}
+	return &monitoringv1.ServiceMonitor{
+		ObjectMeta: objectMeta,
+		Spec:       spec,
+	}
+}
+
+func newPrometheusRule(namespace string) *monitoringv1.PrometheusRule {
+	// The namespace used in the alert rule is not the namespace of the
+	// running application, it is the namespace that the corresponding
+	// ArgoCD application metadata was created in.  This is needed to
+	// scope this alert rule to only fire for applications managed
+	// by the ArgoCD instance installed in this namespace.
+	expr := fmt.Sprintf("argocd_app_info{namespace=\"%s\",sync_status=\"OutOfSync\"} > 0", namespace)
+
+	objectMeta := metav1.ObjectMeta{
+		Name:      alertRuleName,
+		Namespace: namespace,
+	}
+	spec := monitoringv1.PrometheusRuleSpec{
+		Groups: []monitoringv1.RuleGroup{
+			{
+				Name: "GitOpsOperatorArgoCD",
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "ArgoCDSyncAlert",
+						Annotations: map[string]string{
+							"message": "ArgoCD application {{ $labels.name }} is out of sync",
+						},
+						Expr: intstr.IntOrString{
+							Type:   intstr.String,
+							StrVal: expr,
+						},
+						Labels: map[string]string{
+							"severity": "warning",
+						},
+					},
+				},
+			},
+		},
+	}
+	return &monitoringv1.PrometheusRule{
+		ObjectMeta: objectMeta,
+		Spec:       spec,
+	}
+}


### PR DESCRIPTION
Adds a new controller to watch for the creation of ArgoCD instances and to add the configuration to enable the built-in metrics stack to scrape metrics from the new ArgoCD.  Also adds an alert rule to report ArgoCD applications that are out of sync.

### How to test by running the operator locally

Login to an openshift cluster from the command line

Download the operator-sdk binary from here: https://github.com/operator-framework/operator-sdk/releases/tag/v0.17.2


Check out the argocd-metrics branch from https://github.com/jopit/gitops-operator

cd gitops-operator
go mod vendor
kubectl apply -f deploy/crds
operator-sdk run --local --watch-namespace ""

Create a new argocd application in the openshift-gitops namespace with auto-sync turned off, do not sync the app.  It may take several minutes (I've seen it take over five minutes) but eventually an alert should show up on the overview page in the openshift admin console.

<img width="638" alt="Screen Shot 2021-02-18 at 11 41 48 AM" src="https://user-images.githubusercontent.com/29612372/108390882-16da8f00-71df-11eb-8fc6-cd2fe9fa83c1.png">

You can also go to the Monitoring>Metrics page in the admin console and enter a PromQL query, for example `sum(argocd_app_info{dest_namespace=~"default",health_status!=""}) by (sync_status)`


### Testing note by Shoubhik
Please validate that deleting up an ArgoCD instance also removes all associated rolebindings/roles and monitoring objects that were created.