### PR TITLE
Let user override operator-sdk binary for run-local target of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 E2E_TEST_DIR=test/e2e
+OPERATOR_SDK?=operator-sdk
 
 default: test
 
@@ -24,4 +25,4 @@ gofmt:
 
 .PHONY: run-local
 run-local:
-	operator-sdk run --local --watch-namespace ""
+	${OPERATOR_SDK} run --local --watch-namespace ""


### PR DESCRIPTION
Signed-off-by: jannfis <jann@mistrust.net>

**What type of PR is this?**

> /kind enhancement

**What does this PR do / why we need it**:

The `run-local` target of the Makefile uses a hard-coded binary name of `operator-sdk`. This PR lets user override the name of the binary to use by setting the `OPERATOR_SDK` environment variable, so that a version/binary can be used.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
