### PR TITLE
Revert "Mark GitOpsService CRD as internal (#68)"

### DIFF
--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -23,7 +23,6 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    operators.operatorframework.io/internal-objects: '["gitopsservices.pipelines.openshift.io"]'
   name: openshift-gitops-operator.v0.0.3
   namespace: placeholder
 spec:


### PR DESCRIPTION
**What type of PR is this?**

> /kind cleanup


**What does this PR do / why we need it**:

This reverts commit 6ce0ddf1dc8880ab006b8a71bb21c977d0d704bb. The 404 error was due to a bug in the GitOps plugin in the UI. It should be fixed in the OpenShift console repo

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1937929

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
