### PR TITLE
fix: Pull in #372 from argocd-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.16
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210716071134-bed2f41a3dac
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210716115333-5b13ae4379ba
 	github.com/bugsnag/bugsnag-go v1.5.3 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/coreos/prometheus-operator v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210716071134-bed2f41a3dac h1:hymQehsHZdvRGo7VnWO1l7zQLFBYVHLKj0LAvMSM0Pk=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210716071134-bed2f41a3dac/go.mod h1:b6t078lHz63c2mTeyJuDXwceCbAu9GJxeWlDn7XDj7w=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210716115333-5b13ae4379ba h1:eIJUhedAwrlQdVYbdb+C7pd2Zo/cxp0fuPItcn8My14=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210716115333-5b13ae4379ba/go.mod h1:b6t078lHz63c2mTeyJuDXwceCbAu9GJxeWlDn7XDj7w=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
Pull in #372 from argocd-operator

I have observed an unexpected crash of the operator when the operator is trying to reconcile an empty Argo CD configmap.

I can reproduce this issue by creating an empty Argo CD configmap (argocd-cm) in a namespace and then creating an Argo CD CR. Noticed that operator crashed while reconciling the empty configmap.

Error:
```
goroutine 1873 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1769d40, 0x1b43340)
/remote-source/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.18.3/pkg/util/runtime/runtime.go:74 +0xa6
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
/remote-source/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.18.3/pkg/util/runtime/runtime.go:48 +0x86
panic(0x1769d40, 0x1b43340)
/usr/lib/golang/src/runtime/panic.go:965 +0x1b9
github.com/argoproj-labs/argocd-operator/pkg/controller/argocd.(*ReconcileArgoCD).reconcileExistingArgoConfigMap(0xc0008f4000, 0xc008c18780, 0xc00850e000, 0x0, 0x0)
/remote-source/deps/gomod/pkg/mod/github.com/argoproj-labs/argocd-operator@v0.0.16-0.20210715041124-bb75775953f8/pkg/controller/argocd/configmap.go:420 +0x53e
github.com/argoproj-labs/argocd-operator/pkg/controller/argocd.(*ReconcileArgoCD).reconcileArgoConfigMap(0xc0008f4000, 0xc00850e000, 0x0, 0x0)
/remote-source/deps/gomod/pkg/mod/github.com/argoproj-labs/argocd-operator@v0.0.16-0.20210715041124-bb75775953f8/pkg/controller/argocd/configmap.go:312 +0x11af
github.com/argoproj-labs/argocd-operator/pkg/controller/argocd.(*ReconcileArgoCD).reconcileConfigMaps(0xc0008f4000, 0xc00850e000, 0x17, 0x0)
/remote-source/deps/gomod/pkg/mod/github.com/argoproj-labs/argocd-operator@v0.0.16-0.20210715041124-bb75775953f8/pkg/controller/argocd/configmap.go:250 +0x39
github.com/argoproj-labs/argocd-operator/pkg/controller/argocd.(*ReconcileArgoCD).reconcileResources(0xc0008f4000, 0xc00850e000, 0xc000042068, 0xc000ec8680)
runtime@v0.6.0/pkg/internal/controller/controller.go:193 +0x32d
panic: assignment to entry in nil map [recovered]
panic: assignment to entry in nil map
```

**Have you updated the necessary documentation?**
NA

**How to test changes / Special notes to the reviewer**:
Create a empty configmap with name argocd-cm.
Run the operator.
Create a Argo CD CR to crete Argo CD instance.
or

Run the operator locally operator-sdk run local
Create Argo CD CR to create Argo CD instance.
Wait for the operator to create all the workloads.
remove the data section of argocd-cm configmap.
