### PR TITLE
fix: Argo CD installation from operator console fails as HA.Enabled is not set by default

### DIFF
--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -39,6 +39,7 @@ metadata:
               }                
             },
             "ha": {
+              "enabled": false
               "resources": {
                 "limits": {
                   "cpu": "500m",

--- a/pkg/controller/argocd/argocd.go
+++ b/pkg/controller/argocd/argocd.go
@@ -76,8 +76,9 @@ func getArgoGrafanaSpec() argoapp.ArgoCDGrafanaSpec {
 	}
 }
 
-func getArgoHAProxySpec() argoapp.ArgoCDHASpec {
+func getArgoHASpec() argoapp.ArgoCDHASpec {
 	return argoapp.ArgoCDHASpec{
+		Enabled: false,
 		Resources: &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
 				v1.ResourceMemory: resourcev1.MustParse("128Mi"),
@@ -165,7 +166,7 @@ func NewCR(name, ns string) (*argoapp.ArgoCD, error) {
 			Controller:     getArgoControllerSpec(),
 			Dex:            getArgoDexSpec(),
 			Grafana:        getArgoGrafanaSpec(),
-			HA:             getArgoHAProxySpec(),
+			HA:             getArgoHASpec(),
 			Redis:          getArgoRedisSpec(),
 			Repo:           getArgoRepoServerSpec(),
 			Server:         getArgoServerSpec(),

--- a/pkg/controller/argocd/argocd_test.go
+++ b/pkg/controller/argocd/argocd_test.go
@@ -59,7 +59,7 @@ func TestArgoCD(t *testing.T) {
 	}
 	assert.DeepEqual(t, testArgoCD.Spec.Grafana.Resources, testGrafanaResources)
 
-	testHAProxyResources := &v1.ResourceRequirements{
+	testHAResources := &v1.ResourceRequirements{
 		Requests: v1.ResourceList{
 			v1.ResourceMemory: resourcev1.MustParse("128Mi"),
 			v1.ResourceCPU:    resourcev1.MustParse("250m"),
@@ -69,7 +69,8 @@ func TestArgoCD(t *testing.T) {
 			v1.ResourceCPU:    resourcev1.MustParse("500m"),
 		},
 	}
-	assert.DeepEqual(t, testArgoCD.Spec.HA.Resources, testHAProxyResources)
+	assert.DeepEqual(t, testArgoCD.Spec.HA.Resources, testHAResources)
+	assert.Equal(t, testArgoCD.Spec.HA.Enabled, false)
 
 	testRedisResources := &v1.ResourceRequirements{
 		Requests: v1.ResourceList{


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
Argo CD installation from operator console fails as HA.Enabled is not set by default
![image-2021-07-13-09-25-28-590](https://user-images.githubusercontent.com/43399466/125463175-e1da6fb5-23fa-4c3e-8fb4-28c76ebdafe3.png)

**Have you updated the necessary documentation?**
NA

**Test acceptance criteria**:
* [x] Unit Test


**How to test changes / Special notes to the reviewer**:
Created a new Catalog Source to test this changes.
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: gitops-service-source-av
  namespace: openshift-marketplace
spec:
  displayName: 'Gitops Service by Red Hat'
  image: 'quay.io/aveerama/gitops-backend-operator-index:v0.0.4'
  publisher: 'Red Hat Developer'
  sourceType: grpc
```
