### PR TITLE
Improve helper namespace deletion

### DIFF
--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -69,7 +69,8 @@ func TestGitOpsService(t *testing.T) {
 	err := framework.AddToFrameworkScheme(apis.AddToScheme, &operator.GitopsServiceList{})
 	assertNoError(t, err)
 
-	helper.EnsureCleanSlate(t)
+	err = helper.EnsureCleanSlate(t)
+	assertNoError(t, err)
 
 	if !skipOperatorDeployment() {
 		deployOperator(t)
@@ -497,7 +498,7 @@ func validateNonDefaultArgocdNamespaceManagement(t *testing.T) {
 func validateGrantingPermissionsByLabel(t *testing.T) {
 	framework.AddToFrameworkScheme(argoapi.AddToScheme, &argoapp.ArgoCD{})
 	ctx := framework.NewContext(t)
-	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: time.Second * 60, RetryInterval: time.Second * 1}
+	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: time.Second * 120, RetryInterval: time.Second * 1}
 	defer ctx.Cleanup()
 	f := framework.Global
 

--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -588,7 +588,7 @@ func validateGrantingPermissionsByLabel(t *testing.T) {
 	err = cmd.Run()
 	assertNoError(t, err)
 
-	err = wait.Poll(time.Second*1, time.Second*180, func() (bool, error) {
+	err = wait.Poll(time.Second*5, time.Minute*10, func() (bool, error) {
 		if err := helper.ApplicationHealthStatus("nginx", sourceNS); err != nil {
 			t.Log(err)
 			return false, nil

--- a/test/helper/application_status.go
+++ b/test/helper/application_status.go
@@ -16,6 +16,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argoapp "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 )
 
 // ProjectExists return true if the AppProject exists in the namespace,
@@ -128,16 +131,16 @@ const (
 )
 
 // ensureCleanSlate runs before the tests, to ensure that the cluster is in the expected pre-test state
-func EnsureCleanSlate(t *testing.T) {
+func EnsureCleanSlate(t *testing.T) error {
 
 	t.Log("Running ensureCleanSlate")
 
-	DeleteNamespace(StandaloneArgoCDNamespace, t)
+	return DeleteNamespace(StandaloneArgoCDNamespace, t)
 
 }
 
 // DeleteNamespace deletes a namespace, and waits for deletion to complete.
-func DeleteNamespace(nsToDelete string, t *testing.T) {
+func DeleteNamespace(nsToDelete string, t *testing.T) error {
 	f := framework.Global
 
 	// Delete the standaloneArgoCDNamespace namespace and wait for it to not exist
@@ -146,9 +149,35 @@ func DeleteNamespace(nsToDelete string, t *testing.T) {
 			Name: nsToDelete,
 		},
 	}
-	f.Client.Delete(context.Background(), nsTarget)
+	err := f.Client.Delete(context.Background(), nsTarget)
+	if err != nil {
+		if kubeerrors.IsNotFound(err) {
+			// Success: the namespace doesn't exist.
+			return nil
+		}
+		return fmt.Errorf("unable to delete namespace %v", err)
+	}
 
-	err := wait.Poll(1*time.Second, 90*time.Second, func() (bool, error) {
+	err = wait.Poll(1*time.Second, 2*time.Minute, func() (bool, error) {
+
+		// Patch all the ArgoCDs in the NS, to remove the finalizer (so the namespace can be deleted)
+		var list argoapp.ArgoCDList
+
+		opts := &client.ListOptions{
+			Namespace: nsToDelete,
+		}
+		if err = f.Client.List(context.Background(), &list, opts); err != nil {
+			t.Errorf("Unable to list ArgoCDs %v", err)
+			// Report failure, but still continue
+		}
+		for _, item := range list.Items {
+			item.Finalizers = []string{}
+			if err := f.Client.Update(context.Background(), &item); err != nil {
+				t.Errorf("Unable to update ArgoCD application finalizer on '%s': %v", item.Name, err)
+				// Report failure, but still continue
+			}
+		}
+
 		if err := f.Client.Get(context.Background(), types.NamespacedName{Name: nsTarget.Name},
 			nsTarget); kubeerrors.IsNotFound(err) {
 			t.Logf("Namespace '%s' no longer exists", nsTarget.Name)
@@ -161,8 +190,9 @@ func DeleteNamespace(nsToDelete string, t *testing.T) {
 	})
 
 	if err != nil {
-		t.Error(fmt.Errorf("namespace '%s' was not deleted: %v", nsToDelete, err))
-		t.Fail()
+		return fmt.Errorf("namespace '%s' was not deleted: %v", nsToDelete, err)
 	}
+
+	return nil
 
 }

--- a/test/helper/application_status.go
+++ b/test/helper/application_status.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	argoapi "github.com/argoproj-labs/argocd-operator/pkg/apis"
+	argoapp "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	corev1 "k8s.io/api/core/v1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -17,8 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	argoapp "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 )
 
 // ProjectExists return true if the AppProject exists in the namespace,
@@ -142,6 +142,10 @@ func EnsureCleanSlate(t *testing.T) error {
 // DeleteNamespace deletes a namespace, and waits for deletion to complete.
 func DeleteNamespace(nsToDelete string, t *testing.T) error {
 	f := framework.Global
+
+	if err := framework.AddToFrameworkScheme(argoapi.AddToScheme, &argoapp.ArgoCD{}); err != nil {
+		return err
+	}
 
 	// Delete the standaloneArgoCDNamespace namespace and wait for it to not exist
 	nsTarget := &corev1.Namespace{

--- a/test/nondefaulte2e/gitops_service_nondefault_test.go
+++ b/test/nondefaulte2e/gitops_service_nondefault_test.go
@@ -36,8 +36,11 @@ func TestGitOpsServiceNonDefaultInstall(t *testing.T) {
 	err := framework.AddToFrameworkScheme(apis.AddToScheme, &operator.GitopsServiceList{})
 	assertNoError(t, err)
 
-	helper.EnsureCleanSlate(t)
-	helper.DeleteNamespace("openshift-gitops", t)
+	err = helper.EnsureCleanSlate(t)
+	assertNoError(t, err)
+
+	err = helper.DeleteNamespace("openshift-gitops", t)
+	assertNoError(t, err)
 
 	t.Run("Validate Namespace-scoped install", validateNamespaceScopedInstall)
 	t.Run("Validate no default install", validateNoDefaultInstall)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What does this PR do / why we need it**:

Improve the helper namespace deletion logic I added in a previous PR

It is possible for the `openshift-gitops` namespace to still have an active `ArgoCD` instance, at the end of the previous E2E test, which blocks deletion of the `openshift-gitops` namespace (due to the ArgoCD finalizer). 

Which looks like this:
```
I0709 12:50:50.199629   10291 request.go:621] Throttling request took 1.13356149s, request: GET:https://api.ci-op-dpljqn95-02c74.origin-ci-int-aws.dev.rhcloud.com:6443/apis/build.openshift.io/v1?timeout=32s
I0709 12:51:00.397791   10291 request.go:621] Throttling request took 11.331586527s, request: GET:https://api.ci-op-dpljqn95-02c74.origin-ci-int-aws.dev.rhcloud.com:6443/apis/coordination.k8s.io/v1beta1?timeout=32s
    application_status.go:133: Running ensureCleanSlate
    application_status.go:154: Namespace 'gitops-standalone-test' no longer exists
    application_status.go:158: Namespace 'openshift-gitops' still exists
    application_status.go:158: Namespace 'openshift-gitops' still exists
    application_status.go:158: Namespace 'openshift-gitops' still exists
    application_status.go:158: Namespace 'openshift-gitops' still exists
    application_status.go:158: Namespace 'openshift-gitops' still exists
    application_status.go:158: Namespace 'openshift-gitops' still exists
    application_status.go:158: Namespace 'openshift-gitops' still exists
    application_status.go:158: Namespace 'openshift-gitops' still exists
    (until it expires)
```

This PR patches the ArgoCD (in the namesapce) to remove the finalizer, as part of the namespace deletion.

**How to test changes / Special notes to the reviewer**:

