### PR TITLE
feat: Do not install RHSSO OOTB for default Argo CD instance

### DIFF
--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -88,9 +88,6 @@ metadata:
                   "memory": "128Mi"
                 }
               }                
-            },
-            "sso": {
-              "provider": "keycloak"
             }
           }
         }

--- a/pkg/controller/argocd/argocd.go
+++ b/pkg/controller/argocd/argocd.go
@@ -169,7 +169,6 @@ func NewCR(name, ns string) (*argoapp.ArgoCD, error) {
 			Redis:          getArgoRedisSpec(),
 			Repo:           getArgoRepoServerSpec(),
 			Server:         getArgoServerSpec(),
-			SSO:            &argoapp.ArgoCDSSOSpec{Provider: "keycloak"},
 
 			ResourceExclusions: string(b),
 		},

--- a/pkg/controller/argocd/argocd_test.go
+++ b/pkg/controller/argocd/argocd_test.go
@@ -3,7 +3,6 @@ package argocd
 import (
 	"testing"
 
-	argoapp "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	"gotest.tools/assert"
 	v1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
@@ -107,5 +106,4 @@ func TestArgoCD(t *testing.T) {
 		},
 	}
 	assert.DeepEqual(t, testArgoCD.Spec.Server.Resources, testServerResources)
-	assert.DeepEqual(t, testArgoCD.Spec.SSO, &argoapp.ArgoCDSSOSpec{Provider: "keycloak"})
 }

--- a/test/e2e/rhsso_test.go
+++ b/test/e2e/rhsso_test.go
@@ -56,29 +56,18 @@ func verifyRHSSOInstallation(t *testing.T) {
 	namespace, err := gitopsservice.GetBackendNamespace(f.Client.Client)
 	assertNoError(t, err)
 
-	// Update verifyTLS=false in the SSO configuration of ArgoCD resource.
-	argocd := &argoapp.ArgoCD{}
-	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: argoCDInstanceName, Namespace: namespace}, argocd)
-	assertNoError(t, err)
-
-	argocd.Spec.SSO.VerifyTLS = &insecure
-	err = f.Client.Update(context.TODO(), argocd)
-
-	// Assumption that an attempt to reconcile would have happened within 5 seconds.
-	time.Sleep(5 * time.Second)
-
 	// Verify the creation of template instance.
 	tInstance := &templatev1.TemplateInstance{}
 	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: defaultTemplateIdentifier, Namespace: namespace}, tInstance)
 	assertNoError(t, err)
 
-	// Verify the keycloak Deployment and availble replicas.
+	// Verify the keycloak Deployment and available replicas.
 	dc := &appsv1.DeploymentConfig{}
 	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: defaultKeycloakIdentifier, Namespace: namespace}, dc)
 	assertNoError(t, err)
 	assert.Assert(t, dc.Status.AvailableReplicas == 1)
 
-	// Verify the keycloak Deployment and availble replicas.
+	// Verify the keycloak Deployment and available replicas.
 	svc := &corev1.Service{}
 	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: defaultKeycloakIdentifier, Namespace: namespace}, svc)
 	assertNoError(t, err)


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
Do not install RHSSO OOTB for default Argo CD instance. This PR merely removes the code that installs RHSSO OOTB for default Argo CD instance.

**Have you updated the necessary documentation?**
* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.
Internal docs updated, This document will be used as reference to update the OpenShift Docs.
https://docs.google.com/document/d/1vyWQIumR8dFAKf_DNuNkLXdMP4pgLLM2nEpe_CPSyXI/edit?ts=60d9c4c2#

**Which issue(s) this PR fixes**:
#159

Fixes #?
#159

**Test acceptance criteria**:

* [x] Unit Test
* [x] E2E Test

**How to test changes / Special notes to the reviewer**:
1. Run the operator locally using `operator-sdk run local`
2. Run `oc get pods -n openshift-gitops` to ensure that no Keycloak pods are deployed.