### PR TITLE
feat: Set the DISABLE_DEX environment variable to true in CSV

### DIFF
--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -557,7 +557,7 @@ spec:
                 - name: OPERATOR_NAME
                   value: gitops-operator
                 - name: DISABLE_DEX
-                  value: "true"
+                  value: "false"
                 image: quay.io/redhat-developer/gitops-operator:v0.0.3
                 livenessProbe:
                   httpGet:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,6 +51,6 @@ spec:
         - name: OPERATOR_NAME
           value: gitops-operator
         - name: DISABLE_DEX
-          value: "true" 
+          value: "false" 
       serviceAccountName: gitops-operator
       terminationGracePeriodSeconds: 10

--- a/test/e2e/gitopsservice_test.go
+++ b/test/e2e/gitopsservice_test.go
@@ -62,6 +62,12 @@ var _ = Describe("GitOpsServiceController", func() {
 
 		It("Argo CD instance is created", func() {
 			checkIfPresent(types.NamespacedName{Name: argoCDInstanceName, Namespace: argoCDNamespace}, argoCDInstance)
+			checkIfPresent(types.NamespacedName{Name: defaultApplicationControllerName, Namespace: argoCDNamespace}, &appsv1.StatefulSetList{})
+			checkIfPresent(types.NamespacedName{Name: defaultApplicationSetControllerName, Namespace: argoCDNamespace}, &appsv1.Deployment{})
+			checkIfPresent(types.NamespacedName{Name: defaultDexInstanceName, Namespace: argoCDNamespace}, &appsv1.Deployment{})
+			checkIfPresent(types.NamespacedName{Name: defaultRedisName, Namespace: argoCDNamespace}, &appsv1.Deployment{})
+			checkIfPresent(types.NamespacedName{Name: defaultRepoServerName, Namespace: argoCDNamespace}, &appsv1.Deployment{})
+			checkIfPresent(types.NamespacedName{Name: defaultServerName, Namespace: argoCDNamespace}, &appsv1.Deployment{})
 		})
 
 		It("Manual modification of Argo CD CR is allowed", func() {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -65,24 +65,30 @@ var k8sClient client.Client
 var testEnv *envtest.Environment
 
 const (
-	operatorName              = "gitops-operator"
-	argoCDConfigMapName       = "argocd-cm"
-	argoCDRouteName           = "openshift-gitops-server"
-	argoCDNamespace           = "openshift-gitops"
-	authURL                   = "/auth/realms/master/protocol/openid-connect/token"
-	depracatedArgoCDNamespace = "openshift-pipelines-app-delivery"
-	consoleLinkName           = "argocd"
-	argoCDInstanceName        = "openshift-gitops"
-	gitopsInstanceName        = "cluster"
-	defaultKeycloakIdentifier = "keycloak"
-	defaultTemplateIdentifier = "rhsso"
-	realmURL                  = "/auth/admin/realms/argocd"
-	rhssosecret               = "keycloak-secret"
-	clusterConfigEnv          = "ARGOCD_CLUSTER_CONFIG_NAMESPACES"
-	disableDexEnv             = "DISABLE_DEX"
-	argocdManagedByLabel      = "argocd.argoproj.io/managed-by"
-	timeout                   = time.Minute * 2
-	interval                  = time.Millisecond * 250
+	operatorName                        = "gitops-operator"
+	argoCDConfigMapName                 = "argocd-cm"
+	argoCDRouteName                     = "openshift-gitops-server"
+	argoCDNamespace                     = "openshift-gitops"
+	authURL                             = "/auth/realms/master/protocol/openid-connect/token"
+	depracatedArgoCDNamespace           = "openshift-pipelines-app-delivery"
+	defaultApplicationControllerName    = "openshift-gitops-application-controller"
+	defaultApplicationSetControllerName = "openshift-gitops-applicationset-controller"
+	defaultDexInstanceName              = "openshift-gitops-dex-server"
+	defaultRedisName                    = "openshift-gitops-redis"
+	defaultRepoServerName               = "openshift-gitops-repo-server"
+	defaultServerName                   = "openshift-gitops-server"
+	consoleLinkName                     = "argocd"
+	argoCDInstanceName                  = "openshift-gitops"
+	gitopsInstanceName                  = "cluster"
+	defaultKeycloakIdentifier           = "keycloak"
+	defaultTemplateIdentifier           = "rhsso"
+	realmURL                            = "/auth/admin/realms/argocd"
+	rhssosecret                         = "keycloak-secret"
+	clusterConfigEnv                    = "ARGOCD_CLUSTER_CONFIG_NAMESPACES"
+	disableDexEnv                       = "DISABLE_DEX"
+	argocdManagedByLabel                = "argocd.argoproj.io/managed-by"
+	timeout                             = time.Minute * 2
+	interval                            = time.Millisecond * 250
 )
 
 func TestAPIs(t *testing.T) {
@@ -107,8 +113,8 @@ var _ = BeforeSuite(func() {
 	}
 	// set cluster config argocd instance
 	Expect(os.Setenv(clusterConfigEnv, argoCDNamespace)).To(Succeed())
-	// disable dex by default
-	Expect(os.Setenv(disableDexEnv, "true")).To(Succeed())
+	// enable dex by default
+	Expect(os.Setenv(disableDexEnv, "false")).To(Succeed())
 
 	cfg, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())

--- a/test/nondefaulte2e/suite_test.go
+++ b/test/nondefaulte2e/suite_test.go
@@ -97,8 +97,8 @@ var _ = BeforeSuite(func() {
 	}
 	// disable default argocd instance
 	Expect(os.Setenv(common.DisableDefaultInstallEnvVar, "true")).To(Succeed())
-	// disable dex by default
-	Expect(os.Setenv(disableDexEnv, "true")).To(Succeed())
+	// enable dex by default
+	Expect(os.Setenv(disableDexEnv, "false")).To(Succeed())
 
 	cfg, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
This PR set the DISABLE_DEX environment variable to true in CSV.  By doing so, the Dex workload is enabled and the operator controller reconciler dex/oidc configuration.

**Test acceptance criteria**:
* [x] E2E Test

**How to test changes / Special notes to the reviewer**:
run the operator locally using `operator-sdk run local`
After a couple of minutes, verify the install installation is successful and pod is up and running.
