### PR TITLE
fix: Lower default CPU resource requests for better scheduling

### DIFF
--- a/pkg/controller/argocd/argocd.go
+++ b/pkg/controller/argocd/argocd.go
@@ -21,7 +21,7 @@ func getArgoApplicationSetSpec() *argoapp.ArgoCDApplicationSet {
 		Resources: &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
 				v1.ResourceMemory: resourcev1.MustParse("512Mi"),
-				v1.ResourceCPU:    resourcev1.MustParse("1000m"),
+				v1.ResourceCPU:    resourcev1.MustParse("250m"),
 			},
 			Limits: v1.ResourceList{
 				v1.ResourceMemory: resourcev1.MustParse("1024Mi"),
@@ -36,7 +36,7 @@ func getArgoControllerSpec() argoapp.ArgoCDApplicationControllerSpec {
 		Resources: &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
 				v1.ResourceMemory: resourcev1.MustParse("1024Mi"),
-				v1.ResourceCPU:    resourcev1.MustParse("1000m"),
+				v1.ResourceCPU:    resourcev1.MustParse("250m"),
 			},
 			Limits: v1.ResourceList{
 				v1.ResourceMemory: resourcev1.MustParse("2048Mi"),
@@ -111,7 +111,7 @@ func getArgoRepoServerSpec() argoapp.ArgoCDRepoSpec {
 		Resources: &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
 				v1.ResourceMemory: resourcev1.MustParse("256Mi"),
-				v1.ResourceCPU:    resourcev1.MustParse("500m"),
+				v1.ResourceCPU:    resourcev1.MustParse("250m"),
 			},
 			Limits: v1.ResourceList{
 				v1.ResourceMemory: resourcev1.MustParse("512Mi"),

--- a/pkg/controller/argocd/argocd_test.go
+++ b/pkg/controller/argocd/argocd_test.go
@@ -14,7 +14,7 @@ func TestArgoCD(t *testing.T) {
 	testApplicationSetResources := &v1.ResourceRequirements{
 		Requests: v1.ResourceList{
 			v1.ResourceMemory: resourcev1.MustParse("512Mi"),
-			v1.ResourceCPU:    resourcev1.MustParse("1000m"),
+			v1.ResourceCPU:    resourcev1.MustParse("250m"),
 		},
 		Limits: v1.ResourceList{
 			v1.ResourceMemory: resourcev1.MustParse("1024Mi"),
@@ -26,7 +26,7 @@ func TestArgoCD(t *testing.T) {
 	testControllerResources := &v1.ResourceRequirements{
 		Requests: v1.ResourceList{
 			v1.ResourceMemory: resourcev1.MustParse("1024Mi"),
-			v1.ResourceCPU:    resourcev1.MustParse("1000m"),
+			v1.ResourceCPU:    resourcev1.MustParse("250m"),
 		},
 		Limits: v1.ResourceList{
 			v1.ResourceMemory: resourcev1.MustParse("2048Mi"),
@@ -86,7 +86,7 @@ func TestArgoCD(t *testing.T) {
 	testRepoResources := &v1.ResourceRequirements{
 		Requests: v1.ResourceList{
 			v1.ResourceMemory: resourcev1.MustParse("256Mi"),
-			v1.ResourceCPU:    resourcev1.MustParse("500m"),
+			v1.ResourceCPU:    resourcev1.MustParse("250m"),
 		},
 		Limits: v1.ResourceList{
 			v1.ResourceMemory: resourcev1.MustParse("512Mi"),


### PR DESCRIPTION
Signed-off-by: jannfis <jann@mistrust.net>

**What type of PR is this?**

/kind bug


**What does this PR do / why we need it**:

Set the default resource requests to a more sane value to allow scheduling on small and/or loaded clusters. Defaults can still be overriden by the user.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #? https://issues.redhat.com/browse/GITOPS-1171

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:

* Create new ArgoCD CR instance
* Check created resources (deployment of argocd-repo-server and application set controller as well as statefulset of application controller) for having CPU requests set to 250m