### PR TITLE
Make target for running e2e test on installed operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,8 @@ gofmt:
 .PHONY: run-local
 run-local:
 	${OPERATOR_SDK} run --local --watch-namespace ""
+
+# Please install GitOps operator before running this target
+.PHONY: test-e2e-on-operator
+test-e2e-on-operator:
+	CGO_ENABLED=0 SKIP_OPERATOR_DEPLOYMENT=true operator-sdk test local ./test/e2e  --verbose --no-setup

--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -55,7 +56,9 @@ func TestGitOpsService(t *testing.T) {
 	err := framework.AddToFrameworkScheme(apis.AddToScheme, &operator.GitopsServiceList{})
 	assertNoError(t, err)
 
-	deployOperator(t)
+	if os.Getenv("SKIP_OPERATOR_DEPLOYMENT") != "true" {
+		deployOperator(t)
+	}
 
 	// run subtests
 	t.Run("Validate kam service", validateKamService)


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
Running the e2e test on the operator which is already installed in the cluster. It will be helpful for running e2e test on downstream staging operator images. Also the same make target can be used for freshly compiled and installed upstream gitops operator image 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes NA

**Test acceptance criteria**:

* [ ] Unit Test - NA
* [ ] E2E Test - NA

**How to test changes / Special notes to the reviewer**:

1. Install gitops operator
2. run `make test-e2e-on-operator`

