### PR TITLE
fix: Align default resource limits with instances created in DevConsole

### DIFF
--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
                   "memory": "2048Mi"
                 },
                 "requests": {
-                  "cpu": "1000m",
+                  "cpu": "250m",
                   "memory": "1024Mi"
                 }
               }                
@@ -71,7 +71,7 @@ metadata:
                   "memory": "512Mi"
                 },
                 "requests": {
-                  "cpu": "500m",
+                  "cpu": "250m",
                   "memory": "256Mi"
                 }
               }                

--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -40,7 +40,7 @@ metadata:
               }                
             },
             "ha": {
-              "enabled": false
+              "enabled": false,
               "resources": {
                 "limits": {
                   "cpu": "500m",


### PR DESCRIPTION
Signed-off-by: jannfis <jann@mistrust.net>

**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

PR #167 set lower default resource limits for the workloads installed through an ArgoCD CR. When created by DevConsole, default values are taken from the CSV, so those instances are using the old defaults. This change aligns the values.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:

* Create `ArgoCD` instance via DevConsole
* Take a look at resource requests for application controller and repo server workloads
