### PR TITLE
Increase timeout for a flaky e2e test

### DIFF
--- a/test/e2e/gitops_service_test.go
+++ b/test/e2e/gitops_service_test.go
@@ -587,7 +587,7 @@ func validateGrantingPermissionsByLabel(t *testing.T) {
 	err = cmd.Run()
 	assertNoError(t, err)
 
-	err = wait.Poll(time.Second*1, time.Second*180, func() (bool, error) {
+	err = wait.Poll(time.Second*1, time.Minute*5, func() (bool, error) {
 		if err := helper.ApplicationHealthStatus("nginx", sourceNS); err != nil {
 			t.Log(err)
 			return false, nil


### PR DESCRIPTION
**What type of PR is this?**
> /kind failing-test


**What does this PR do / why we need it**:
e2e test `validateGrantingPermissionsByLabel` is flaky because of a timeout issue. This PR increases the timeout duration

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
