### PR TITLE
add service account with required permissions for backend service

### DIFF
--- a/pkg/controller/gitopsservice/gitopsservice_controller_test.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller_test.go
@@ -84,15 +84,15 @@ func TestReconcile(t *testing.T) {
 	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceNamespace}, &corev1.Namespace{})
 	assertNoError(t, err)
 
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: gitopsBackendPrefix + serviceName, Namespace: serviceNamespace}, &corev1.ServiceAccount{})
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: gitopsServicePrefix + serviceName, Namespace: serviceNamespace}, &corev1.ServiceAccount{})
 	assertNoError(t, err)
 
 	role := &rbacv1.ClusterRole{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: gitopsBackendPrefix + serviceName}, role)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: gitopsServicePrefix + serviceName}, role)
 	assertNoError(t, err)
 	assert.DeepEqual(t, role.Rules, policyRuleForBackendServiceClusterRole())
 
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: gitopsBackendPrefix + serviceName}, &rbacv1.ClusterRoleBinding{})
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: gitopsServicePrefix + serviceName}, &rbacv1.ClusterRoleBinding{})
 	assertNoError(t, err)
 
 	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}, &appsv1.Deployment{})


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
This PR creates a Cluster Role and Cluster Role Binding which provides the permissions to list/get/watch Application object in argoproj.io api and associate it with the Service Account for Gitops Backend Service (cluster). 

Creates SA/Cluster_Role/Cluster_Role_Binding with the name : "gitops-backend-service-cluster"

TODO: 

- [x] write unit tests

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
- Deploy the latest GitOps operator with these changes.
- Check deployement yaml for GitOps Backend Service, it should have a `serviceAccount/serviceAccountName = gitops-backend-service-cluster`
- Check if SA/ClusterRole/ClusterRoleBinding exists with the above-provided name.
- Verify if the permissions specified in the cluster role allows the gitOps backend service to `GET/LIST/WATCH` Applications resource in all namespaces. 