### PR TITLE
Mark GitOpsService CRD as internal

### DIFF
--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -17,6 +17,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    operators.operatorframework.io/internal-objects: '["gitopsservices.pipelines.openshift.io"]'
   name: openshift-gitops-operator.v0.0.3
   namespace: placeholder
 spec:


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug


**What does this PR do / why we need it**:

The GitOps service is a cluster scoped resource that is created by the operator. Since it doesn't have any user input fields, the UI shouldn't expose this resource to the user.
This PR adds an annotation to the operator CSV that makes the resource internal and hides it from OperatorHub UI.

Ref: https://docs.openshift.com/container-platform/4.4/operators/operator_sdk/osdk-generating-csvs.html#osdk-hiding-internal-objects_osdk-generating-csvs

Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

Fixes https://issues.redhat.com/browse/GITOPS-698

**How to test changes / Special notes to the reviewer**:

1. Install the GitOps operator by building a catalog source.
2. Navigate to  installed operators > OpenShift GitOps 
3. The OperatorHub UI shouldn't expose the GitOpsService resource
![Screenshot from 2021-03-04 18-32-27](https://user-images.githubusercontent.com/21128732/109969118-8725fc00-7d19-11eb-98e2-7f6db3401112.png)
