### PR TITLE
Pull in fix: delete existing RBACs when namespace label is updated (#…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.16
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210715041124-bb75775953f8
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210716071134-bed2f41a3dac
 	github.com/bugsnag/bugsnag-go v1.5.3 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/coreos/prometheus-operator v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210715041124-bb75775953f8 h1:9CS3YjkcmKsIV3qXH9RKmO/pay7kKEE1NvU/6xGjegw=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210715041124-bb75775953f8/go.mod h1:b6t078lHz63c2mTeyJuDXwceCbAu9GJxeWlDn7XDj7w=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210716071134-bed2f41a3dac h1:hymQehsHZdvRGo7VnWO1l7zQLFBYVHLKj0LAvMSM0Pk=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210716071134-bed2f41a3dac/go.mod h1:b6t078lHz63c2mTeyJuDXwceCbAu9GJxeWlDn7XDj7w=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
…368)

**What type of PR is this?**
> /kind bug


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
- Deploy the latest Operator.
- Deploy two argocd instances in the namespace foo1 and foo2.
- Create a namesapce bar with the label argocd-argoproj.io/managed-by: foo1.
- Make sure argocd instance in foo1 can manage the resources in bar namespace.
- Update the namespace label value from foo1 -> foo2
- Make sure RBACs for foo2 are created and RBACs for foo1 gets deleted.