### PR TITLE
GITOPS-547: Auth Integration with RedHat SSO for Openshift Login

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -42,6 +42,8 @@ import (
 	_ "github.com/argoproj-labs/argocd-operator/pkg/reconciler/openshift"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 
+	keycloakv1alpha1 "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	oauthv1 "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"
 )
 
@@ -146,6 +148,8 @@ func main() {
 	registerComponentOrExit(mgr, argoapi.AddToScheme)
 	registerComponentOrExit(mgr, configv1.AddToScheme)
 	registerComponentOrExit(mgr, monitoringv1.AddToScheme)
+	registerComponentOrExit(mgr, keycloakv1alpha1.SchemeBuilder.AddToScheme)
+	registerComponentOrExit(mgr, oauthv1.AddToScheme)
 
 	// Add the Metrics Service
 	addMetrics(ctx, cfg)

--- a/deploy/crds/pipelines.openshift.io_gitopsservices_crd.yaml
+++ b/deploy/crds/pipelines.openshift.io_gitopsservices_crd.yaml
@@ -30,6 +30,9 @@ spec:
           type: object
         spec:
           description: GitopsServiceSpec defines the desired state of GitopsService
+          properties:
+            enablesso:
+              type: boolean
           type: object
         status:
           description: GitopsServiceStatus defines the observed state of GitopsService

--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -177,6 +177,12 @@ spec:
           - clusterrolebindings
           verbs:
           - '*'
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - oauthclients 
+          verbs:
+          - '*'
         serviceAccountName: gitops-operator
       permissions:
       - rules:
@@ -231,6 +237,29 @@ spec:
           - ingresses
           verbs:
           - '*'
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - oauthclient  
+          verbs:
+          - '*'
+        - apiGroups:
+          - keycloak.org
+          resources:
+          - keycloaks
+          - keycloaks/status
+          - keycloaks/finalizers
+          - keycloakrealms
+          - keycloakrealms/status
+          - keycloakrealms/finalizers
+          - keycloakclients
+          - keycloakclients/status
+          - keycloakclients/finalizers
+          verbs:
+          - create
+          - get
+          - list
+          - watch
         - apiGroups:
           - monitoring.coreos.com
           resources:

--- a/deploy/olm-catalog/gitops-operator/manifests/pipelines.openshift.io_gitopsservices_crd.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/pipelines.openshift.io_gitopsservices_crd.yaml
@@ -30,6 +30,9 @@ spec:
           type: object
         spec:
           description: GitopsServiceSpec defines the desired state of GitopsService
+          properties:
+            enablesso:
+              type: boolean
           type: object
         status:
           description: GitopsServiceStatus defines the observed state of GitopsService

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -142,3 +142,26 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - oauth.openshift.io
+  resources:
+  - oauthclients 
+  verbs:
+  - '*'
+- apiGroups:
+  - keycloak.org
+  resources:
+  - keycloaks
+  - keycloaks/status
+  - keycloaks/finalizers
+  - keycloakrealms
+  - keycloakrealms/status
+  - keycloakrealms/finalizers
+  - keycloakclients
+  - keycloakclients/status
+  - keycloakclients/finalizers
+  verbs:
+  - create
+  - get
+  - list
+  - watch

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,20 @@ require (
 	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210301162004-70d7ccdfb761
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v0.1.0
-	github.com/google/go-cmp v0.4.0
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/google/go-cmp v0.5.2
+	github.com/keycloak/keycloak-operator v0.0.0-20210217134400-410337e825cc
 	github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible
 	github.com/operator-framework/api v0.3.18
 	github.com/operator-framework/operator-sdk v0.18.2
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd // indirect
+	golang.org/x/text v0.3.4 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.18.3
 	k8s.io/apimachinery v0.18.3

--- a/go.sum
+++ b/go.sum
@@ -519,6 +519,8 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1 h1:ZFgWrT+bLgsYPirOnRfKLYJLvssAegOj/hgyMFdJZe0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
+github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
+github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -533,7 +535,11 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-jsonnet v0.16.0/go.mod h1:sOcuej3UW1vpPTZOr8L7RQimqai1a57bt5j22LzGZCw=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
@@ -672,6 +678,7 @@ github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19y
 github.com/influxdata/roaring v0.4.13-0.20180809181101-fc520f41fab6/go.mod h1:bSgUQ7q5ZLSO+bKBGqJiCBGAl+9DxyW63zLTujjUlOE=
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9/go.mod h1:Js0mqiSBE6Ffsg94weZZ2c+v/ciT8QRHFOap7EKDrR0=
 github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368/go.mod h1:Wbbw6tYNvwa5dlB6304Sd+82Z3f7PmVZHVKU637d4po=
+github.com/integr8ly/grafana-operator/v3 v3.6.0/go.mod h1:pWWg9RerCkkwmTcmaygmfhkjjGilEN30han1yq2MAsA=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jessevdk/go-flags v0.0.0-20180331124232-1c38ed7ad0cc/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -707,6 +714,8 @@ github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uia
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
+github.com/keycloak/keycloak-operator v0.0.0-20210217134400-410337e825cc h1:D2uz7bTF4l9xVtPKZDtvJsZC5xzncPvcxLiAdncxmAY=
+github.com/keycloak/keycloak-operator v0.0.0-20210217134400-410337e825cc/go.mod h1:otm+Vi8Manbd4NQ8V26ox8muzkn/hC6aMzSBxMygHsk=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -879,6 +888,7 @@ github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.m
 github.com/opencontainers/runtime-spec v0.1.2-0.20190618234442-a950415649c7 h1:Dliu5QO+4JYWu/yMshaMU7G3JN2POGpwjJN7gjy10Go=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190618234442-a950415649c7/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
+github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible h1:XKVBXsObu4jv2nzgvjnTZ7eBlM3G9H3mrG8yP4TE61U=
 github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
@@ -1038,6 +1048,8 @@ github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfP
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
+github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sethvargo/go-password v0.2.0 h1:BTDl4CC/gjf/axHMaDQtw507ogrXLci6XRiLc7i/UHI=
 github.com/sethvargo/go-password v0.2.0/go.mod h1:Ym4Mr9JXLBycr02MFuVQ/0JHidNetSgbzutTr3zsYXE=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
@@ -1096,6 +1108,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/thanos-io/thanos v0.11.0/go.mod h1:N/Yes7J68KqvmY+xM6J5CJqEvWIvKSR5sqGtmuD6wDc=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
@@ -1212,6 +1226,8 @@ golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200422194213-44a606286825 h1:dSChiwOTvzwbHFTMq2l6uRardHH7/E6SqEkqccinS/o=
 golang.org/x/crypto v0.0.0-20200422194213-44a606286825/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1294,6 +1310,8 @@ golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200602114024-627f9648deb9 h1:pNX+40auqi2JqRfOP1akLGtYcn15TUbkhwuCO3foqqM=
 golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
+golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1380,6 +1398,9 @@ golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 h1:OjiUf46hAmXblsZdnoSXsEUSKU8r1UEzcL5RVZ4gO9Y=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
+golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1388,6 +1409,9 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
+golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -1463,6 +1487,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gomodules.xyz/jsonpatch/v3 v3.0.1/go.mod h1:CBhndykehEwTOlEfnsfJwvkFQbSN8YZFr9M+cIHAJto=
@@ -1529,6 +1555,8 @@ google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20200603110839-e855014d5736 h1:+IE3xTD+6Eb7QWG5JFp+dQr/XjKpjmrNkh4pdjTdHEs=
 google.golang.org/genproto v0.0.0-20200603110839-e855014d5736/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
+google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a h1:pOwg4OoaRYScjmR4LlLgdtnyoHYTSAVhhqe5uPdpII8=
+google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -1555,9 +1583,12 @@ google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQ
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0 h1:UhZDfRO8JRQru4/+LlLE0BRKGF8L+PICnvYZmx/fEGA=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
+google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
+google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -1599,6 +1630,7 @@ gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200603094226-e3079894b1e8 h1:jL/vaozO53FMfZLySWM+4nulF3gQEC6q5jH90LPomDo=
 gopkg.in/yaml.v3 v3.0.0-20200603094226-e3079894b1e8/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/pkg/apis/pipelines/v1alpha1/gitopsservice_types.go
+++ b/pkg/apis/pipelines/v1alpha1/gitopsservice_types.go
@@ -6,6 +6,7 @@ import (
 
 // GitopsServiceSpec defines the desired state of GitopsService
 type GitopsServiceSpec struct {
+	EnableSSO bool `json:"enablesso,omitempty"`
 }
 
 // GitopsServiceStatus defines the observed state of GitopsService

--- a/pkg/controller/argocd/argocd.go
+++ b/pkg/controller/argocd/argocd.go
@@ -14,6 +14,15 @@ type resource struct {
 	Clusters  []string `json:"clusters"`
 }
 
+// OIDCConfig enables Integration with RHSSO
+type OIDCConfig struct {
+	Name           string   `json:"name"`
+	Issuer         string   `json:"issuer"`
+	ClientID       string   `json:"clientID"`
+	ClientSecret   string   `json:"clientSecret"`
+	RequestedScope []string `json:"requestedScopes"`
+}
+
 // NewCR returns an ArgoCD reference optimized for use in OpenShift
 // with Tekton
 func NewCR(name, ns string) (*argoapp.ArgoCD, error) {

--- a/pkg/controller/argocd/argocd_controller.go
+++ b/pkg/controller/argocd/argocd_controller.go
@@ -70,7 +70,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// Watch for changes to argocd-server route in argocd namespace
 	// The ConsoleLink holds the route URL and should be regenerated when route is updated
-	err = c.Watch(&source.Kind{Type: &routev1.Route{}}, &handler.EnqueueRequestForObject{}, filterPredicate(filterArgoCDRoute))
+	err = c.Watch(&source.Kind{Type: &routev1.Route{}}, &handler.EnqueueRequestForObject{}, FilterPredicate(FilterArgoCDRoute))
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	return nil
 }
 
-func filterPredicate(assert func(namespace, name string) bool) predicate.Funcs {
+func FilterPredicate(assert func(namespace, name string) bool) predicate.Funcs {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return assert(e.MetaNew.GetNamespace(), e.MetaNew.GetName()) &&
@@ -94,7 +94,7 @@ func filterPredicate(assert func(namespace, name string) bool) predicate.Funcs {
 	}
 }
 
-func filterArgoCDRoute(namespace, name string) bool {
+func FilterArgoCDRoute(namespace, name string) bool {
 	return namespace == argocdNS && argocdRouteName == name
 }
 

--- a/pkg/controller/rhsso/keycloak.go
+++ b/pkg/controller/rhsso/keycloak.go
@@ -1,0 +1,146 @@
+package rhsso
+
+import (
+	"fmt"
+
+	keycloakv1alpha1 "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// KeycloakNamespace defines the namespace where keycloak instance will be created.
+	KeycloakNamespace = "openshift-gitops"
+	// EnableExternalAccess enables external access for keycloak instance.
+	EnableExternalAccess = true
+	// KeycloakInstanceCount defines the instance count.
+	KeycloakInstanceCount = 1
+	// KeycloakArgoClient defines the keycloak client for openshift gitops.
+	KeycloakArgoClient = "openshift-gitops"
+	// ArgoBaseURL is the ArgoCD Base URL.
+	ArgoBaseURL = "/applications"
+	// ClientProtocol used by keycloak
+	ClientProtocol = "openid-connect"
+)
+
+var log = logf.Log.WithName("cmd")
+
+// NewKeycloakCR returns a keycloak reference optimized for use in OpenShift
+func NewKeycloakCR(name string) *keycloakv1alpha1.Keycloak {
+	l := make(map[string]string)
+	l["app"] = fmt.Sprintf("keycloak-%s", name)
+
+	return &keycloakv1alpha1.Keycloak{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Keycloak",
+			APIVersion: "keycloak.org/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "keycloak-" + name,
+			Namespace: KeycloakNamespace,
+			Labels:    l,
+		},
+		Spec: keycloakv1alpha1.KeycloakSpec{
+			Instances: KeycloakInstanceCount,
+			ExternalAccess: keycloakv1alpha1.KeycloakExternalAccess{
+				Enabled: EnableExternalAccess,
+			},
+		},
+	}
+}
+
+// NewKeycloakRealmCR returns a keycloak realm reference optimized for use in OpenShift
+func NewKeycloakRealmCR(name string) *keycloakv1alpha1.KeycloakRealm {
+	s := map[string]string{
+		"app": "keycloak-" + name,
+	}
+	l := map[string]string{
+		"app": "keycloakrealm-" + name,
+	}
+	config := map[string]string{
+		"clientId":     "oauthclient-" + name,
+		"clientSecret": "admin",
+		"baseUrl":      getBaseURL(),
+		"defaultScope": "user:full",
+	}
+
+	return &keycloakv1alpha1.KeycloakRealm{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KeycloakRealm",
+			APIVersion: "keycloak.org/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "keycloakrealm-" + name,
+			Namespace: KeycloakNamespace,
+			Labels:    l,
+		},
+		Spec: keycloakv1alpha1.KeycloakRealmSpec{
+			Realm: &keycloakv1alpha1.KeycloakAPIRealm{
+				Realm:       name,
+				Enabled:     true,
+				DisplayName: name,
+				IdentityProviders: []*keycloakv1alpha1.KeycloakIdentityProvider{
+					&keycloakv1alpha1.KeycloakIdentityProvider{
+						Alias:                     "openshift-v4",
+						ProviderID:                "openshift-v4",
+						DisplayName:               "Login with Openshift",
+						InternalID:                "keycloak-broker",
+						AddReadTokenRoleOnCreate:  true,
+						FirstBrokerLoginFlowAlias: "first broker login",
+						Config:                    config,
+					},
+				},
+			},
+			InstanceSelector: &metav1.LabelSelector{
+				MatchLabels: s,
+			},
+		},
+	}
+}
+
+// NewKeycloakClientCR returns a keycloak client reference optimized for use in OpenShift
+func NewKeycloakClientCR(name string, argoRouteHost string) *keycloakv1alpha1.KeycloakClient {
+	s := map[string]string{
+		"app": "keycloakrealm-" + name,
+	}
+	l := map[string]string{
+		"app": "keycloakclient-" + name,
+	}
+
+	return &keycloakv1alpha1.KeycloakClient{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KeycloakClient",
+			APIVersion: "keycloak.org/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "keycloakclient-" + name,
+			Namespace: KeycloakNamespace,
+			Labels:    l,
+		},
+		Spec: keycloakv1alpha1.KeycloakClientSpec{
+			Client: &keycloakv1alpha1.KeycloakAPIClient{
+				ClientID:                  KeycloakArgoClient,
+				Secret:                    KeycloakArgoClient,
+				Protocol:                  ClientProtocol,
+				RootURL:                   fmt.Sprintf("https://%s", argoRouteHost),
+				BaseURL:                   ArgoBaseURL,
+				StandardFlowEnabled:       true,
+				DirectAccessGrantsEnabled: true,
+				PublicClient:              true,
+			},
+			RealmSelector: &metav1.LabelSelector{
+				MatchLabels: s,
+			},
+		},
+	}
+}
+
+func getBaseURL() string {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		log.Error(err, "")
+	}
+	return cfg.Host
+}

--- a/pkg/controller/rhsso/keycloak_test.go
+++ b/pkg/controller/rhsso/keycloak_test.go
@@ -1,0 +1,71 @@
+package rhsso
+
+import (
+	"testing"
+
+	keycloakv1alpha1 "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	"gotest.tools/assert"
+)
+
+var (
+	externalAccess = keycloakv1alpha1.KeycloakExternalAccess{
+		Enabled: true,
+	}
+
+	testConfig = map[string]string{
+		"clientId":     "oauthclient-openshift-gitops",
+		"clientSecret": "admin",
+		"baseUrl":      getBaseURL(),
+		"defaultScope": "user:full",
+	}
+
+	dummyRealmData = &keycloakv1alpha1.KeycloakAPIRealm{
+		Realm:       "openshift-gitops",
+		Enabled:     true,
+		DisplayName: "openshift-gitops",
+		IdentityProviders: []*keycloakv1alpha1.KeycloakIdentityProvider{
+			&keycloakv1alpha1.KeycloakIdentityProvider{
+				Alias:                     "openshift-v4",
+				ProviderID:                "openshift-v4",
+				DisplayName:               "Login with Openshift",
+				InternalID:                "keycloak-broker",
+				AddReadTokenRoleOnCreate:  true,
+				FirstBrokerLoginFlowAlias: "first broker login",
+				Config:                    testConfig,
+			},
+		},
+	}
+
+	dummyClientData = &keycloakv1alpha1.KeycloakAPIClient{
+		ClientID:                  "openshift-gitops",
+		Secret:                    "openshift-gitops",
+		Protocol:                  "openid-connect",
+		RootURL:                   "https://argocd.com",
+		BaseURL:                   "/applications",
+		StandardFlowEnabled:       true,
+		DirectAccessGrantsEnabled: true,
+		PublicClient:              true,
+	}
+)
+
+func TestKeycloakInstanceCreation(t *testing.T) {
+	testKeycloakInstance := NewKeycloakCR("openshift-gitops")
+	assert.Equal(t, testKeycloakInstance.Name, "keycloak-openshift-gitops")
+	assert.Equal(t, testKeycloakInstance.Namespace, "openshift-gitops")
+	assert.Equal(t, testKeycloakInstance.Spec.Instances, 1)
+	assert.Equal(t, testKeycloakInstance.Spec.ExternalAccess, externalAccess)
+}
+
+func TestKeycloakRealmCreation(t *testing.T) {
+	testKeycloakRealm := NewKeycloakRealmCR("openshift-gitops")
+	assert.Equal(t, testKeycloakRealm.Name, "keycloakrealm-openshift-gitops")
+	assert.Equal(t, testKeycloakRealm.Namespace, "openshift-gitops")
+	assert.DeepEqual(t, testKeycloakRealm.Spec.Realm, dummyRealmData)
+}
+
+func TestKeycloakClientCreation(t *testing.T) {
+	testKeycloakClient := NewKeycloakClientCR("openshift-gitops", "argocd.com")
+	assert.Equal(t, testKeycloakClient.Name, "keycloakclient-openshift-gitops")
+	assert.Equal(t, testKeycloakClient.Namespace, "openshift-gitops")
+	assert.DeepEqual(t, testKeycloakClient.Spec.Client, dummyClientData)
+}

--- a/pkg/controller/rhsso/oauthclient.go
+++ b/pkg/controller/rhsso/oauthclient.go
@@ -1,0 +1,27 @@
+package rhsso
+
+import (
+	"fmt"
+
+	oauthv1 "github.com/openshift/api/oauth/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewOAuthClient returns a openshift OAuthClient reference
+func NewOAuthClient(name string, keycloakRouteHost string) *oauthv1.OAuthClient {
+	redirectURI := fmt.Sprintf("https://%s/auth/realms/%s/broker/openshift-v4/endpoint",
+		keycloakRouteHost, name)
+	return &oauthv1.OAuthClient{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "OAuthClient",
+			APIVersion: "oauth.openshift.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oauthclient-" + name,
+			Namespace: KeycloakNamespace,
+		},
+		Secret:       "admin",
+		RedirectURIs: []string{redirectURI},
+		GrantMethod:  "prompt",
+	}
+}

--- a/pkg/controller/rhsso/oauthclient_test.go
+++ b/pkg/controller/rhsso/oauthclient_test.go
@@ -1,0 +1,21 @@
+package rhsso
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+var (
+	testRedirectURI = fmt.Sprintf("https://%s/auth/realms/%s/broker/openshift-v4/endpoint",
+		"keycloak.com", "openshift-gitops")
+)
+
+func TestOAuthClientCreation(t *testing.T) {
+	testOAuthClient := NewOAuthClient("openshift-gitops", "keycloak.com")
+	assert.Equal(t, testOAuthClient.Name, "oauthclient-openshift-gitops")
+	assert.Equal(t, testOAuthClient.Namespace, "openshift-gitops")
+	assert.Equal(t, testOAuthClient.Secret, "admin")
+	assert.DeepEqual(t, testOAuthClient.RedirectURIs, []string{testRedirectURI})
+}


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
Enables SSO option for ArgoCD using RHSSO as Identity Broker and Openshift V4 as Identity Provider.  This is achieved by installing the below RHSSO resources and OpenShift OAuth Client.
1. Keycloak 
2. Keycloak Realm
3. Keycloak Client

However, apart from installing the above mentioned resources it also configures these resources to avoid any manual intervention in setting up SSO. 

Once the PR is merged the Users should be able to login into ArgoCD using their Openshift login. This PR does not create or provide steps on how to create openshift users.

**Have you updated the necessary documentation?**
This story does not need any documentation.

**Which issue(s) this PR fixes**:
GITOPS-549 and GITOPS-662 (not the installation of operator , will be taken care in a different PR)

Fixes #?
GITOPS-549 and GITOPS-662 (not the installation of operator , will be taken care in a different PR)

**How to test changes / Special notes to the reviewer**:
1. Create "openshift-gitops" namespace
2.  Install RHSSO operator in "openshift-gitops" namespace
3. Install operator-sdk locally (recommended version - 0.17.0)
4. Run the below command 
`operator-sdk run --local --watch-namespace "openshift-gitops"`

login to openshift and you should see `login with keycloak`. Please follow the document for testing. 
```
https://github.com/dewan-ahmed/gitops-contents/blob/main/blogs/2021-02-16-openshift-sso-argocd.md
```