### PR TITLE
bug: remove additional operator-backed items in the developer catalog

### DIFF
--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -99,21 +99,6 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: GitOpsService configures a web service for rendering the GitOps UI on OpenShift
-      kind: GitopsService
-      name: gitopsservices.pipelines.openshift.io
-      version: v1alpha1
-      displayName: GitOps Service
-    - kind: Application
-      name: applications.argoproj.io
-      version: v1alpha1
-      displayName: Application
-      description: An Application is a group of Kubernetes resources as defined by a manifest.
-    - kind: AppProject
-      name: appprojects.argoproj.io
-      version: v1alpha1
-      displayName: AppProject
-      description: An AppProject is a logical grouping of Argo CD Applications.
     - kind: ArgoCD
       name: argocds.argoproj.io
       version: v1alpha1
@@ -165,10 +150,6 @@ spec:
       - kind: StatefulSet
         name: ''
         version: v1
-    - kind: ApplicationSet
-      name: applicationsets.argoproj.io
-      version: v1alpha1
-      description: ApplicationSet is the representation of an ApplicationSet controller deployment.
   description: |
     Red Hat OpenShift GitOps is a declarative continuous delivery platform based on [Argo CD](https://argoproj.github.io/argo-cd/). It enables teams to adopt GitOps principles for managing cluster configurations and automating secure and repeatable application delivery across hybrid multi-cluster Kubernetes environments. Following GitOps and infrastructure as code principles, you can store the configuration of clusters and applications in Git repositories and use Git workflows to roll them out to the target clusters.
 


### PR DESCRIPTION

**What type of PR is this?**
 /kind bug

**What does this PR do / why we need it**:
Only the ArgoCD CRD should be displayed as an operator-backed item in the developer catalog in Dev Console.

![image](https://user-images.githubusercontent.com/46771830/125209001-f382b000-e263-11eb-9be1-1247a291d647.png)


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-933 

Fixes #? 

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:

1. Create a custom index image by following instruction in https://github.com/redhat-developer/gitops-operator#re-build-and-deploy
2. Make custom operator available in the operator hub https://github.com/redhat-developer/gitops-operator#making-the-operator-available-on-the-in-cluster-operatorhub 
3. Install the custom operator
4. Upon successful installation, check the developer catalog and search `gitops` . (**Note:** Only Argo CD CRD should be present.)
