### PR TITLE
Correct spelling of ArgoCD to Argo CD in some cases including App Launcher

### DIFF
--- a/pkg/controller/argocd/argocd.go
+++ b/pkg/controller/argocd/argocd.go
@@ -137,7 +137,7 @@ func getArgoServerSpec() argoapp.ArgoCDServerSpec {
 	}
 }
 
-// NewCR returns an ArgoCD reference optimized for use in OpenShift
+// NewCR returns an Argo CD reference optimized for use in OpenShift
 // with Tekton
 func NewCR(name, ns string) (*argoapp.ArgoCD, error) {
 	b, err := yaml.Marshal([]resource{

--- a/pkg/controller/argocd/argocd_controller.go
+++ b/pkg/controller/argocd/argocd_controller.go
@@ -46,7 +46,7 @@ func init() {
 	image = imageDataURL(base64.StdEncoding.EncodeToString(readStatikImage()))
 }
 
-// Add creates a new ArgoCD Controller and adds it to the Manager. The Manager will set fields on the Controller
+// Add creates a new Argo CD Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
 	return add(mgr, newReconciler(mgr))
@@ -61,7 +61,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	reqLogger := logs.WithValues()
-	reqLogger.Info("Watching ArgoCD Server Route")
+	reqLogger.Info("Watching Argo CD Server Route")
 
 	c, err := controller.New("argocd-route-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
@@ -75,7 +75,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	reqLogger.Info("Created controller for ArgoCD server route")
+	reqLogger.Info("Created controller for Argo CD server route")
 	return nil
 }
 
@@ -101,7 +101,7 @@ func filterArgoCDRoute(namespace, name string) bool {
 // blank assignment to verify that ReconcileArgoCDRoute implements reconcile.Reconciler
 var _ reconcile.Reconciler = &ReconcileArgoCDRoute{}
 
-// ReconcileArgoCDRoute reconciles a ArgoCD Route object
+// ReconcileArgoCDRoute reconciles a Argo CD Route object
 type ReconcileArgoCDRoute struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
@@ -109,23 +109,23 @@ type ReconcileArgoCDRoute struct {
 	scheme *runtime.Scheme
 }
 
-// Reconcile reads that state of the cluster for a ArgoCD Route object and makes changes based on the state read
+// Reconcile reads that state of the cluster for a Argo CD Route object and makes changes based on the state read
 // and what is in the Route.Spec
 // Note:
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileArgoCDRoute) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := logs.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling ArgoCD Route")
+	reqLogger.Info("Reconciling Argo CD Route")
 
 	ctx := context.Background()
 
-	// Fetch ArgoCD server route
+	// Fetch Argo CD server route
 	argoCDRoute := &routev1.Route{}
 	err := r.client.Get(ctx, types.NamespacedName{Name: argocdRouteName, Namespace: argocdNS}, argoCDRoute)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			reqLogger.Info("ArgoCD server route not found", "Route.Namespace", argocdNS)
+			reqLogger.Info("Argo CD server route not found", "Route.Namespace", argocdNS)
 			// if argocd-server route is deleted, remove the ConsoleLink if present
 			return reconcile.Result{}, r.deleteConsoleLinkIfPresent(ctx, reqLogger)
 		}
@@ -135,7 +135,7 @@ func (r *ReconcileArgoCDRoute) Reconcile(request reconcile.Request) (reconcile.R
 
 	argocCDRouteURL := fmt.Sprintf("https://%s", argoCDRoute.Spec.Host)
 
-	consoleLink := newConsoleLink(argocCDRouteURL, "ArgoCD")
+	consoleLink := newConsoleLink(argocCDRouteURL, "Argo CD")
 
 	found := &console.ConsoleLink{}
 	err = r.client.Get(ctx, types.NamespacedName{Name: consoleLink.Name}, found)
@@ -196,12 +196,12 @@ func readStatikImage() []byte {
 	}
 	file, err := statikFs.Open(iconFilePath)
 	if err != nil {
-		log.Fatalf("Failed to open ArgoCD icon file: %v", err)
+		log.Fatalf("Failed to open Argo CD icon file: %v", err)
 	}
 	defer file.Close()
 	data, err := ioutil.ReadAll(file)
 	if err != nil {
-		log.Fatalf("Failed to read ArgoCD icon file: %v", err)
+		log.Fatalf("Failed to read Argo CD icon file: %v", err)
 	}
 	return data
 }

--- a/pkg/controller/argocd/argocd_controller_test.go
+++ b/pkg/controller/argocd/argocd_controller_test.go
@@ -48,7 +48,7 @@ func TestReconcile_create_consolelink(t *testing.T) {
 	fakeClient := fake.NewFakeClient(argoCDRoute)
 
 	reconcileArgoCD := newFakeReconcileArgoCD(fakeClient, s)
-	want := newConsoleLink("https://test.com", "ArgoCD")
+	want := newConsoleLink("https://test.com", "Argo CD")
 
 	result, err := reconcileArgoCD.Reconcile(newRequest(argocdNS, argocdInstanceName))
 	assertConsoleLinkExists(t, fakeClient, reconcileResult{result, err}, want)

--- a/pkg/controller/argocdmetrics/argocd_metrics_controller.go
+++ b/pkg/controller/argocdmetrics/argocd_metrics_controller.go
@@ -3,6 +3,7 @@ package argocdmetrics
 import (
 	"context"
 	"fmt"
+
 	argoapp "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/go-logr/logr"
@@ -41,7 +42,7 @@ type ArgoCDMetricsReconciler struct {
 // blank assignment to verify that ReconcileArgoCDRoute implements reconcile.Reconciler
 var _ reconcile.Reconciler = &ArgoCDMetricsReconciler{}
 
-// Add creates a new ArgoCD Metrics Controller and adds it to the Manager.
+// Add creates a new Argo CD Metrics Controller and adds it to the Manager.
 // The Manager will set fields on the Controller and start it when the
 // Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -51,13 +52,13 @@ func Add(mgr manager.Manager) error {
 func add(mgr manager.Manager, reconciler reconcile.Reconciler) error {
 	reqLogger := logs.WithValues()
 
-	reqLogger.Info("Creating ArgoCD metrics controller")
+	reqLogger.Info("Creating Argo CD metrics controller")
 	c, err := controller.New("argocd-metrics-controller", mgr, controller.Options{Reconciler: reconciler})
 	if err != nil {
 		return err
 	}
 
-	reqLogger.Info("Watching for ArgoCD instance creation")
+	reqLogger.Info("Watching for Argo CD instance creation")
 	err = c.Watch(&source.Kind{Type: &argoapp.ArgoCD{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return err
@@ -73,7 +74,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 
 func (r *ArgoCDMetricsReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := logs.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling ArgoCD Metrics")
+	reqLogger.Info("Reconciling Argo CD Metrics")
 
 	namespace := corev1.Namespace{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: request.Namespace}, &namespace)
@@ -93,12 +94,12 @@ func (r *ArgoCDMetricsReconciler) Reconcile(request reconcile.Request) (reconcil
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: request.Name, Namespace: request.Namespace}, argocd)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// ArgoCD not found, could have been deleted after reconcile request.
+			// Argo CD not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
 			return reconcile.Result{}, nil
 		}
-		reqLogger.Error(err, "Error getting ArgoCD instsance")
+		reqLogger.Error(err, "Error getting Argo CD instsance")
 		return reconcile.Result{}, err
 	}
 
@@ -132,7 +133,7 @@ func (r *ArgoCDMetricsReconciler) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, err
 	}
 
-	// Create ServiceMonitor for ArgoCD application metrics
+	// Create ServiceMonitor for Argo CD application metrics
 	serviceMonitorLabel := fmt.Sprintf("%s-metrics", request.Name)
 	serviceMonitorName := request.Name
 	err = r.createServiceMonitorIfAbsent(request.Namespace, argocd, serviceMonitorName, serviceMonitorLabel, reqLogger)
@@ -140,7 +141,7 @@ func (r *ArgoCDMetricsReconciler) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, err
 	}
 
-	// Create ServiceMonitor for ArgoCD API server metrics
+	// Create ServiceMonitor for Argo CD API server metrics
 	serviceMonitorLabel = fmt.Sprintf("%s-server-metrics", request.Name)
 	serviceMonitorName = fmt.Sprintf("%s-server", request.Name)
 	err = r.createServiceMonitorIfAbsent(request.Namespace, argocd, serviceMonitorName, serviceMonitorLabel, reqLogger)
@@ -148,7 +149,7 @@ func (r *ArgoCDMetricsReconciler) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, err
 	}
 
-	// Create ServiceMonitor for ArgoCD repo server metrics
+	// Create ServiceMonitor for Argo CD repo server metrics
 	serviceMonitorLabel = fmt.Sprintf("%s-repo-server", request.Name)
 	serviceMonitorName = fmt.Sprintf("%s-repo-server", request.Name)
 	err = r.createServiceMonitorIfAbsent(request.Namespace, argocd, serviceMonitorName, serviceMonitorLabel, reqLogger)
@@ -178,7 +179,7 @@ func (r *ArgoCDMetricsReconciler) createReadRoleIfAbsent(namespace string, argoc
 		reqLogger.Info("Creating new read role",
 			"Namespace", readRole.Namespace, "Name", readRole.Name)
 
-		// Set the ArgoCD instance as the owner and controller
+		// Set the Argo CD instance as the owner and controller
 		if err := controllerutil.SetControllerReference(argocd, readRole, r.scheme); err != nil {
 			reqLogger.Error(err, "Error setting read role owner ref",
 				"Namespace", readRole.Namespace, "Name", readRole.Name, "ArgoCD Name", argocd.Name)
@@ -212,7 +213,7 @@ func (r *ArgoCDMetricsReconciler) createReadRoleBindingIfAbsent(namespace string
 		reqLogger.Info("Creating new read role binding",
 			"Namespace", readRoleBinding.Namespace, "Name", readRoleBinding.Name)
 
-		// Set the ArgoCD instance as the owner and controller
+		// Set the Argo CD instance as the owner and controller
 		if err := controllerutil.SetControllerReference(argocd, readRoleBinding, r.scheme); err != nil {
 			reqLogger.Error(err, "Error setting read role owner ref",
 				"Namespace", readRoleBinding.Namespace, "Name", readRoleBinding.Name, "ArgoCD Name", argocd.Name)
@@ -246,7 +247,7 @@ func (r *ArgoCDMetricsReconciler) createServiceMonitorIfAbsent(namespace string,
 		reqLogger.Info("Creating a new ServiceMonitor instance",
 			"Namespace", serviceMonitor.Namespace, "Name", serviceMonitor.Name)
 
-		// Set the ArgoCD instance as the owner and controller
+		// Set the Argo CD instance as the owner and controller
 		if err := controllerutil.SetControllerReference(argocd, serviceMonitor, r.scheme); err != nil {
 			reqLogger.Error(err, "Error setting read role owner ref",
 				"Namespace", serviceMonitor.Namespace, "Name", serviceMonitor.Name, "ArgoCD Name", argocd.Name)
@@ -279,7 +280,7 @@ func (r *ArgoCDMetricsReconciler) createPrometheusRuleIfAbsent(namespace string,
 		reqLogger.Info("Creating new alert rule",
 			"Namespace", alertRule.Namespace, "Name", alertRule.Name)
 
-		// Set the ArgoCD instance as the owner and controller
+		// Set the Argo CD instance as the owner and controller
 		if err := controllerutil.SetControllerReference(argocd, alertRule, r.scheme); err != nil {
 			reqLogger.Error(err, "Error setting read role owner ref",
 				"Namespace", alertRule.Namespace, "Name", alertRule.Name, "ArgoCD Name", argocd.Name)
@@ -371,9 +372,9 @@ func newServiceMonitor(namespace, name, matchLabel string) *monitoringv1.Service
 func newPrometheusRule(namespace string) *monitoringv1.PrometheusRule {
 	// The namespace used in the alert rule is not the namespace of the
 	// running application, it is the namespace that the corresponding
-	// ArgoCD application metadata was created in.  This is needed to
+	// Argo CD application metadata was created in.  This is needed to
 	// scope this alert rule to only fire for applications managed
-	// by the ArgoCD instance installed in this namespace.
+	// by the Argo CD instance installed in this namespace.
 	expr := fmt.Sprintf("argocd_app_info{namespace=\"%s\",sync_status=\"OutOfSync\"} > 0", namespace)
 
 	objectMeta := metav1.ObjectMeta{
@@ -388,7 +389,7 @@ func newPrometheusRule(namespace string) *monitoringv1.PrometheusRule {
 					{
 						Alert: "ArgoCDSyncAlert",
 						Annotations: map[string]string{
-							"message": "ArgoCD application {{ $labels.name }} is out of sync",
+							"message": "Argo CD application {{ $labels.name }} is out of sync",
 						},
 						Expr: intstr.IntOrString{
 							Type:   intstr.String,

--- a/pkg/controller/gitopsservice/gitopsservice_controller.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller.go
@@ -274,7 +274,7 @@ func (r *ReconcileGitopsService) Reconcile(request reconcile.Request) (reconcile
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: defaultArgoCDInstance.Name, Namespace: defaultArgoCDInstance.Namespace}, existingArgoCD)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			reqLogger.Info("Creating a new ArgoCD instance", "Namespace", defaultArgoCDInstance.Namespace, "Name", defaultArgoCDInstance.Name)
+			reqLogger.Info("Creating a new Argo CD instance", "Namespace", defaultArgoCDInstance.Namespace, "Name", defaultArgoCDInstance.Name)
 			err = r.client.Create(context.TODO(), defaultArgoCDInstance)
 			if err != nil {
 				return reconcile.Result{}, err

--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -54,9 +54,9 @@ func TestGitOpsService(t *testing.T) {
 	t.Run("Validate kam service", validateKamService)
 	t.Run("Validate GitOps Backend", validateGitOpsBackend)
 	t.Run("Validate ConsoleLink", validateConsoleLink)
-	t.Run("Validate ArgoCD Installation", validateArgoCDInstallation)
-	t.Run("Validate ArgoCD Metrics Configuration", validateArgoCDMetrics)
-	t.Run("Validate tear down of ArgoCD Installation", tearDownArgoCD)
+	t.Run("Validate Argo CD Installation", validateArgoCDInstallation)
+	t.Run("Validate Argo CD Metrics Configuration", validateArgoCDMetrics)
+	t.Run("Validate tear down of Argo CD Installation", tearDownArgoCD)
 }
 
 func validateGitOpsBackend(t *testing.T) {
@@ -130,12 +130,12 @@ func validateArgoCDInstallation(t *testing.T) {
 	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: argoCDNamespace}, &corev1.Namespace{})
 	assertNoError(t, err)
 
-	// Check if ArgoCD instance is created
+	// Check if Argo CD instance is created
 	existingArgoInstance := &argoapp.ArgoCD{}
 	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: argoCDInstanceName, Namespace: argoCDNamespace}, existingArgoInstance)
 	assertNoError(t, err)
 
-	// modify the ArgoCD instance "manually"
+	// modify the Argo CD instance "manually"
 	// and ensure that a manual modification of the
 	// ArgoCD CR is allowed, and not overwritten
 	// by the reconciler


### PR DESCRIPTION
According to https://issues.redhat.com/browse/DTUX-998 under point 3, in the Application Launcher, "ArgoCD" should be "Argo CD". I took this opportunity to change some other instances over to Argo CD as well, please let me know if you disagree with any of the changes!

**What type of PR is this?**

 /kind bug

**What does this PR do / why we need it**:
Changes Application Launcher text for ArgoCD to Argo CD. Also changes some error messages and comments to Argo CD

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
Not listed as a github issue, only listed in JIRA under DTUX-998 (linked above)

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
Need help testing this before it gets merged
