### PR TITLE
Inject git commit into binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ WORKDIR /go/src/github.com/redhat-developer/gitops-operator
 COPY . .
 
 ARG VERBOSE=2
-RUN go build -o bin/gitops-operator cmd/manager/main.go
+RUN GIT_COMMIT=$(git rev-list -1 HEAD) && \
+  go build -ldflags "-X main.GitCommit=$GIT_COMMIT" -o bin/gitops-operator cmd/manager/main.go
 
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -50,10 +50,12 @@ var (
 	metricsHost               = "0.0.0.0"
 	metricsPort         int32 = 8383
 	operatorMetricsPort int32 = 8686
+	GitCommit           string
 )
 var log = logf.Log.WithName("cmd")
 
 func printVersion() {
+	log.Info(fmt.Sprintf("Git Commit: %s", GitCommit))
 	log.Info(fmt.Sprintf("Operator Version: %s", version.Version))
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))


### PR DESCRIPTION
{"level":"info","ts":1614286509.002165,"logger":"cmd","msg":"Git Commit: 89b04f64e2774876870de93fbf046b617de2c0cf"}
{"level":"info","ts":1614286509.002208,"logger":"cmd","msg":"Operator Version: 0.0.1"}
{"level":"info","ts":1614286509.0022101,"logger":"cmd","msg":"Go Version: go1.15.5"}
{"level":"info","ts":1614286509.002214,"logger":"cmd","msg":"Go OS/Arch: darwin/amd64"}
{"level":"info","ts":1614286509.0022159,"logger":"cmd","msg":"Version of operator-sdk: v0.18.2"}
{"level":"info","ts":1614286509.0096781,"logger":"leader","msg":"Trying to become the leader."}
{"level":"info","ts":1614286509.009747,"logger":"leader","msg":"Skipping leader election; not running in a cluster."}