### PR TITLE
feat: create RHSSO using sso template instance (#GITOPS-841)

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -42,7 +42,9 @@ import (
 	_ "github.com/argoproj-labs/argocd-operator/pkg/reconciler/openshift"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 
+	appsv1 "github.com/openshift/api/apps/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	template "github.com/openshift/api/template/v1"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -146,6 +148,8 @@ func main() {
 	registerComponentOrExit(mgr, argoapi.AddToScheme)
 	registerComponentOrExit(mgr, configv1.AddToScheme)
 	registerComponentOrExit(mgr, monitoringv1.AddToScheme)
+	registerComponentOrExit(mgr, template.AddToScheme)
+	registerComponentOrExit(mgr, appsv1.AddToScheme)
 
 	// Add the Metrics Service
 	addMetrics(ctx, cfg)

--- a/deploy/argocd_role.yaml
+++ b/deploy/argocd_role.yaml
@@ -71,6 +71,13 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - template.openshift.io
+  resources:
+  - templates
+  - templateinstances
+  verbs:
+  - '*'
+- apiGroups:
   - route.openshift.io
   resources:
   - routes

--- a/deploy/crds/pipelines.openshift.io_gitopsservices_crd.yaml
+++ b/deploy/crds/pipelines.openshift.io_gitopsservices_crd.yaml
@@ -30,6 +30,9 @@ spec:
           type: object
         spec:
           description: GitopsServiceSpec defines the desired state of GitopsService
+          properties:
+            disableSSO:
+              type: boolean
           type: object
         status:
           description: GitopsServiceStatus defines the observed state of GitopsService

--- a/deploy/crds/pipelines.openshift.io_v1alpha1_gitopsservice_cr.yaml
+++ b/deploy/crds/pipelines.openshift.io_v1alpha1_gitopsservice_cr.yaml
@@ -2,4 +2,6 @@ apiVersion: pipelines.openshift.io/v1alpha1
 kind: GitopsService
 metadata:
   name: example-gitopsservice
-spec:
+spec: {
+  disableSSO: false
+}

--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -249,6 +249,13 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - template.openshift.io
+          resources:
+          - templates
+          - templateinstances
+          verbs:
+          - '*'
+        - apiGroups:
           - route.openshift.io
           resources:
           - routes

--- a/deploy/olm-catalog/gitops-operator/manifests/pipelines.openshift.io_gitopsservices_crd.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/pipelines.openshift.io_gitopsservices_crd.yaml
@@ -30,6 +30,9 @@ spec:
           type: object
         spec:
           description: GitopsServiceSpec defines the desired state of GitopsService
+          properties:
+            disableSSO:
+              type: boolean
           type: object
         status:
           description: GitopsServiceStatus defines the observed state of GitopsService

--- a/pkg/apis/pipelines/v1alpha1/gitopsservice_types.go
+++ b/pkg/apis/pipelines/v1alpha1/gitopsservice_types.go
@@ -6,6 +6,7 @@ import (
 
 // GitopsServiceSpec defines the desired state of GitopsService
 type GitopsServiceSpec struct {
+	DisableSSO bool `json:"disableSSO,omitempty"`
 }
 
 // GitopsServiceStatus defines the observed state of GitopsService

--- a/pkg/controller/gitopsservice/gitopsservice_controller_test.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 
 	argoapp "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
+	oappsv1 "github.com/openshift/api/apps/v1"
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	template "github.com/openshift/api/template/v1"
 	pipelinesv1alpha1 "github.com/redhat-developer/gitops-operator/pkg/apis/pipelines/v1alpha1"
 	"github.com/redhat-developer/gitops-operator/pkg/controller/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -94,6 +96,10 @@ func TestReconcile(t *testing.T) {
 	// Check if argocd instance is created in openshift-gitops namespace
 	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "openshift-gitops", Namespace: serviceNamespace}, &argoapp.ArgoCD{})
 	assertNoError(t, err)
+
+	// Check if rhsso template instance is created in openshift-gitops namespace
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "rhsso", Namespace: serviceNamespace}, &template.TemplateInstance{})
+	assertNoError(t, err)
 }
 
 func TestReconcile_AppDeliveryNamespace(t *testing.T) {
@@ -128,6 +134,10 @@ func TestReconcile_AppDeliveryNamespace(t *testing.T) {
 
 	// Check if argocd instance is created in openshift-gitops namespace
 	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "openshift-gitops", Namespace: serviceNamespace}, &argoapp.ArgoCD{})
+	assertNoError(t, err)
+
+	// Check if rhsso template instance is created in openshift-gitops namespace
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "rhsso", Namespace: serviceNamespace}, &template.TemplateInstance{})
 	assertNoError(t, err)
 }
 
@@ -190,6 +200,9 @@ func addKnownTypesToScheme(scheme *runtime.Scheme) {
 	scheme.AddKnownTypes(pipelinesv1alpha1.SchemeGroupVersion, &pipelinesv1alpha1.GitopsService{})
 	scheme.AddKnownTypes(routev1.GroupVersion, &routev1.Route{})
 	scheme.AddKnownTypes(argoapp.SchemeGroupVersion, &argoapp.ArgoCD{})
+	scheme.AddKnownTypes(oappsv1.SchemeGroupVersion, &oappsv1.DeploymentConfig{})
+	scheme.AddKnownTypes(template.SchemeGroupVersion, &template.Template{})
+	scheme.AddKnownTypes(template.SchemeGroupVersion, &template.TemplateInstance{})
 }
 
 func newReconcileGitOpsService(client client.Client, scheme *runtime.Scheme) *ReconcileGitopsService {

--- a/pkg/controller/gitopsservice/sso_template.go
+++ b/pkg/controller/gitopsservice/sso_template.go
@@ -1,0 +1,357 @@
+package gitopsservice
+
+import (
+	json "encoding/json"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	template "github.com/openshift/api/template/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var (
+	privilegedMode bool  = false
+	graceTime      int64 = 75
+)
+
+func getSSOConfigMapTemplate() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"description": "ConfigMap providing service ca bundle",
+				"service.beta.openshift.io/inject-cabundle": "true",
+			},
+			Labels: map[string]string{
+				"application": "${APPLICATION_NAME}",
+			},
+			Name: "${APPLICATION_NAME}-service-ca",
+		},
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+	}
+}
+
+func getRHSSOContainer() corev1.Container {
+	return corev1.Container{
+		Env: []corev1.EnvVar{
+			{Name: "SSO_HOSTNAME", Value: "${SSO_HOSTNAME}"},
+			{Name: "DB_MIN_POOL_SIZE", Value: "${DB_MIN_POOL_SIZE}"},
+			{Name: "DB_MAX_POOL_SIZE", Value: "${DB_MAX_POOL_SIZE}"},
+			{Name: "DB_TX_ISOLATION", Value: "${DB_TX_ISOLATION}"},
+			{Name: "JGROUPS_PING_PROTOCOL", Value: "openshift.DNS_PING"},
+			{Name: "OPENSHIFT_DNS_PING_SERVICE_NAME", Value: "${APPLICATION_NAME}-ping"},
+			{Name: "OPENSHIFT_DNS_PING_SERVICE_PORT", Value: "8888"},
+			{Name: "X509_CA_BUNDLE", Value: "/var/run/configmaps/service-ca/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"},
+			{Name: "JGROUPS_CLUSTER_PASSWORD", Value: "${JGROUPS_CLUSTER_PASSWORD}"},
+			{Name: "SSO_ADMIN_USERNAME", Value: "${SSO_ADMIN_USERNAME}"},
+			{Name: "SSO_ADMIN_PASSWORD", Value: "${SSO_ADMIN_PASSWORD}"},
+			{Name: "SSO_REALM", Value: "${SSO_REALM}"},
+			{Name: "SSO_SERVICE_USERNAME", Value: "${SSO_SERVICE_USERNAME}"},
+			{Name: "SSO_SERVICE_PASSWORD", Value: "${SSO_SERVICE_PASSWORD}"},
+		},
+		Image:           "${APPLICATION_NAME}",
+		ImagePullPolicy: "Always",
+		LivenessProbe: &corev1.Probe{
+			FailureThreshold: 3,
+			Handler: corev1.Handler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/bin/bash",
+						"-c",
+						"/opt/eap/bin/livenessProbe.sh",
+					},
+				},
+			},
+			InitialDelaySeconds: 60,
+		},
+		Name: "${APPLICATION_NAME}",
+		Ports: []corev1.ContainerPort{
+			{ContainerPort: 8778, Name: "jolokia", Protocol: "TCP"},
+			{ContainerPort: 8080, Name: "http", Protocol: "TCP"},
+			{ContainerPort: 8443, Name: "https", Protocol: "TCP"},
+			{ContainerPort: 8888, Name: "ping", Protocol: "TCP"},
+		},
+		ReadinessProbe: &corev1.Probe{
+			FailureThreshold: 10,
+			Handler: corev1.Handler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/bin/bash",
+						"-c",
+						"/opt/eap/bin/readinessProbe.sh",
+					},
+				},
+			},
+			InitialDelaySeconds: 60,
+		},
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"memory": resource.Quantity{
+					Format: "${MEMORY_LIMIT}",
+				},
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				MountPath: "/etc/x509/https",
+				Name:      "sso-x509-https-volume",
+				ReadOnly:  true,
+			},
+			{
+				MountPath: "/etc/x509/jgroups",
+				Name:      "sso-x509-jgroups-volume",
+				ReadOnly:  true,
+			},
+			{
+				MountPath: "/var/run/configmaps/service-ca",
+				Name:      "service-ca",
+				ReadOnly:  true,
+			},
+		},
+	}
+}
+
+func getSSODeploymentConfigTemplate() *appsv1.DeploymentConfig {
+	rhSSOContainer := getRHSSOContainer()
+	return &appsv1.DeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    map[string]string{"application": "${APPLICATION_NAME}"},
+			Name:      "${APPLICATION_NAME}",
+			Namespace: serviceNamespace,
+		},
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "DeploymentConfig"},
+		Spec: appsv1.DeploymentConfigSpec{
+			Replicas: 1,
+			Selector: map[string]string{"deploymentConfig": "${APPLICATION_NAME}"},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: "Recreate",
+			},
+			Template: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"application":      "${APPLICATION_NAME}",
+						"deploymentConfig": "${APPLICATION_NAME}",
+					},
+					Name: "${APPLICATION_NAME}",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						rhSSOContainer,
+					},
+					TerminationGracePeriodSeconds: &graceTime,
+					Volumes: []corev1.Volume{
+						{
+							Name: "sso-x509-https-volume",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "sso-x509-https-secret",
+								},
+							},
+						},
+						{
+							Name: "sso-x509-jgroups-volume",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "sso-x509-https-secret",
+								},
+							},
+						},
+						{
+							Name: "service-ca",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "${APPLICATION_NAME}-service-ca",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Triggers: appsv1.DeploymentTriggerPolicies{
+				appsv1.DeploymentTriggerPolicy{
+					Type: "ImageChange",
+					ImageChangeParams: &appsv1.DeploymentTriggerImageChangeParams{
+						Automatic:      true,
+						ContainerNames: []string{"${APPLICATION_NAME}"},
+						From: corev1.ObjectReference{
+							Kind:      "ImageStreamTag",
+							Name:      "sso74-openshift-rhel8:7.4",
+							Namespace: "${IMAGE_STREAM_NAMESPACE}",
+						},
+					},
+				},
+				appsv1.DeploymentTriggerPolicy{
+					Type: "ConfigChange",
+				},
+			},
+		},
+	}
+}
+
+func getSSOServiceTemplate() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"application": "${APPLICATION_NAME}"},
+			Name:   "${APPLICATION_NAME}",
+			Annotations: map[string]string{
+				"description": "The web server's https port",
+				"service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-https-secret",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Port: portTLS, TargetPort: intstr.FromInt(int(portTLS))},
+			},
+			Selector: map[string]string{
+				"deploymentConfig": "${APPLICATION_NAME}",
+			},
+		},
+	}
+}
+
+func getSSOPingServiceTemplate() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"application": "${APPLICATION_NAME}"},
+			Name:   "${APPLICATION_NAME}",
+			Annotations: map[string]string{
+				"description": "The JGroups ping port for clustering",
+				"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
+				"service.alpha.openshift.io/serving-cert-secret-name":    "sso-x509-jgroups-secret",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "None",
+			Ports: []corev1.ServicePort{
+				{Name: "ping", Port: 8888},
+			},
+			Selector: map[string]string{
+				"deploymentConfig": "${APPLICATION_NAME}",
+			},
+		},
+	}
+}
+
+func getSSORouteTemplate() *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      map[string]string{"application": "${APPLICATION_NAME}"},
+			Name:        "${APPLICATION_NAME}",
+			Annotations: map[string]string{"description": "Route for application's https service"},
+		},
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Route"},
+		Spec: routev1.RouteSpec{
+			TLS: &routev1.TLSConfig{
+				Termination: "reencrypt",
+			},
+			To: routev1.RouteTargetReference{
+				Name: "${APPLICATION_NAME}",
+			},
+		},
+	}
+}
+
+func newSSOTemplateInstance() *template.TemplateInstance {
+	tpl, err := newSSOTemplate()
+	if err != nil {
+		log.Error(err, "Failed creating template instance for sso")
+		return &template.TemplateInstance{}
+	}
+	return &template.TemplateInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhsso",
+			Namespace: "openshift-gitops",
+		},
+		Spec: template.TemplateInstanceSpec{
+			Template: tpl,
+		},
+	}
+}
+
+func newSSOTemplate() (template.Template, error) {
+	tmpl := template.Template{}
+	configMapTemplate := getSSOConfigMapTemplate()
+	deploymentConfigTemplate := getSSODeploymentConfigTemplate()
+	serviceTemplate := getSSOServiceTemplate()
+	pingServiceTemplate := getSSOPingServiceTemplate()
+	routeTemplate := getSSORouteTemplate()
+
+	configMap, err := json.Marshal(configMapTemplate)
+	if err != nil {
+		return tmpl, err
+	}
+
+	deploymentConfig, err := json.Marshal(deploymentConfigTemplate)
+	if err != nil {
+		return tmpl, err
+	}
+
+	service, err := json.Marshal(serviceTemplate)
+	if err != nil {
+		return tmpl, err
+	}
+
+	pingService, err := json.Marshal(pingServiceTemplate)
+	if err != nil {
+		return tmpl, err
+	}
+
+	route, err := json.Marshal(routeTemplate)
+	if err != nil {
+		return tmpl, err
+	}
+
+	tmpl = template.Template{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"description":               "RH-SSO Template for Gitops Operator",
+				"iconClass":                 "icon-sso",
+				"openshift.io/display-name": "Keycloak",
+				"tags":                      "keycloak",
+				"version":                   "9.0.4-SNAPSHOT",
+			},
+			Name:      "rhsso",
+			Namespace: "openshift-gitops",
+		},
+		Objects: []runtime.RawExtension{
+			{
+				Raw: json.RawMessage(configMap),
+			},
+			{
+				Raw: json.RawMessage(deploymentConfig),
+			},
+			{
+				Raw: json.RawMessage(service),
+			},
+			{
+				Raw: json.RawMessage(pingService),
+			},
+			{
+				Raw: json.RawMessage(route),
+			},
+		},
+		Parameters: []template.Parameter{
+			{Name: "APPLICATION_NAME", Value: "sso", Required: true},
+			{Name: "SSO_HOSTNAME"},
+			{Name: "JGROUPS_CLUSTER_PASSWORD", Generate: "expression", From: "[a-zA-Z0-9]{32}", Required: true},
+			{Name: "DB_MIN_POOL_SIZE"},
+			{Name: "DB_MAX_POOL_SIZE"},
+			{Name: "DB_TX_ISOLATION"},
+			{Name: "IMAGE_STREAM_NAMESPACE", Value: "openshift", Required: true},
+			{Name: "SSO_ADMIN_USERNAME", Generate: "expression", From: "[a-zA-Z0-9]{8}", Required: true},
+			{Name: "SSO_ADMIN_PASSWORD", Generate: "expression", From: "[a-zA-Z0-9]{8}", Required: true},
+			{Name: "SSO_REALM", DisplayName: "RH-SSO Realm"},
+			{Name: "SSO_SERVICE_USERNAME", DisplayName: "RH-SSO Service Username"},
+			{Name: "SSO_SERVICE_PASSWORD", DisplayName: "RH-SSO Service Password"},
+			{Name: "MEMORY_LIMIT", Value: "1Gi"},
+		},
+	}
+	return tmpl, err
+}

--- a/pkg/controller/gitopsservice/sso_template_test.go
+++ b/pkg/controller/gitopsservice/sso_template_test.go
@@ -1,0 +1,33 @@
+package gitopsservice
+
+import (
+	"testing"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+
+	"gotest.tools/assert"
+)
+
+var (
+	testSelector = map[string]string{
+		"deploymentConfig": "${APPLICATION_NAME}",
+	}
+	testStrategy = appsv1.DeploymentStrategy{
+		Type: "Recreate",
+	}
+)
+
+func TestSSODeploymentConfig(t *testing.T) {
+	testSSODeploymentConfig := getSSODeploymentConfigTemplate()
+	assert.Equal(t, testSSODeploymentConfig.Namespace, serviceNamespace)
+	assert.Equal(t, testSSODeploymentConfig.Name, "${APPLICATION_NAME}")
+	assert.DeepEqual(t, testSSODeploymentConfig.Spec.Selector, testSelector)
+	assert.DeepEqual(t, testSSODeploymentConfig.Spec.Strategy, testStrategy)
+	assert.DeepEqual(t, testSSODeploymentConfig.Spec.Template.Spec.Containers[0], getRHSSOContainer())
+}
+
+func TestSSOInstanceCreation(t *testing.T) {
+	testTemplateInstance := newSSOTemplateInstance()
+	assert.Equal(t, testTemplateInstance.Namespace, serviceNamespace)
+	assert.Equal(t, testTemplateInstance.Name, "rhsso")
+}

--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -55,6 +55,7 @@ func TestGitOpsService(t *testing.T) {
 	t.Run("Validate GitOps Backend", validateGitOpsBackend)
 	t.Run("Validate ConsoleLink", validateConsoleLink)
 	t.Run("Validate ArgoCD Installation", validateArgoCDInstallation)
+	t.Run("Validate rhsso installation", validateRHSSO)
 	t.Run("Validate ArgoCD Metrics Configuration", validateArgoCDMetrics)
 	t.Run("Validate tear down of ArgoCD Installation", tearDownArgoCD)
 }

--- a/test/e2e/rhsso_test.go
+++ b/test/e2e/rhsso_test.go
@@ -1,0 +1,28 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	template "github.com/openshift/api/template/v1"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	RHSSOTemplateInstanceName = "rhsso"
+)
+
+func validateRHSSO(t *testing.T) {
+
+	framework.AddToFrameworkScheme(template.AddToScheme, &template.Template{})
+	framework.AddToFrameworkScheme(template.AddToScheme, &template.TemplateInstance{})
+
+	f := framework.Global
+
+	// Check if rhsso templateInstance is created
+	existingTemplateInstance := &template.TemplateInstance{}
+	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: RHSSOTemplateInstanceName, Namespace: argoCDNamespace}, existingTemplateInstance)
+	assertNoError(t, err)
+}


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
GITOPS-841

**Have you updated the necessary documentation?**
Document will be updated together with the follow up stories. A detailed doc for this is already available [here](https://deploy-preview-30615--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/configuring-sso-for-argo-cd-on-openshift.html#registering-an-additional-oauth-client_configuring-sso-for-argo-cd-on-openshift)


**Which issue(s) this PR fixes**:
GITOPS-841

Fixes #?
GITOPS-841

**How to test changes / Special notes to the reviewer**:
1. Run operator locally using operator-sdk or using operatorhub
2. Get the url to login to RH-SSO
`oc get route sso -n openshift-gitops`

Access the url with https in your browser and use the below commands to fetch the credentials.

```
oc exec sso-1-pc44p -n openshift-gitops -- "env" | grep SSO_ADMIN_USERNAME
```
--> Output: SSO_ADMIN_USERNAME=SbjLgMQp

```
 oc exec sso-1-pc44p -n openshift-gitops -- "env" | grep SSO_ADMIN_PASSWORD
```