### PR TITLE
Fix docker build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ mode. You could update your image "payload" and re-install the operator.
 * Build the operator image.
 
 ```
-docker build -t quay.io/redhat-developer/gitops-backend-operator:v0.0.1
+docker build -t quay.io/redhat-developer/gitops-backend-operator:v0.0.1 .
 docker push quay.io/redhat-developer/gitops-backend-operator:v0.0.1
 ```
 


### PR DESCRIPTION
**What type of PR is this?**
kind documentation

**What does this PR do / why we need it**:
Fixing the command in the README.md file
```
$ docker build -t quay.io/redhat-developer/gitops-backend-operator:v0.0.1
"docker build" requires exactly 1 argument.
See 'docker build --help'.
```
Usage:  docker build [OPTIONS] PATH | URL | -

Build an image from a Dockerfile

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes NA

**How to test changes / Special notes to the reviewer**:

Command ```$ docker build -t quay.io/redhat-developer/gitops-backend-operator:v0.0.1 .``` is updated in the README.md file
