### PR TITLE
Pull in dex clientID fix from argocd-operator@master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.13
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210222122027-482ecdb6f042
+	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210225133918-e8b9b089f413
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210222122027-482ecdb6f042 h1:aGSuxDd4xF23kInjplXt2H/n9DPb8HUS/kPgwaMLGPE=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210222122027-482ecdb6f042/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210225133918-e8b9b089f413 h1:eVNWscmUzefMD4od4UHe4c/FrwUV7Gc5pi1ttoqYqJE=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210225133918-e8b9b089f413/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
Pull in fix for GITOPS-696 from ArgoCD Operator 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
GITOPS-696

**How to test changes / Special notes to the reviewer**:
Not tested in this repo but build GitOps Operator TP v1.0.1 candidate to test.
Steps to test:

0. Install GitOps Operator as follow.
1. set DISABLE_DEX=false in the subscription as documented
2. . Do not enable OpenShift authentication in the ArgoCD CR
3.  Create this Job 
```
apiVersion: batch/v1
kind: Job
metadata:
  annotations:
    argocd.argoproj.io/hook: PostSync
    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
  labels:
    run: argocd-setup
  name: argocd-setup
  generateName: argocd-setup-
  namespace: openshift-operators
spec:
  template:
    spec:
      activeDeadlineSeconds: 600
      containers:
        - image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.6
          command:
            - /bin/bash
            - -c
            - |
              export HOME=/tmp/argocd-setup
              until oc -n openshift-gitops get routes argocd-cluster-server > /dev/null 2>&1; do sleep 5; done;
              ARGOCD_DEX_REDIRECT_URI=https://$(oc -n openshift-gitops get routes argocd-cluster-server -o jsonpath='{ .spec.host }')/api/dex/callback
              until oc -n openshift-gitops get sa argocd-cluster-argocd-dex-server > /dev/null 2>&1; do sleep 5; done;
              ARGOCD_DEX_SA_TOKEN=$(oc -n openshift-gitops sa get-token argocd-cluster-argocd-dex-server)
              oc annotate -n openshift-gitops --overwrite sa argocd-cluster-argocd-dex-server serviceaccounts.openshift.io/oauth-redirecturi.argocd=${ARGOCD_DEX_REDIRECT_URI}
              until oc -n openshift-gitops get argocd argocd-cluster  > /dev/null 2>&1; do sleep 5; done;
              cat <<EOF > /tmp/dex-config-template.txt
              connectors:
              - config:
                  clientID: system:serviceaccount:openshift-gitops:argocd-cluster-argocd-dex-server
                  clientSecret: ${ARGOCD_DEX_SA_TOKEN}
                  insecureCA: true
                  issuer: https://kubernetes.default.svc
                  redirectURI: ${ARGOCD_DEX_REDIRECT_URI}
                id: openshift
                name: OpenShift
                type: openshift
              EOF
              while true; do
                oc get argocd -n openshift-gitops argocd-cluster -o json | jq 'del(.metadata.resourceVersion)' > /tmp/argocd-cluster.json
                jq --arg config "$(cat /tmp/dex-config-template.txt)" '.spec.dex.config = $config' /tmp/argocd-cluster.json > /tmp/argocd-cluster.json.updated
                oc apply -n openshift-gitops -f /tmp/argocd-cluster.json.updated
                if [ $? -eq 0 ]; then
                  break
                else
                  rm /tmp/argocd-cluster.json /tmp/argocd-cluster.json.updated
                fi
              done
          imagePullPolicy: IfNotPresent
          name: argocd-setup
      dnsPolicy: ClusterFirst
      restartPolicy: OnFailure
      serviceAccount: gitops-operator
      serviceAccountName: gitops-operator
      terminationGracePeriodSeconds: 30
```

