### PR TITLE
sync argocd-operator fix: Remove admin permissions for ArgoCD instanc…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.16
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210708113628-c85d1875315f
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210709182135-1e7bef36ebe7
 	github.com/bugsnag/bugsnag-go v1.5.3 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/coreos/prometheus-operator v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210708113628-c85d1875315f h1:JxVOUbYfn7DcFyy4dcIfvUTAyAEqAoUJsRFCuZvDfUE=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210708113628-c85d1875315f/go.mod h1:b6t078lHz63c2mTeyJuDXwceCbAu9GJxeWlDn7XDj7w=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210709182135-1e7bef36ebe7 h1:+Y7AX9CJ8Vqp2P8gG+AnDVK/gsRgcIWVqlpnkAw3NKM=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210709182135-1e7bef36ebe7/go.mod h1:b6t078lHz63c2mTeyJuDXwceCbAu9GJxeWlDn7XDj7w=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
…e when namespace label is removed #353

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
/kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

Pick up this fix from upstream argocd operator. 
https://github.com/argoproj-labs/argocd-operator/pull/353


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:

    Deploy the latest Operator.
    Create an ArgoCD instance.
    Create a new namespace with the label argocd.argoproj.io/managed-by: <argocd-instance-namespace>
    Make sure the ArgoCD instance has the permissions to manage the namespace by deploying an application or verifying if the correct roles/role_bindings were created.
    Manually remove the label argocd.argoproj.io/managed-by: <argocd-instance-namespace> from the namespace.
    Make sure the created roles/rolebindings were deleted.
    Commit some change to the github repo and trigger the sync. It should fail.


