### PR TITLE
added permissions to create resource quotas for gitops-operator

### DIFF
--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -256,6 +256,15 @@ spec:
           - clusterrolebindings
           verbs:
           - '*'
+        - apiGroups:
+            - ""
+          resources:
+          - resourcequotas
+          verbs:
+          - "get"
+          - "list"
+          - "watch"
+          - "create"
         serviceAccountName: gitops-operator
       permissions:
       - rules:


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
With new changes introduced in the Operator, it needs the permissions to list/watch/create `ResourceQuotas`. These permissions are needed to be added to the `gitops-operator` service account.  

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
REPRODUCING THE ISSUE:
- Build a custom gitops operator bundle with the latest changes. 
- Deploy the Gitops Operator using the bundle, it would fail to create the default ArgoCD instance in openshift-gitops namespace as it doesn't have the permissions to create Resource Quotas.

TESTING THE FIX:
- Create a custom bundle with these changes. 
- Deploy the Gitops Operator using the bundle, it would be able to deploy the ArgoCD instance in openshift-gitops namespace successfully. 