### PR TITLE
Pull it fix from argocd-operator to generate unqiue cluster resource name 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.13
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210225133918-e8b9b089f413
+	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210301162004-70d7ccdfb761
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/argoproj-labs/argocd-operator v0.0.15-0.20210225133918-e8b9b089f413 h1:eVNWscmUzefMD4od4UHe4c/FrwUV7Gc5pi1ttoqYqJE=
 github.com/argoproj-labs/argocd-operator v0.0.15-0.20210225133918-e8b9b089f413/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210301162004-70d7ccdfb761 h1:/YY5eEqnny1VAXr3MN4aNKgN10kxMHtqXlTTa9o/iJs=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210301162004-70d7ccdfb761/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,6 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210225133918-e8b9b089f413 h1:eVNWscmUzefMD4od4UHe4c/FrwUV7Gc5pi1ttoqYqJE=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210225133918-e8b9b089f413/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
 github.com/argoproj-labs/argocd-operator v0.0.15-0.20210301162004-70d7ccdfb761 h1:/YY5eEqnny1VAXr3MN4aNKgN10kxMHtqXlTTa9o/iJs=
 github.com/argoproj-labs/argocd-operator v0.0.15-0.20210301162004-70d7ccdfb761/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=


### PR DESCRIPTION
Pull it fix from argocd-operator https://github.com/argoproj-labs/argocd-operator/pull/248

/kind bug

**What does this PR do / why we need it**:
https://issues.redhat.com/browse/GITOPS-666

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

https://issues.redhat.com/browse/GITOPS-666

**How to test changes / Special notes to the reviewer**:
Not tested in this repo.   The fix will be validated in GitOps 1.0.1 build
Follow the steps in https://github.com/argoproj-labs/argocd-operator/pull/248
