### PR TITLE
feat: Support application controller sharding, pull #384 from argocd-operator

### DIFF
--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -130,6 +130,20 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
+                  sharding:
+                    description: Sharding contains the options for the Application
+                      Controller sharding configuration.
+                    properties:
+                      enabled:
+                        description: Enabled defines whether sharding should be enabled
+                          on the Application Controller component.
+                        type: boolean
+                      replicas:
+                        description: Replicas defines the number of replicas to run
+                          in the Application controller shard.
+                        format: int32
+                        type: integer
+                    type: object
                 type: object
               dex:
                 description: Dex defines the Dex server options for ArgoCD.

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -129,6 +129,20 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
+                  sharding:
+                    description: Sharding contains the options for the Application
+                      Controller sharding configuration.
+                    properties:
+                      enabled:
+                        description: Enabled defines whether sharding should be enabled
+                          on the Application Controller component.
+                        type: boolean
+                      replicas:
+                        description: Replicas defines the number of replicas to run
+                          in the Application controller shard.
+                        format: int32
+                        type: integer
+                    type: object
                 type: object
               dex:
                 description: Dex defines the Dex server options for ArgoCD.


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
Support Application Controller Sharding. This PR pulls the latest PR 384 from the upstream argocd-operator.

[384](https://github.com/argoproj-labs/argocd-operator/pull/384) -> Add ability to shard application controller.

**Have you updated the necessary documentation?**
NA

**How to test changes / Special notes to the reviewer**:
run gitops-operator locally using `operator-sdk run local`
create a basic argocd resource as below
apiVersion: argoproj.io/v1alpha1
```
kind: ArgoCD
metadata:
  name: example-argocd
  labels:
    example: basic
spec:
  controller:
    sharding:
      enabled: true
      replicas: 3
```
Verify the provider replicas of application controller are created and a new environment variable with name `ARGOCD_CONTROLLER_REPLICAS` is created for the application-controller statefulset.

