### PR TITLE
Update Argo CD operator version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.13
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210211102851-2e5f5e98588c
+	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210222122027-482ecdb6f042
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210211102851-2e5f5e98588c h1:SHkwbuJgmmSIw4KsUWdFoQvdFFV2/1drVAIcw0gmYdE=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210211102851-2e5f5e98588c/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210222122027-482ecdb6f042 h1:aGSuxDd4xF23kInjplXt2H/n9DPb8HUS/kPgwaMLGPE=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210222122027-482ecdb6f042/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What does this PR do / why we need it**:
With PR(https://github.com/argoproj-labs/argocd-operator/pull/247) merged, the operator can now clean up cluster resources on the deletion of the argocd instance.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
1. Login to OpenShift cluster and apply CRDs
 ```shell
 kubectl apply -f deploy/crds
 ```
1. Run the operator locally
```shell
make run-local
```
2. Create a namespace `test`
3. Create an argocd instance in `test` namespace
4. Delete the instance
5. Observe if the following cluster resources are deleted

Cluster Roles:
* \<cr-name\>-argocd-application-controller
* \<cr-name\>-argocd-server

Cluster Rolebindings:
* \<cr-name\>-argocd-application-controller
* \<cr-name\>-argocd-server

Service accounts:
* \<cr-name\>-argocd-application-controller
* \<cr-name\>-argocd-server
* \<cr-name\>-argocd-redis-ha
