### PR TITLE
fix: update existing resources on reconciliation based on the desired state

### DIFF
--- a/pkg/controller/gitopsservice/kam.go
+++ b/pkg/controller/gitopsservice/kam.go
@@ -153,10 +153,14 @@ func (r *ReconcileGitopsService) reconcileCLIServer(cr *pipelinesv1alpha1.Gitops
 
 	// Check if this Deployment already exists
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: deploymentObj.Name, Namespace: deploymentObj.Namespace}, &appsv1.Deployment{})
-	if err != nil && errors.IsNotFound(err) {
-		reqLogger.Info("Creating a new Deployment", "Namespace", deploymentObj.Namespace, "Name", deploymentObj.Name)
-		err = r.client.Create(context.TODO(), deploymentObj)
-		if err != nil {
+	if err != nil {
+		if errors.IsNotFound(err) {
+			reqLogger.Info("Creating a new Deployment", "Namespace", deploymentObj.Namespace, "Name", deploymentObj.Name)
+			err = r.client.Create(context.TODO(), deploymentObj)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		} else {
 			return reconcile.Result{}, err
 		}
 	}
@@ -167,10 +171,14 @@ func (r *ReconcileGitopsService) reconcileCLIServer(cr *pipelinesv1alpha1.Gitops
 
 	// Check if this Service already exists
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: serviceRef.Name, Namespace: serviceRef.Namespace}, &corev1.Service{})
-	if err != nil && errors.IsNotFound(err) {
-		reqLogger.Info("Creating a new Service", "Namespace", deploymentObj.Namespace, "Name", deploymentObj.Name)
-		err = r.client.Create(context.TODO(), serviceRef)
-		if err != nil {
+	if err != nil {
+		if errors.IsNotFound(err) {
+			reqLogger.Info("Creating a new Service", "Namespace", deploymentObj.Namespace, "Name", deploymentObj.Name)
+			err = r.client.Create(context.TODO(), serviceRef)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		} else {
 			return reconcile.Result{}, err
 		}
 	}
@@ -181,13 +189,16 @@ func (r *ReconcileGitopsService) reconcileCLIServer(cr *pipelinesv1alpha1.Gitops
 	}
 
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: routeRef.Name, Namespace: routeRef.Namespace}, &routev1.Route{})
-	if err != nil && errors.IsNotFound(err) {
-		reqLogger.Info("Creating a new Route", "Namespace", routeRef.Namespace, "Name", routeRef.Name)
-		err = r.client.Create(context.TODO(), routeRef)
-		if err != nil {
+	if err != nil {
+		if errors.IsNotFound(err) {
+			reqLogger.Info("Creating a new Route", "Namespace", routeRef.Namespace, "Name", routeRef.Name)
+			err = r.client.Create(context.TODO(), routeRef)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		} else {
 			return reconcile.Result{}, err
 		}
-		return reconcile.Result{}, nil
 	}
 
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: routeRef.Name, Namespace: routeRef.Namespace}, routeRef)


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
This PR fixes the reconciliation logic for gitops operator. 
- Checks if the resource already exists
- If exists, checks for the desired state and current state
- If desired state != current state, updates the exisiting resource with the desired state. 

Also, fixed the error checks. 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
- Deploy the GitOps Operator with the changes.
- Update the permissions defined in the Cluster Role for backend service (cluster role - gitops-service-cluster).
- Operator should reconcile and update the permissions back to default permissions. 
- Update the container image for gitops backend deployment to a different image.
- Operator should reconcile and revert back the default image for gitops backend service.