### PR TITLE
fix: Updated RHSSO failing tests for make target "test-e2e-on-operator"

### DIFF
--- a/test/e2e/rhsso_test.go
+++ b/test/e2e/rhsso_test.go
@@ -25,7 +25,6 @@ import (
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	templatev1 "github.com/openshift/api/template/v1"
-	"github.com/redhat-developer/gitops-operator/pkg/controller/gitopsservice"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -53,12 +52,11 @@ func verifyRHSSOInstallation(t *testing.T) {
 	defer ctx.Cleanup()
 
 	f := framework.Global
-	namespace, err := gitopsservice.GetBackendNamespace(f.Client.Client)
-	assertNoError(t, err)
+	namespace := argoCDNamespace
 
 	// Verify the creation of template instance.
 	tInstance := &templatev1.TemplateInstance{}
-	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: defaultTemplateIdentifier, Namespace: namespace}, tInstance)
+	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: defaultTemplateIdentifier, Namespace: namespace}, tInstance)
 	assertNoError(t, err)
 
 	// Verify the keycloak Deployment and available replicas.
@@ -90,12 +88,11 @@ func verifyRHSSOConfiguration(t *testing.T) {
 	defer ctx.Cleanup()
 
 	f := framework.Global
-	namespace, err := gitopsservice.GetBackendNamespace(f.Client.Client)
-	assertNoError(t, err)
+	namespace := argoCDNamespace
 
 	// Verify OIDC Configuration is created.
 	cm := &corev1.ConfigMap{}
-	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: argoCDConfigMapName, Namespace: namespace}, cm)
+	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: argoCDConfigMapName, Namespace: namespace}, cm)
 	assertNoError(t, err)
 	assert.Assert(t, cm.Data[common.ArgoCDKeyOIDCConfig] != "")
 
@@ -169,11 +166,10 @@ func verifyRHSSOUnInstallation(t *testing.T) {
 	defer ctx.Cleanup()
 
 	f := framework.Global
-	namespace, err := gitopsservice.GetBackendNamespace(f.Client.Client)
-	assertNoError(t, err)
+	namespace := argoCDNamespace
 
 	argocd := &argoapp.ArgoCD{}
-	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: argoCDInstanceName, Namespace: namespace}, argocd)
+	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: argoCDInstanceName, Namespace: namespace}, argocd)
 	assertNoError(t, err)
 
 	// Remove SSO feild from ArgoCD CR.


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
fix: Updated RHSSO failing tests for make target "test-e2e-on-operator"

```
rhsso_test.go:57: no kind is registered for the type v1.ClusterVersion in scheme "github.com/operator-framework/operator-sdk/pkg/test/framework.go:130"
```

**Have you updated the necessary documentation?**
NA

**Test acceptance criteria**:
* [] Unit Test
* [x] E2E Test

**How to test changes / Special notes to the reviewer**:
Run the operator either locally or using operator hub.
Patch the Argo CD CR to enable Login with Keycloak.
```
spec:
   sso:
     provider: keycloak
```
Wait for the operator to reconcile keycloak changes. RHSSO may take a couple of minutes to start.
Run the make target `make test-e2e-on-operator` and note that you dont see the below error.

```
rhsso_test.go:57: no kind is registered for the type v1.ClusterVersion in scheme "github.com/operator-framework/operator-sdk/pkg/test/framework.go:130"
```
