### PR TITLE
Set default namespace resource quotas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.16
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.15-0.20210420044500-941fd5934de4
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210504013943-043ecc91c231
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210420044500-941fd5934de4 h1:g0nFjToiTo06evv6W1r6B1NbeSaMfEmsSuxYNXTDonM=
-github.com/argoproj-labs/argocd-operator v0.0.15-0.20210420044500-941fd5934de4/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210504013943-043ecc91c231 h1:Wn/h90mOqyz31KnuPMUloo1yzhnAqQconkyuvTGjaZ4=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210504013943-043ecc91c231/go.mod h1:FnnHlU59v18bhT0cC8eeEWSXhxzvGulJvjOpGqozeTE=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/pkg/controller/gitopsservice/gitopsservice_controller.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller.go
@@ -17,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -226,6 +227,35 @@ func (r *ReconcileGitopsService) Reconcile(request reconcile.Request) (reconcile
 		}
 	}
 
+	// Ensure compute resource quotas are set for the default ArgoCD namespace
+	resourceQuotaName := argocdNS.Name + "-compute-resources"
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: resourceQuotaName, Namespace: argocdNS.Name}, &corev1.ResourceQuota{})
+	if err != nil && errors.IsNotFound(err) {
+		reqLogger.Info("Setting compute resource quotas for ArgoCD namespace", "Name", argocdNS.Name)
+		resourceQuota := corev1.ResourceQuota{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ResourceQuota",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceQuotaName,
+				Namespace: argocdNS.Name,
+			},
+			Spec: corev1.ResourceQuotaSpec{
+				Hard: corev1.ResourceList{
+					corev1.ResourceMemory:       resourcev1.MustParse("4032Mi"),
+					corev1.ResourceCPU:          resourcev1.MustParse("6188m"),
+					corev1.ResourceLimitsMemory: resourcev1.MustParse("8046Mi"),
+					corev1.ResourceLimitsCPU:    resourcev1.MustParse("12750m"),
+				},
+			},
+		}
+		err = r.client.Create(context.TODO(), &resourceQuota)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	// Set GitopsService instance as the owner and controller
 	if err := controllerutil.SetControllerReference(instance, defaultArgoCDInstance, r.scheme); err != nil {
 		return reconcile.Result{}, err
@@ -402,6 +432,16 @@ func newBackendDeployment(ns types.NamespacedName) *appsv1.Deployment {
 						MountPath: "/etc/gitops/ssl",
 						Name:      "backend-ssl",
 						ReadOnly:  true,
+					},
+				},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resourcev1.MustParse("128Mi"),
+						corev1.ResourceCPU:    resourcev1.MustParse("250m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resourcev1.MustParse("256Mi"),
+						corev1.ResourceCPU:    resourcev1.MustParse("500m"),
 					},
 				},
 			},

--- a/pkg/controller/gitopsservice/gitopsservice_controller_test.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller_test.go
@@ -14,6 +14,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -164,6 +165,49 @@ func TestReconcile_GitOpsNamespace(t *testing.T) {
 	if err == nil {
 		t.Fatalf("was expecting an error %s, but got nil", wantErr)
 	}
+}
+
+func TestReconcile_GitOpsNamespaceResourceQuotas(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	s := scheme.Scheme
+	addKnownTypesToScheme(s)
+
+	fakeClient := fake.NewFakeClientWithScheme(s, util.NewClusterVersion("4.7.1"), newGitopsService())
+	reconciler := newReconcileGitOpsService(fakeClient, s)
+
+	_, err := reconciler.Reconcile(newRequest("test", "test"))
+	assertNoError(t, err)
+
+	resourceQuota := corev1.ResourceQuota{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceNamespace + "-compute-resources", Namespace: serviceNamespace}, &resourceQuota)
+	assertNoError(t, err)
+
+	assert.Equal(t, resourceQuota.Spec.Hard[corev1.ResourceCPU], resourcev1.MustParse("6188m"))
+	assert.Equal(t, resourceQuota.Spec.Hard[corev1.ResourceMemory], resourcev1.MustParse("4032Mi"))
+	assert.Equal(t, resourceQuota.Spec.Hard[corev1.ResourceLimitsCPU], resourcev1.MustParse("12750m"))
+	assert.Equal(t, resourceQuota.Spec.Hard[corev1.ResourceLimitsMemory], resourcev1.MustParse("8046Mi"))
+}
+
+func TestReconcile_BackendResourceLimits(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	s := scheme.Scheme
+	addKnownTypesToScheme(s)
+
+	fakeClient := fake.NewFakeClientWithScheme(s, util.NewClusterVersion("4.7.1"), newGitopsService())
+	reconciler := newReconcileGitOpsService(fakeClient, s)
+
+	_, err := reconciler.Reconcile(newRequest("test", "test"))
+	assertNoError(t, err)
+
+	deployment := appsv1.Deployment{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}, &deployment)
+	assertNoError(t, err)
+
+	resources := deployment.Spec.Template.Spec.Containers[0].Resources
+	assert.Equal(t, resources.Requests[corev1.ResourceCPU], resourcev1.MustParse("250m"))
+	assert.Equal(t, resources.Requests[corev1.ResourceMemory], resourcev1.MustParse("128Mi"))
+	assert.Equal(t, resources.Limits[corev1.ResourceCPU], resourcev1.MustParse("500m"))
+	assert.Equal(t, resources.Limits[corev1.ResourceMemory], resourcev1.MustParse("256Mi"))
 }
 
 func TestGetBackendNamespace(t *testing.T) {

--- a/pkg/controller/gitopsservice/kam.go
+++ b/pkg/controller/gitopsservice/kam.go
@@ -3,6 +3,7 @@ package gitopsservice
 import (
 	"context"
 	"fmt"
+	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	"os"
 
 	console "github.com/openshift/api/console/v1"
@@ -40,6 +41,16 @@ func newDeploymentForCLI() *appsv1.Deployment {
 						Name:          "http",
 						Protocol:      corev1.ProtocolTCP,
 						ContainerPort: port, // should come from flag
+					},
+				},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resourcev1.MustParse("128Mi"),
+						corev1.ResourceCPU:    resourcev1.MustParse("250m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resourcev1.MustParse("256Mi"),
+						corev1.ResourceCPU:    resourcev1.MustParse("500m"),
 					},
 				},
 			},


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:

- Sets compute resources for the kam and backend pods.
- Sets resource quotas for the *openshift-gitops* namespace

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

GITOPS-890

**Test acceptance criteria**:

* [x] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:

Install the operator.  The *openshift-gitops* namespace should have resource quotas set, and all argocd pods in that namespace should start successfully.

**Note to Reviewers** The resource quotas for the namespace were calculated by adding up all the compute resources for the various workloads and then multiplying the total by 1.5.
