### PR TITLE
add e2e test to validate permissions by label for OOTB argocd instance

### DIFF
--- a/test/appcrs/nginx_default_ns_appcr.yaml
+++ b/test/appcrs/nginx_default_ns_appcr.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nginx
+  namespace: openshift-gitops
+spec:
+  destination:
+    namespace: argocd-target
+    server: 'https://kubernetes.default.svc'
+  project: default
+  source:
+    path: test/examples/nginx
+    repoURL: 'https://github.com/redhat-developer/gitops-operator'
+    targetRevision: HEAD
+  syncPolicy:
+    automated: {}
+status: {}

--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -62,6 +62,8 @@ const (
 	rhssosecret                           = "keycloak-secret"
 	argocdNonDefaultNamespaceInstanceName = "argocd-non-default-namespace-instance"
 	argocdNonDefaultNamespace             = "argocd-non-default-source"
+	argocdTargetNamespace                 = "argocd-target"
+	argocdManagedByLabel                  = "argocd.argoproj.io/managed-by"
 	standaloneArgoCDNamespace             = "gitops-standalone-test"
 )
 
@@ -648,6 +650,86 @@ func validateGrantingPermissionsByLabel(t *testing.T) {
 			return false, nil
 		}
 		if err := helper.ApplicationSyncStatus("nginx", sourceNS); err != nil {
+			t.Log(err)
+			return false, nil
+		}
+		return true, nil
+	})
+	assertNoError(t, err)
+}
+
+func validateGrantingPermissionsByLabelForOOTBArgocdInstance(t *testing.T) {
+	framework.AddToFrameworkScheme(argoapi.AddToScheme, &argoapp.ArgoCD{})
+	ctx := framework.NewContext(t)
+	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: time.Second * 60, RetryInterval: time.Second * 1}
+	defer ctx.Cleanup()
+	f := framework.Global
+	// Wait for the default project to exist; this avoids a race condition where the Application
+	// can be created before the Project that it targets.
+	if err := wait.Poll(time.Second*5, time.Minute*5, func() (bool, error) {
+		if status, err := helper.ProjectExists("default", argoCDNamespace); !status {
+			t.Log(err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatalf("project never existed %v", err)
+	}
+	// 'When GitOps operator is run locally (not installed via OLM), it does not correctly setup
+	// the 'argoproj.io' Role rules for the 'argocd-application-controller'
+	// Thus, applying missing rules for 'argocd-application-controller'
+	// TODO: Remove once https://github.com/redhat-developer/gitops-operator/issues/148 is fixed
+	if err := applyMissingPermissions(ctx, f, argoCDInstanceName, argoCDNamespace); err != nil {
+		t.Fatal(err)
+	}
+	// create a target namespace to deploy resources
+	// allow argocd to create resources in the target namespace by adding managed-by label
+	targetNamespaceObj := &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name: argocdTargetNamespace,
+			Labels: map[string]string{
+				argocdManagedByLabel: argoCDNamespace,
+			},
+		},
+	}
+	err := f.Client.Create(context.TODO(), targetNamespaceObj, cleanupOptions)
+	if !kubeerrors.IsAlreadyExists(err) {
+		assertNoError(t, err)
+	}
+	// check if the necessary roles/rolebindings are created in the target namespace
+	resourceList := []resourceList{
+		{
+			&rbacv1.Role{},
+			[]string{
+				argoCDInstanceName + "-argocd-application-controller",
+				argoCDInstanceName + "-argocd-redis-ha",
+				argoCDInstanceName + "-argocd-server",
+			},
+		},
+		{
+			&rbacv1.RoleBinding{},
+			[]string{
+				argoCDInstanceName + "-argocd-application-controller",
+				argoCDInstanceName + "-argocd-redis-ha",
+				argoCDInstanceName + "-argocd-server",
+			},
+		},
+	}
+	err = waitForResourcesByName(resourceList, argocdTargetNamespace, time.Second*180, t)
+	assertNoError(t, err)
+	// create an ArgoCD app and check if it can create resources in the target namespace
+	nginxAppCr := filepath.Join("test", "appcrs", "nginx_default_ns_appcr.yaml")
+	ocPath, err := exec.LookPath("oc")
+	assertNoError(t, err)
+	cmd := exec.Command(ocPath, "apply", "-f", nginxAppCr)
+	err = cmd.Run()
+	assertNoError(t, err)
+	err = wait.Poll(time.Second*1, time.Second*180, func() (bool, error) {
+		if err := helper.ApplicationHealthStatus("nginx", argoCDNamespace); err != nil {
+			t.Log(err)
+			return false, nil
+		}
+		if err := helper.ApplicationSyncStatus("nginx", argoCDNamespace); err != nil {
 			t.Log(err)
 			return false, nil
 		}

--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -91,6 +91,7 @@ func TestGitOpsService(t *testing.T) {
 	t.Run("Validate Redhat Single sign-on Uninstallation", verifyRHSSOUnInstallation)
 	t.Run("Validate Namespace-scoped install", validateNamespaceScopedInstall)
 	t.Run("Validate granting permissions by adding label", validateGrantingPermissionsByLabel)
+	t.Run("Validate granting permissions by adding label for ootb argocd instance", validateGrantingPermissionsByLabelForOOTBArgocdInstance)
 	t.Run("Validate tear down of ArgoCD Installation", tearDownArgoCD)
 
 }

--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -25,7 +25,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -64,7 +63,6 @@ const (
 	argocdNonDefaultNamespace             = "argocd-non-default-source"
 	argocdTargetNamespace                 = "argocd-target"
 	argocdManagedByLabel                  = "argocd.argoproj.io/managed-by"
-	standaloneArgoCDNamespace             = "gitops-standalone-test"
 )
 
 func TestGitOpsService(t *testing.T) {
@@ -673,15 +671,6 @@ func validateGrantingPermissionsByLabelForOOTBArgocdInstance(t *testing.T) {
 		return true, nil
 	})
 	assertNoError(t, err)
-}
-
-// resourceList is used by waitForResourcesByName
-type resourceList struct {
-	// resource is the type of resource to verify that it exists
-	resource runtime.Object
-
-	// expectedResources are the names of the resources of the above type
-	expectedResources []string
 }
 
 func skipOperatorDeployment() bool {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
/kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
adds an e2e test case to validate permissions by label for ootb argocd instance and a new target namespace 
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes [GITOPS-1004](https://issues.redhat.com/browse/GITOPS-1004)?

**Test acceptance criteria**:

* [ ] Unit Test
* [x] E2E Test

**How to test changes / Special notes to the reviewer**:
