### PR TITLE
fix: set resource requirements to containers incase of the operator upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.16
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210716115333-5b13ae4379ba
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210722130040-5406a672631a
 	github.com/bugsnag/bugsnag-go v1.5.3 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/coreos/prometheus-operator v0.40.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.16
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210722130040-5406a672631a
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210722160114-5fe7ef0c459f
 	github.com/bugsnag/bugsnag-go v1.5.3 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/coreos/prometheus-operator v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210722130040-5406a672631a h1:9woHBBx9/p9rirvRVZbo3fgAAtG0FF6D7/iNjMoEQ0o=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210722130040-5406a672631a/go.mod h1:b6t078lHz63c2mTeyJuDXwceCbAu9GJxeWlDn7XDj7w=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210722160114-5fe7ef0c459f h1:TxQfGOnlkbQWFUAH7RGMTnKSYCoKC9fetcEVY1TvcFw=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210722160114-5fe7ef0c459f/go.mod h1:b6t078lHz63c2mTeyJuDXwceCbAu9GJxeWlDn7XDj7w=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210716115333-5b13ae4379ba h1:eIJUhedAwrlQdVYbdb+C7pd2Zo/cxp0fuPItcn8My14=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210716115333-5b13ae4379ba/go.mod h1:b6t078lHz63c2mTeyJuDXwceCbAu9GJxeWlDn7XDj7w=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210722130040-5406a672631a h1:9woHBBx9/p9rirvRVZbo3fgAAtG0FF6D7/iNjMoEQ0o=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210722130040-5406a672631a/go.mod h1:b6t078lHz63c2mTeyJuDXwceCbAu9GJxeWlDn7XDj7w=
 github.com/argoproj/argo-cd v1.5.8 h1:fmJP50W48OVGeDMZlbYBG0SMHY50wsEETvOx8IhHi/Q=
 github.com/argoproj/argo-cd v1.5.8/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/pkg/controller/gitopsservice/gitopsservice_controller.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller.go
@@ -368,8 +368,59 @@ func (r *ReconcileGitopsService) reconcileDefaultArgoCDInstance(instance *pipeli
 		} else {
 			return reconcile.Result{}, err
 		}
-	}
+	} else {
+		changed := false
 
+		if existingArgoCD.Spec.ApplicationSet != nil {
+			if existingArgoCD.Spec.ApplicationSet.Resources == nil {
+				existingArgoCD.Spec.ApplicationSet.Resources = defaultArgoCDInstance.Spec.ApplicationSet.Resources
+				changed = true
+			}
+		}
+
+		if existingArgoCD.Spec.Controller.Resources == nil {
+			existingArgoCD.Spec.Controller.Resources = defaultArgoCDInstance.Spec.Controller.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.Dex.Resources == nil {
+			existingArgoCD.Spec.Dex.Resources = defaultArgoCDInstance.Spec.Dex.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.Grafana.Resources == nil {
+			existingArgoCD.Spec.Grafana.Resources = defaultArgoCDInstance.Spec.Grafana.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.HA.Resources == nil {
+			existingArgoCD.Spec.HA.Resources = defaultArgoCDInstance.Spec.HA.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.Redis.Resources == nil {
+			existingArgoCD.Spec.Redis.Resources = defaultArgoCDInstance.Spec.Redis.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.Repo.Resources == nil {
+			existingArgoCD.Spec.Repo.Resources = defaultArgoCDInstance.Spec.Repo.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.Server.Resources == nil {
+			existingArgoCD.Spec.Server.Resources = defaultArgoCDInstance.Spec.Server.Resources
+			changed = true
+		}
+
+		if changed {
+			reqLogger.Info("Reconciling ArgoCD", "Namespace", existingArgoCD.Namespace, "Name", existingArgoCD.Name)
+			err = r.client.Update(context.TODO(), existingArgoCD)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+	}
 	return reconcile.Result{}, nil
 }
 
@@ -491,6 +542,10 @@ func (r *ReconcileGitopsService) reconcileBackend(gitopsserviceNamespacedName ty
 			}
 			if !reflect.DeepEqual(found.Spec.Template.Spec.Containers[0].Args, deploymentObj.Spec.Template.Spec.Containers[0].Args) {
 				found.Spec.Template.Spec.Containers[0].Args = deploymentObj.Spec.Template.Spec.Containers[0].Args
+				changed = true
+			}
+			if found.Spec.Template.Spec.Containers[0].Resources.Requests == nil {
+				found.Spec.Template.Spec.Containers[0].Resources = deploymentObj.Spec.Template.Spec.Containers[0].Resources
 				changed = true
 			}
 

--- a/pkg/controller/gitopsservice/gitopsservice_controller.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller.go
@@ -544,7 +544,7 @@ func (r *ReconcileGitopsService) reconcileBackend(gitopsserviceNamespacedName ty
 				found.Spec.Template.Spec.Containers[0].Args = deploymentObj.Spec.Template.Spec.Containers[0].Args
 				changed = true
 			}
-			if found.Spec.Template.Spec.Containers[0].Resources.Requests == nil {
+			if !reflect.DeepEqual(found.Spec.Template.Spec.Containers[0].Resources, deploymentObj.Spec.Template.Spec.Containers[0].Resources) {
 				found.Spec.Template.Spec.Containers[0].Resources = deploymentObj.Spec.Template.Spec.Containers[0].Resources
 				changed = true
 			}

--- a/pkg/controller/gitopsservice/gitopsservice_controller_test.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller_test.go
@@ -19,6 +19,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -329,6 +330,54 @@ func TestReconcile_BackendResourceLimits(t *testing.T) {
 	assert.Equal(t, resources.Requests[corev1.ResourceMemory], resourcev1.MustParse("128Mi"))
 	assert.Equal(t, resources.Limits[corev1.ResourceCPU], resourcev1.MustParse("500m"))
 	assert.Equal(t, resources.Limits[corev1.ResourceMemory], resourcev1.MustParse("256Mi"))
+}
+
+func TestReconcile_testArgoCDForOperatorUpgrade(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	s := scheme.Scheme
+	addKnownTypesToScheme(s)
+
+	fakeClient := fake.NewFakeClientWithScheme(s, util.NewClusterVersion("4.7.1"), newGitopsService())
+	reconciler := newReconcileGitOpsService(fakeClient, s)
+
+	// Create a basic ArgoCD CR. ArgoCD created by Operator version less than v1.2
+	existingArgoCD := &argoapp.ArgoCD{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      serviceNamespace,
+			Namespace: serviceNamespace,
+		},
+		Spec: argoapp.ArgoCDSpec{
+			Server: argoapp.ArgoCDServerSpec{
+				Route: argoapp.ArgoCDRouteSpec{
+					Enabled: true,
+				},
+			},
+			ApplicationSet: &argoapp.ArgoCDApplicationSet{},
+		},
+	}
+
+	err := fakeClient.Create(context.TODO(), existingArgoCD)
+	assertNoError(t, err)
+
+	_, err = reconciler.Reconcile(newRequest("test", "test"))
+	assertNoError(t, err)
+
+	// ArgoCD instance SHOULD be updated with resource request/limits for each workload.
+	updateArgoCD := &argoapp.ArgoCD{}
+
+	if err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: common.ArgoCDInstanceName, Namespace: serviceNamespace},
+		updateArgoCD); err != nil {
+		t.Fatalf("ArgoCD instance should exist in namespace, error: %v", err)
+	}
+
+	assert.Check(t, updateArgoCD.Spec.ApplicationSet.Resources != nil)
+	assert.Check(t, updateArgoCD.Spec.Controller.Resources != nil)
+	assert.Check(t, updateArgoCD.Spec.Dex.Resources != nil)
+	assert.Check(t, updateArgoCD.Spec.Grafana.Resources != nil)
+	assert.Check(t, updateArgoCD.Spec.HA.Resources != nil)
+	assert.Check(t, updateArgoCD.Spec.Redis.Resources != nil)
+	assert.Check(t, updateArgoCD.Spec.Repo.Resources != nil)
+	assert.Check(t, updateArgoCD.Spec.Server.Resources != nil)
 }
 
 func TestGetBackendNamespace(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
This PR addresses the following issue.

After upgrading to v1.2, Resource Quota has been configured in `openshift-gitops` namespace by the operator.   However, existing Deployments do not contain Resource limit/request.   When any one of the existing pods are deleted, new pods failed to start because resource limit/requests are not defined in the Deployments.`

This PR makes the following changes:
* When reconciling the default instance, we make sure the following workloads contain resource request/limit definitions.
** applicationset controller
** application controller
** dex
** grafana
** ha proxy
** redis
** repo server
* Reconcile resource limit/request changes of backend service
* Reconcile resource limit/request changes of kam delivery container

**Have you updated the necessary documentation?**
NA

**Test acceptance criteria**:
* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
1. Install the operator v1.1.2
2. Upgrade to the new version of operator v1.2
3. Delete any pod, you will notice that a new pod will never move into running state as it is not created with resource requirements.
