### PR TITLE
Pull in fixes from argocd operator:  #362, #366

### DIFF
--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -447,6 +447,23 @@ spec:
                 description: KustomizeBuildOptions is used to specify build options/parameters
                   to use with `kustomize build`.
                 type: string
+              kustomizeVersions:
+                description: KustomizeVersions is a listing of configured versions
+                  of Kustomize to be made available within ArgoCD.
+                items:
+                  description: KustomizeVersionSpec is used to specify information
+                    about a kustomize version to be used within ArgoCD.
+                  properties:
+                    path:
+                      description: Path is the path to a configured kustomize version
+                        on the filesystem of your repo server.
+                      type: string
+                    version:
+                      description: Version is a configured kustomize version in the
+                        format of vX.Y.Z
+                      type: string
+                  type: object
+                type: array
               oidcConfig:
                 description: OIDCConfig is the OIDC configuration as an alternative
                   to dex.
@@ -1021,6 +1038,33 @@ spec:
                     description: Provider installs and configures the given SSO Provider
                       with Argo CD.
                     type: string
+                  resources:
+                    description: Resources defines the Compute Resources required
+                      by the container for SSO.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
                   verifyTLS:
                     description: VerifyTLS set to false disables strict TLS validation.
                     type: boolean

--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
     containerImage: quay.io/redhat-developer/gitops-backend-operator:v0.0.3
     description: Enables teams to adopt GitOps principles for managing cluster configurations and application delivery across hybrid multi-cluster Kubernetes environments.
     createdAt: "2020-06-25T19:44:21Z"
+    operators.operatorframework.io/internal-objects: '["gitopsservices.pipelines.openshift.io"]'
     alm-examples: |-
       [
         {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.16
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210712220925-3c945c648bd0
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210713194200-248bd562c502
 	github.com/bugsnag/bugsnag-go v1.5.3 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/coreos/prometheus-operator v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210712220925-3c945c648bd0 h1:8/qViIQ17yk2m1HDVi9vHkV+7wpz9tW0g5qOZG+ukow=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210712220925-3c945c648bd0/go.mod h1:b6t078lHz63c2mTeyJuDXwceCbAu9GJxeWlDn7XDj7w=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210713194200-248bd562c502 h1:k2TZ6ZNXwsnbFSuZjAErJWylcheDqPWtBR0sfjKfzHc=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210713194200-248bd562c502/go.mod h1:b6t078lHz63c2mTeyJuDXwceCbAu9GJxeWlDn7XDj7w=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
* https://github.com/argoproj-labs/argocd-operator/pull/362  feat: Add the ability to specify additional kustomize versions within the ArgoCD ConfigMap #362
* https://github.com/argoproj-labs/argocd-operator/pull/366  fix: Allow ArgoCD CR to override keycloak resource request/limit defaults #366

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug
> /kind cleanup
> /kind failing-test
/kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
Please refer to upstream PRs.
* https://github.com/argoproj-labs/argocd-operator/pull/362  feat: Add the ability to specify additional kustomize versions within the ArgoCD ConfigMap #362
* https://github.com/argoproj-labs/argocd-operator/pull/366  fix: Allow ArgoCD CR to override keycloak resource request/limit defaults #366
