### PR TITLE
Pick up from argocd operator "Upgraded ArgoCD version from 1.7.7 to 1.8.7"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.13
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210301162004-70d7ccdfb761
+	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210311214501-ab24cb9e8229
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210301162004-70d7ccdfb761 h1:/YY5eEqnny1VAXr3MN4aNKgN10kxMHtqXlTTa9o/iJs=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210301162004-70d7ccdfb761/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210311214501-ab24cb9e8229 h1:w5wIsVNRl8ZetokRj1vhhvMAWEBsbnQMxvwJK9znE9U=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210311214501-ab24cb9e8229/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
Pick up from argocd operator "Upgraded ArgoCD version from 1.7.7 to 1.8.7 " (#260)

**What type of PR is this?**

GitOps Operator to support Argo CD 1.8's change in Application Controller Deployment to Replica Sets
https://issues.redhat.com/browse/GITOPS-683


 /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
Not tested on this repo.   To be tested on 1.1 build candidates
Steps to test:

1. Upgrade GitOps Operator from 1.0.1 to 1.1.0
2. Verify that argocd application controller is running as replica set in the `openshift-gitops` namespace (oc get replicaset -n openshift-gitops) and pods are running.
3. Verify that there is no deployment for argocd controller (oc get deploy -n operator-gitops)
4. Create an Argo CD app and verify that the app is sync'ed and healthy.
