### PR TITLE
Add DISABLE_DEFAULT_ARGOCD_INSTANCE environment variable to operator to disable creation of default Argo CD instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 E2E_TEST_DIR=test/e2e
+NON_DEFAULT_E2E_TEST_DIR=test/nondefaulte2e
 OPERATOR_SDK?=operator-sdk
 
 default: test
 
 .PHONY: test
 test:
-	go test `go list ./... | grep -v ${E2E_TEST_DIR}`
+	go test `go list ./... | grep -v ${E2E_TEST_DIR} | grep -v ${NON_DEFAULT_E2E_TEST_DIR}`
 
 .PHONY: prepare-test-cluster
 prepare-test-cluster:

--- a/common/common.go
+++ b/common/common.go
@@ -2,5 +2,6 @@ package common
 
 // Default Argo CD instance name
 const (
-	ArgoCDInstanceName = "openshift-gitops"
+	ArgoCDInstanceName           = "openshift-gitops"
+	EnvVar_disableDefaultInstall = "DISABLE_DEFAULT_ARGOCD_INSTANCE"
 )

--- a/common/common.go
+++ b/common/common.go
@@ -3,5 +3,5 @@ package common
 // Default Argo CD instance name
 const (
 	ArgoCDInstanceName           = "openshift-gitops"
-	EnvVar_disableDefaultInstall = "DISABLE_DEFAULT_ARGOCD_INSTANCE"
+	DisableDefaultInstallEnvVar = "DISABLE_DEFAULT_ARGOCD_INSTANCE"
 )

--- a/common/common.go
+++ b/common/common.go
@@ -2,6 +2,6 @@ package common
 
 // Default Argo CD instance name
 const (
-	ArgoCDInstanceName           = "openshift-gitops"
+	ArgoCDInstanceName          = "openshift-gitops"
 	DisableDefaultInstallEnvVar = "DISABLE_DEFAULT_ARGOCD_INSTANCE"
 )

--- a/pkg/controller/gitopsservice/gitopsservice_controller.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller.go
@@ -65,7 +65,7 @@ func Add(mgr manager.Manager) error {
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 
-	disableDefaultInstall := strings.ToLower(os.Getenv(common.EnvVar_disableDefaultInstall)) == "true"
+	disableDefaultInstall := strings.ToLower(os.Getenv(common.DisableDefaultInstallEnvVar)) == "true"
 
 	return &ReconcileGitopsService{client: mgr.GetClient(), scheme: mgr.GetScheme(), disableDefaultInstall: disableDefaultInstall}
 }

--- a/pkg/controller/gitopsservice/gitopsservice_controller_test.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller_test.go
@@ -11,11 +11,13 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	"github.com/redhat-developer/gitops-operator/common"
 	pipelinesv1alpha1 "github.com/redhat-developer/gitops-operator/pkg/apis/pipelines/v1alpha1"
 	"github.com/redhat-developer/gitops-operator/pkg/controller/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -69,6 +71,45 @@ func TestImageFromEnvVariable(t *testing.T) {
 			t.Errorf("Image mismatch: got %s, want %s", got, cliImage)
 		}
 	})
+
+}
+
+func TestReconcileDisableDefault(t *testing.T) {
+
+	logf.SetLogger(logf.ZapLogger(true))
+	s := scheme.Scheme
+	addKnownTypesToScheme(s)
+
+	var err error
+
+	fakeClient := fake.NewFakeClient(newGitopsService())
+	reconciler := newReconcileGitOpsService(fakeClient, s)
+	reconciler.disableDefaultInstall = true
+
+	_, err = reconciler.Reconcile(newRequest("test", "test"))
+	assertNoError(t, err)
+
+	argoCD := &argoapp.ArgoCD{}
+
+	// ArgoCD instance SHOULD NOT created (in openshift-gitops namespace)
+	if err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: common.ArgoCDInstanceName, Namespace: serviceNamespace},
+		argoCD); err == nil || !errors.IsNotFound(err) {
+
+		t.Fatalf("ArgoCD instance should not exist in namespace, error: %v", err)
+	}
+
+	// openshift-gitops namespace SHOULD be created
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceNamespace}, &corev1.Namespace{})
+	assertNoError(t, err)
+
+	// backend Route SHOULD be created
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}, &routev1.Route{})
+	assertNoError(t, err)
+
+	// backend Deployment SHOULD be created
+	deploy := &appsv1.Deployment{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}, deploy)
+	assertNoError(t, err)
 
 }
 

--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -547,25 +547,25 @@ func validateGrantingPermissionsByLabel(t *testing.T) {
 	}
 
 	// check if the necessary roles/rolebindings are created in the target namespace
-	resourceList := []resourceList{
+	resourceList := []helper.ResourceList{
 		{
-			&rbacv1.Role{},
-			[]string{
+			Resource: &rbacv1.Role{},
+			ExpectedResources: []string{
 				argocdInstance + "-argocd-application-controller",
 				argocdInstance + "-argocd-redis-ha",
 				argocdInstance + "-argocd-server",
 			},
 		},
 		{
-			&rbacv1.RoleBinding{},
-			[]string{
+			Resource: &rbacv1.RoleBinding{},
+			ExpectedResources: []string{
 				argocdInstance + "-argocd-application-controller",
 				argocdInstance + "-argocd-redis-ha",
 				argocdInstance + "-argocd-server",
 			},
 		},
 	}
-	err = waitForResourcesByName(resourceList, targetNS, time.Second*180, t)
+	err = helper.WaitForResourcesByName(resourceList, targetNS, time.Second*180, t)
 	assertNoError(t, err)
 
 	// create an ArgoCD app and check if it can create resources in the target namespace

--- a/test/nondefaulte2e/gitops_service_nondefault_test.go
+++ b/test/nondefaulte2e/gitops_service_nondefault_test.go
@@ -1,0 +1,207 @@
+package nondefaulte2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"context"
+
+	argoapi "github.com/argoproj-labs/argocd-operator/pkg/apis"
+	argoapp "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	configv1 "github.com/openshift/api/config/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/redhat-developer/gitops-operator/common"
+	"github.com/redhat-developer/gitops-operator/pkg/apis"
+	operator "github.com/redhat-developer/gitops-operator/pkg/apis/pipelines/v1alpha1"
+	"github.com/redhat-developer/gitops-operator/test/helper"
+
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// TestGitOpsServiceNonDefaultInstall runs the operator with 'DISABLE_DEFAULT_ARGOCD_INSTANCE'
+// set to true, so that the default ArgoCD instance is not created.
+func TestGitOpsServiceNonDefaultInstall(t *testing.T) {
+
+	err := framework.AddToFrameworkScheme(apis.AddToScheme, &operator.GitopsServiceList{})
+	assertNoError(t, err)
+
+	helper.EnsureCleanSlate(t)
+	helper.DeleteNamespace("openshift-gitops", t)
+
+	t.Run("Validate Namespace-scoped install", validateNamespaceScopedInstall)
+	t.Run("Validate no default install", validateNoDefaultInstall)
+
+}
+
+// Wait up to 60 seconds to make sure the operator never creates an ArgoCD instance in openshift-gitops,
+// and verify the other openshift-gitops resources are still created.
+func validateNoDefaultInstall(t *testing.T) {
+
+	framework.AddToFrameworkScheme(argoapi.AddToScheme, &argoapp.ArgoCD{})
+	framework.AddToFrameworkScheme(configv1.AddToScheme, &configv1.ClusterVersion{})
+	framework.AddToFrameworkScheme(routev1.AddToScheme, &routev1.Route{})
+
+	f := framework.Global
+	ctx := framework.NewContext(t)
+	defer ctx.Cleanup()
+
+	existingArgoInstance := &argoapp.ArgoCD{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      common.ArgoCDInstanceName,
+			Namespace: "openshift-gitops",
+		},
+	}
+
+	// Validate that the cluster and kam resources are still created in 'openshift-gitops'
+	resourceList := []helper.ResourceList{
+		{
+			Resource: &appsv1.Deployment{},
+			ExpectedResources: []string{
+				"cluster",
+				"kam",
+			},
+		},
+		{
+			Resource: &routev1.Route{},
+			ExpectedResources: []string{
+				"cluster",
+				"kam",
+			},
+		},
+	}
+	err := helper.WaitForResourcesByName(resourceList, existingArgoInstance.Namespace, time.Second*180, t)
+	assertNoError(t, err)
+
+	// Wait 60 seconds to give operator a chance to create the ArgoCD instance
+	// (if an ArgoCD instance IS created, the test should fail, as this is not desired)
+	err = wait.Poll(5*time.Second, 1*time.Minute, func() (done bool, err error) {
+
+		err = f.Client.Get(context.Background(),
+			types.NamespacedName{Name: existingArgoInstance.Name, Namespace: existingArgoInstance.Namespace},
+			existingArgoInstance)
+
+		if err == nil {
+			err = fmt.Errorf("argoCD instance in 'openshift-gitops' should not be found")
+			return true, err
+		}
+
+		return false, nil
+
+	})
+
+	// A timeout error is expected here: an ArgoCD instance in 'openshift-gitops' should not be found in this timeframe.
+	if err != wait.ErrWaitTimeout {
+		assertNoError(t, err)
+	}
+
+}
+
+func validateNamespaceScopedInstall(t *testing.T) {
+
+	framework.AddToFrameworkScheme(argoapi.AddToScheme, &argoapp.ArgoCD{})
+	framework.AddToFrameworkScheme(configv1.AddToScheme, &configv1.ClusterVersion{})
+
+	ctx := framework.NewContext(t)
+	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: time.Second * 60, RetryInterval: time.Second * 1}
+	defer ctx.Cleanup()
+
+	f := framework.Global
+
+	// Create new namespace
+	newNamespace := &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name: helper.StandaloneArgoCDNamespace,
+		},
+	}
+	err := f.Client.Create(context.TODO(), newNamespace, cleanupOptions)
+	if !kubeerrors.IsAlreadyExists(err) {
+		assertNoError(t, err)
+		return
+	}
+
+	// Create new ArgoCD instance in the test namespace
+	name := "standalone-argocd-instance"
+	existingArgoInstance := &argoapp.ArgoCD{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: newNamespace.Name,
+		},
+	}
+	err = f.Client.Create(context.TODO(), existingArgoInstance, cleanupOptions)
+	assertNoError(t, err)
+
+	// Verify that a subset of resources are created
+	resourceList := []helper.ResourceList{
+		{
+			Resource: &appsv1.Deployment{},
+			ExpectedResources: []string{
+				name + "-dex-server",
+				name + "-redis",
+				name + "-repo-server",
+				name + "-server",
+			},
+		},
+		{
+			Resource: &corev1.ConfigMap{},
+			ExpectedResources: []string{
+				"argocd-cm",
+				"argocd-gpg-keys-cm",
+				"argocd-rbac-cm",
+				"argocd-ssh-known-hosts-cm",
+				"argocd-tls-certs-cm",
+			},
+		},
+		{
+			Resource: &corev1.ServiceAccount{},
+			ExpectedResources: []string{
+				name + "-argocd-application-controller",
+				name + "-argocd-server",
+			},
+		},
+		{
+			Resource: &rbacv1.Role{},
+			ExpectedResources: []string{
+				name + "-argocd-application-controller",
+				name + "-argocd-server",
+			},
+		},
+		{
+			Resource: &rbacv1.RoleBinding{},
+			ExpectedResources: []string{
+				name + "-argocd-application-controller",
+				name + "-argocd-server",
+			},
+		},
+		{
+			Resource: &monitoringv1.ServiceMonitor{},
+			ExpectedResources: []string{
+				name,
+				name + "-repo-server",
+				name + "-server",
+			},
+		},
+	}
+
+	err = helper.WaitForResourcesByName(resourceList, existingArgoInstance.Namespace, time.Second*180, t)
+	assertNoError(t, err)
+
+}
+
+func assertNoError(t *testing.T, err error) {
+
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/nondefaulte2e/gitops_service_nondefault_test.go
+++ b/test/nondefaulte2e/gitops_service_nondefault_test.go
@@ -107,6 +107,7 @@ func validateNoDefaultInstall(t *testing.T) {
 
 }
 
+// validateNamespaceScopedInstall ensures that we are able to create a namespace-scoped Argo CD within its own namespace
 func validateNamespaceScopedInstall(t *testing.T) {
 
 	framework.AddToFrameworkScheme(argoapi.AddToScheme, &argoapp.ArgoCD{})

--- a/test/nondefaulte2e/main_test.go
+++ b/test/nondefaulte2e/main_test.go
@@ -1,0 +1,25 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nondefaulte2e
+
+import (
+	"testing"
+
+	f "github.com/operator-framework/operator-sdk/pkg/test"
+)
+
+func TestMain(m *testing.M) {
+	f.MainEntry(m)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement


**What does this PR do / why we need it**:

This PR:
- Adds a `DISABLE_DEFAULT_ARGOCD_INSTANCE` environment variable to the GitopsService reconciler, which, if true, will prevent an ArgoCD instance from being create in the `openshift-gitops` namespace.
    - If this environment variable is set, the `openshift-gitops` still is created, as are the `cluster` and `kam` resources
    - If this environment variable is set, any existing `ArgoCD` instances in `openshift-gitops` namespace will be deleted.
- Unit test to verify the above works as expected
- E2E tests to verify the above works as expected
    - But since the operator needs to run with the above environment variable set, I created a new e2e test dir for these tests
    - Tests under `test/nondefaulte2e`
    - `run_e2e_tests.sh` will now call this tests, after the main e2e tests
- Additional refactoring:
    - Move additional utility methods to helper

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [X] Unit Test
* [X] E2E Test

**How to test changes / Special notes to the reviewer**:

How to test (manually):
```
# Ensure the gitops-operator CRDs are installed
cd (path to)/gitops-operators

make run-local
# Wait for it to create the openshift-gitops namespace, and create the default Argo CD install

# Stop the process

# Verify the resources were created
kubectl get all -n openshift-gitops
kubectl get argocds -n openshift-gitops


DISABLE_DEFAULT_ARGOCD_INSTANCE=true  make run-local

# Wait for it to delete the ArgoCD instance in openshift-gitops

# Stop the process

# Verify the ArgoCD CR is deleted:
kubectl get argocds -n openshift-gitops

# Verify the 'cluster' and 'kam' pods still exist
kubectl get all -n openshift-gitops

```

How to test automatically:
```
make test-e2e

make test
```

How to test the bundle:
```
# Build the bundle, push it, and add a CatalogSource for it
# Install via OLM UI

# Verify that the ArgoCD CR is created in openshift-gitops

# Edit the Subscription and add the following
spec:
  config:
    env:
      - name: DISABLE_DEFAULT_ARGOCD_INSTANCE
        value: 'true'

# Wait for the pod to be redeployed

# Verify that the ArgoCD CR is removed from openshift-gitops

```