### PR TITLE
Sync argocd operator master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.14
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210311214501-ab24cb9e8229
+	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210316205240-3068400e3334
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210311214501-ab24cb9e8229 h1:w5wIsVNRl8ZetokRj1vhhvMAWEBsbnQMxvwJK9znE9U=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210311214501-ab24cb9e8229/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210316205240-3068400e3334 h1:3svsI3s7yfabm7vrNVrKmMQDszoVaU/nJcrqFTTw8mY=
+github.com/argoproj-labs/argocd-operator v0.0.15-0.20210316205240-3068400e3334/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:
Sync upstream argocd operator to pickup
https://github.com/argoproj-labs/argocd-operator/pull/266 support compliance.openshift.io apiGroup for cluster config
https://github.com/argoproj-labs/argocd-operator/pull/265 OpenShift hooks for HA
https://github.com/argoproj-labs/argocd-operator/pull/267 support compliance.openshift.io apiGroup for cluster config

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
No testing done on this repo.  To be tested on v1.1.0 build.

https://github.com/argoproj-labs/argocd-operator/pull/265 OpenShift hooks for HA
https://github.com/argoproj-labs/argocd-operator/pull/267 support compliance.openshift.io apiGroup for cluster config
* Install gitops operator
* create a new argocd instance with ha mode on from the Operator DevConsole UI
* confirm that redis ha server and ha proxyr pods are running by replicaset (not a deployment)
*  add argocd app and confirm app is sync;ed and healthy

https://github.com/argoproj-labs/argocd-operator/pull/266 support compliance.openshift.io apiGroup for cluster config
* Refer to "how to test" in https://github.com/argoproj-labs/argocd-operator/pull/267
