### PR TITLE
Pull in Pipelines v1.3.0 for OCP 4.7

### DIFF
--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -23,9 +23,9 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     required:
-    - name: config.operator.tekton.dev
+    - name:tektonconfigs.operator.tekton.dev
       version: v1alpha1
-      kind: Config
+      kind: TektonConfig
       displayName: OpenShift Pipelines Config
       description: Represents Installation of Tekton.
     owned:


### PR DESCRIPTION

**What type of PR is this?**

/kind bug


**What does this PR do / why we need it**:

Ensures a specific version of OpenShift Pipelines is installed

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
fixes https://issues.redhat.com/browse/GITOPS-675


**How to test changes / Special notes to the reviewer**:

Steps:

On a 4.7 cluster, Install Pipelines 1.3 using the Preview channel
Install GitOps Operator