### PR TITLE
Teardown ArgoCD instance in E2E tests

### DIFF
--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -18,6 +18,7 @@ import (
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -55,6 +56,7 @@ func TestGitOpsService(t *testing.T) {
 	t.Run("Validate ConsoleLink", validateConsoleLink)
 	t.Run("Validate ArgoCD Installation", validateArgoCDInstallation)
 	t.Run("Validate ArgoCD Metrics Configuration", validateArgoCDMetrics)
+	t.Run("Validate tear down of ArgoCD Installation", tearDownArgoCD)
 }
 
 func validateGitOpsBackend(t *testing.T) {
@@ -215,4 +217,23 @@ func validateArgoCDMetrics(t *testing.T) {
 		types.NamespacedName{Name: "gitops-operator-argocd-alerts", Namespace: argoCDNamespace},
 		&rule)
 	assertNoError(t, err)
+}
+
+func tearDownArgoCD(t *testing.T) {
+	framework.AddToFrameworkScheme(argoapi.AddToScheme, &argoapp.ArgoCD{})
+	framework.AddToFrameworkScheme(configv1.AddToScheme, &configv1.ClusterVersion{})
+
+	f := framework.Global
+
+	existingArgoInstance := &argoapp.ArgoCD{}
+	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: argoCDInstanceName, Namespace: argoCDNamespace}, existingArgoInstance)
+	assertNoError(t, err)
+
+	// Tear down Argo CD instance
+	err = f.Client.Delete(context.TODO(), existingArgoInstance, &client.DeleteOptions{}) //Get(context.TODO(), types.NamespacedName{Name: argoCDInstanceName, Namespace: argoCDNamespace}, existingArgoInstance)
+	assertNoError(t, err)
+
+	err = e2eutil.WaitForDeletion(t, f.Client.Client, existingArgoInstance, retryInterval, timeout)
+	assertNoError(t, err)
+
 }

--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -230,7 +230,7 @@ func tearDownArgoCD(t *testing.T) {
 	assertNoError(t, err)
 
 	// Tear down Argo CD instance
-	err = f.Client.Delete(context.TODO(), existingArgoInstance, &client.DeleteOptions{}) //Get(context.TODO(), types.NamespacedName{Name: argoCDInstanceName, Namespace: argoCDNamespace}, existingArgoInstance)
+	err = f.Client.Delete(context.TODO(), existingArgoInstance, &client.DeleteOptions{})
 	assertNoError(t, err)
 
 	err = e2eutil.WaitForDeletion(t, f.Client.Client, existingArgoInstance, retryInterval, timeout)


### PR DESCRIPTION
Signed-off-by: jannfis <jann@mistrust.net>

**What type of PR is this?**

> /kind enhancement

**What does this PR do / why we need it**:

This adds tear-down of the `ArgoCD` instance we install during end-to-end testing. Currently, two subsequent runs of end-to-end testsuite on same cluster is not possible, because the `openshift-gitops` namespace won't be correctly deleted - it's stuck in terminating state due to a finalizer on the `ArgoCD` resource which cannot be satisfied, because the operator already is uninstalled when the resource should be deleted. Also, this test is good to have too.

Also, updated the e2e shell script to correctly constraint operator-sdk to pre-v1.0

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
