### PR TITLE
feat: Add RHSSO support for OpenShift Disconnected Cluster

### DIFF
--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -969,6 +969,9 @@ spec:
               description: SSO defines the Single Sign-on configuration for Argo
                 CD
               properties:
+                image:
+                  description: Image is the SSO container image.
+                  type: string
                 provider:
                   description: Provider installs and configures the given SSO Provider
                     with Argo CD.
@@ -976,6 +979,9 @@ spec:
                 verifyTLS:
                   description: VerifyTLS set to false disables strict TLS validation.
                   type: boolean
+                version:
+                  description: Version is the SSO container image tag.
+                  type: string
               type: object
             statusBadgeEnabled:
               description: StatusBadgeEnabled toggles application status badge feature.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.16
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210706021413-b1d5839e2b9c
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210708113628-c85d1875315f
 	github.com/bugsnag/bugsnag-go v1.5.3 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/coreos/prometheus-operator v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210706021413-b1d5839e2b9c h1:DOsb8gkdIG+OPEqx+SoozD8klXfN+azcMX0DLDy68eE=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210706021413-b1d5839e2b9c/go.mod h1:b6t078lHz63c2mTeyJuDXwceCbAu9GJxeWlDn7XDj7w=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210708113628-c85d1875315f h1:JxVOUbYfn7DcFyy4dcIfvUTAyAEqAoUJsRFCuZvDfUE=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210708113628-c85d1875315f/go.mod h1:b6t078lHz63c2mTeyJuDXwceCbAu9GJxeWlDn7XDj7w=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
**What type of PR is this?**
Add RHSSO support for OpenShift Disconnected Cluster

> /kind enhancement

**What does this PR do / why we need it**:
This PR adds RHSSO support for OpenShift Disconnected cluster.

**Have you updated the necessary documentation?**
* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.
Documentation is updated in the upstream docs. Similar documentation will be published to OpenShift Docs.
https://argocd-operator.readthedocs.io/en/latest/usage/keycloak/#additional-steps-for-disconnected-openshift-clusters

**How to test changes / Special notes to the reviewer**:
1. Create a operator bundle and an Index Image.
2. Deploy the Index Image in Disconnected cluster.
3. Verify keycloak pods are running in openshift-gitops namespace.
4. On the Argo CD UI page, You should see an option to Login with Keycloak