### PR TITLE
Add E2E test for cluster-scoped namespace

### DIFF
--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -436,6 +436,7 @@ func validateNamespaceScopedInstall(t *testing.T) {
 
 // waitForResourcesByName will wait up to 'timeout' minutes for a set of resources to exist; the resources
 // should be of the given type (Deployment, Service, etc) and name(s).
+// Returns error if the resources could not be found within the given time frame.
 func waitForResourcesByName(resourceList []resourceList, namespace string, timeout time.Duration, t *testing.T) error {
 
 	f := framework.Global


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

This PR adds a simple E2E test for creation of cluster-scoped ArgoCD instance in a new namespace.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

N/A

Fixes #?

N/A

**Test acceptance criteria**:

* [ ] Unit Test
* [X] E2E Test

**How to test changes / Special notes to the reviewer**:
