### PR TITLE
Upgrade operator CRDs to v1 to be compatible with OCP 4.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ That's it, your API `route` should be created for you. You don't need to explicl
 
 **Note:** Please check that you're using [operator-sdk]( https://github.com/operator-framework/operator-sdk/releases/tag/v0.17.2) version 0.17 or earlier. Since the community-operators do not support `v1` version of `CustomResourceDefinition`, the operator is using `v1beta1` version of `CustomResourceDefinition`.
 
+**Update:** As of kubernetes v1.22.0, `v1beta1` version of `CustomResourceDefinition` has been deprecated and is no longer supported. Hence, `CustomResourceDefinition` has been upgraded to `v1` in order to make the operator compliant with OCP 4.9
 ## Tests
 
 ```

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,6 +6,15 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=gitops-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.0
+LABEL operators.operatorframework.io.metrics.project_layout=go
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.0
+LABEL operators.operatorframework.io.metrics.project_layout=go
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.0
+LABEL operators.operatorframework.io.metrics.project_layout=go
 
 COPY deploy/olm-catalog/gitops-operator/manifests /manifests/
 COPY deploy/olm-catalog/gitops-operator/metadata /metadata/

--- a/deploy/crds/argoproj.io_applications_crd.yaml
+++ b/deploy/crds/argoproj.io_applications_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -16,645 +16,136 @@ spec:
     - apps
     singular: application
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: Application is a definition of Application resource.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        operation:
-          description: Operation contains requested operation parameters.
-          properties:
-            info:
-              items:
-                properties:
-                  name:
-                    type: string
-                  value:
-                    type: string
-                required:
-                - name
-                - value
-                type: object
-              type: array
-            initiatedBy:
-              description: OperationInitiator holds information about the operation initiator
-              properties:
-                automated:
-                  description: Automated is set to true if operation was initiated automatically by the application controller.
-                  type: boolean
-                username:
-                  description: Name of a user who started operation.
-                  type: string
-              type: object
-            retry:
-              description: Retry controls failed sync retry behavior
-              properties:
-                backoff:
-                  description: Backoff is a backoff strategy
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.sync.status
+      name: Sync Status
+      type: string
+    - jsonPath: .status.health.status
+      name: Health Status
+      type: string
+    - jsonPath: .status.sync.revision
+      name: Revision
+      priority: 10
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Application is a definition of Application resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          operation:
+            description: Operation contains information about a requested or running operation
+            properties:
+              info:
+                description: Info is a list of informational items for this operation
+                items:
                   properties:
-                    duration:
-                      description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                    name:
                       type: string
-                    factor:
-                      description: Factor is a factor to multiply the base duration after each failed retry
-                      format: int64
-                      type: integer
-                    maxDuration:
-                      description: MaxDuration is the maximum amount of time allowed for the backoff strategy
-                      type: string
-                  type: object
-                limit:
-                  description: Limit is the maximum number of attempts when retrying a container
-                  format: int64
-                  type: integer
-              type: object
-            sync:
-              description: SyncOperation contains sync operation details.
-              properties:
-                dryRun:
-                  description: DryRun will perform a `kubectl apply --dry-run` without actually performing the sync
-                  type: boolean
-                manifests:
-                  description: Manifests is an optional field that overrides sync source with a local directory for development
-                  items:
-                    type: string
-                  type: array
-                prune:
-                  description: Prune deletes resources that are no longer tracked in git
-                  type: boolean
-                resources:
-                  description: Resources describes which resources to sync
-                  items:
-                    description: SyncOperationResource contains resources to sync.
-                    properties:
-                      group:
-                        type: string
-                      kind:
-                        type: string
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - kind
-                    - name
-                    type: object
-                  type: array
-                revision:
-                  description: Revision is the revision in which to sync the application to. If omitted, will use the revision specified in app spec.
-                  type: string
-                source:
-                  description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and nil during a Sync operation
-                  properties:
-                    chart:
-                      description: Chart is a Helm chart name
-                      type: string
-                    directory:
-                      description: Directory holds path/directory specific options
-                      properties:
-                        jsonnet:
-                          description: ApplicationSourceJsonnet holds jsonnet specific options
-                          properties:
-                            extVars:
-                              description: ExtVars is a list of Jsonnet External Variables
-                              items:
-                                description: JsonnetVar is a jsonnet variable
-                                properties:
-                                  code:
-                                    type: boolean
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - name
-                                - value
-                                type: object
-                              type: array
-                            libs:
-                              description: Additional library search dirs
-                              items:
-                                type: string
-                              type: array
-                            tlas:
-                              description: TLAS is a list of Jsonnet Top-level Arguments
-                              items:
-                                description: JsonnetVar is a jsonnet variable
-                                properties:
-                                  code:
-                                    type: boolean
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - name
-                                - value
-                                type: object
-                              type: array
-                          type: object
-                        recurse:
-                          type: boolean
-                      type: object
-                    helm:
-                      description: Helm holds helm specific options
-                      properties:
-                        fileParameters:
-                          description: FileParameters are file parameters to the helm template
-                          items:
-                            description: HelmFileParameter is a file parameter to a helm template
-                            properties:
-                              name:
-                                description: Name is the name of the helm parameter
-                                type: string
-                              path:
-                                description: Path is the path value for the helm parameter
-                                type: string
-                            type: object
-                          type: array
-                        parameters:
-                          description: Parameters are parameters to the helm template
-                          items:
-                            description: HelmParameter is a parameter to a helm template
-                            properties:
-                              forceString:
-                                description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
-                                type: boolean
-                              name:
-                                description: Name is the name of the helm parameter
-                                type: string
-                              value:
-                                description: Value is the value for the helm parameter
-                                type: string
-                            type: object
-                          type: array
-                        releaseName:
-                          description: The Helm release name. If omitted it will use the application name
-                          type: string
-                        valueFiles:
-                          description: ValuesFiles is a list of Helm value files to use when generating a template
-                          items:
-                            type: string
-                          type: array
-                        values:
-                          description: Values is Helm values, typically defined as a block
-                          type: string
-                      type: object
-                    ksonnet:
-                      description: Ksonnet holds ksonnet specific options
-                      properties:
-                        environment:
-                          description: Environment is a ksonnet application environment name
-                          type: string
-                        parameters:
-                          description: Parameters are a list of ksonnet component parameter override values
-                          items:
-                            description: KsonnetParameter is a ksonnet component parameter
-                            properties:
-                              component:
-                                type: string
-                              name:
-                                type: string
-                              value:
-                                type: string
-                            required:
-                            - name
-                            - value
-                            type: object
-                          type: array
-                      type: object
-                    kustomize:
-                      description: Kustomize holds kustomize specific options
-                      properties:
-                        commonLabels:
-                          additionalProperties:
-                            type: string
-                          description: CommonLabels adds additional kustomize commonLabels
-                          type: object
-                        images:
-                          description: Images are kustomize image overrides
-                          items:
-                            type: string
-                          type: array
-                        namePrefix:
-                          description: NamePrefix is a prefix appended to resources for kustomize apps
-                          type: string
-                        nameSuffix:
-                          description: NameSuffix is a suffix appended to resources for kustomize apps
-                          type: string
-                        version:
-                          description: Version contains optional Kustomize version
-                          type: string
-                      type: object
-                    path:
-                      description: Path is a directory path within the Git repository
-                      type: string
-                    plugin:
-                      description: ConfigManagementPlugin holds config management plugin specific options
-                      properties:
-                        env:
-                          items:
-                            properties:
-                              name:
-                                description: the name, usually uppercase
-                                type: string
-                              value:
-                                description: the value
-                                type: string
-                            required:
-                            - name
-                            - value
-                            type: object
-                          type: array
-                        name:
-                          type: string
-                      type: object
-                    repoURL:
-                      description: RepoURL is the repository URL of the application manifests
-                      type: string
-                    targetRevision:
-                      description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                    value:
                       type: string
                   required:
-                  - repoURL
+                  - name
+                  - value
                   type: object
-                syncOptions:
-                  description: SyncOptions provide per-sync sync-options, e.g. Validate=false
-                  items:
-                    type: string
-                  type: array
-                syncStrategy:
-                  description: SyncStrategy describes how to perform the sync
-                  properties:
-                    apply:
-                      description: Apply wil perform a `kubectl apply` to perform the sync.
-                      properties:
-                        force:
-                          description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
-                          type: boolean
-                      type: object
-                    hook:
-                      description: Hook will submit any referenced resources to perform the sync. This is the default strategy
-                      properties:
-                        force:
-                          description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
-                          type: boolean
-                      type: object
-                  type: object
-              type: object
-          type: object
-        spec:
-          description: ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
-          properties:
-            destination:
-              description: Destination overrides the kubernetes server and namespace defined in the environment ksonnet app.yaml
-              properties:
-                name:
-                  description: Name of the destination cluster which can be used instead of server (url) field
-                  type: string
-                namespace:
-                  description: Namespace overrides the environment namespace value in the ksonnet app.yaml
-                  type: string
-                server:
-                  description: Server overrides the environment server value in the ksonnet app.yaml
-                  type: string
-              type: object
-            ignoreDifferences:
-              description: IgnoreDifferences controls resources fields which should be ignored during comparison
-              items:
-                description: ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.
+                type: array
+              initiatedBy:
+                description: InitiatedBy contains information about who initiated the operations
                 properties:
-                  group:
+                  automated:
+                    description: Automated is set to true if operation was initiated automatically by the application controller.
+                    type: boolean
+                  username:
+                    description: Username contains the name of a user who started operation
                     type: string
-                  jsonPointers:
+                type: object
+              retry:
+                description: Retry controls the strategy to apply if a sync fails
+                properties:
+                  backoff:
+                    description: Backoff controls how to backoff on subsequent retries of failed syncs
+                    properties:
+                      duration:
+                        description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                        type: string
+                      factor:
+                        description: Factor is a factor to multiply the base duration after each failed retry
+                        format: int64
+                        type: integer
+                      maxDuration:
+                        description: MaxDuration is the maximum amount of time allowed for the backoff strategy
+                        type: string
+                    type: object
+                  limit:
+                    description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
+                    format: int64
+                    type: integer
+                type: object
+              sync:
+                description: Sync contains parameters for the operation
+                properties:
+                  dryRun:
+                    description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
+                    type: boolean
+                  manifests:
+                    description: Manifests is an optional field that overrides sync source with a local directory for development
                     items:
                       type: string
                     type: array
-                  kind:
-                    type: string
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                required:
-                - jsonPointers
-                - kind
-                type: object
-              type: array
-            info:
-              description: Infos contains a list of useful information (URLs, email addresses, and plain text) that relates to the application
-              items:
-                properties:
-                  name:
-                    type: string
-                  value:
-                    type: string
-                required:
-                - name
-                - value
-                type: object
-              type: array
-            project:
-              description: Project is a application project name. Empty name means that application belongs to 'default' project.
-              type: string
-            revisionHistoryLimit:
-              description: This limits this number of items kept in the apps revision history. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-              format: int64
-              type: integer
-            source:
-              description: Source is a reference to the location ksonnet application definition
-              properties:
-                chart:
-                  description: Chart is a Helm chart name
-                  type: string
-                directory:
-                  description: Directory holds path/directory specific options
-                  properties:
-                    jsonnet:
-                      description: ApplicationSourceJsonnet holds jsonnet specific options
+                  prune:
+                    description: Prune specifies to delete resources from the cluster that are no longer tracked in git
+                    type: boolean
+                  resources:
+                    description: Resources describes which resources shall be part of the sync
+                    items:
+                      description: SyncOperationResource contains resources to sync.
                       properties:
-                        extVars:
-                          description: ExtVars is a list of Jsonnet External Variables
-                          items:
-                            description: JsonnetVar is a jsonnet variable
-                            properties:
-                              code:
-                                type: boolean
-                              name:
-                                type: string
-                              value:
-                                type: string
-                            required:
-                            - name
-                            - value
-                            type: object
-                          type: array
-                        libs:
-                          description: Additional library search dirs
-                          items:
-                            type: string
-                          type: array
-                        tlas:
-                          description: TLAS is a list of Jsonnet Top-level Arguments
-                          items:
-                            description: JsonnetVar is a jsonnet variable
-                            properties:
-                              code:
-                                type: boolean
-                              name:
-                                type: string
-                              value:
-                                type: string
-                            required:
-                            - name
-                            - value
-                            type: object
-                          type: array
-                      type: object
-                    recurse:
-                      type: boolean
-                  type: object
-                helm:
-                  description: Helm holds helm specific options
-                  properties:
-                    fileParameters:
-                      description: FileParameters are file parameters to the helm template
-                      items:
-                        description: HelmFileParameter is a file parameter to a helm template
-                        properties:
-                          name:
-                            description: Name is the name of the helm parameter
-                            type: string
-                          path:
-                            description: Path is the path value for the helm parameter
-                            type: string
-                        type: object
-                      type: array
-                    parameters:
-                      description: Parameters are parameters to the helm template
-                      items:
-                        description: HelmParameter is a parameter to a helm template
-                        properties:
-                          forceString:
-                            description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
-                            type: boolean
-                          name:
-                            description: Name is the name of the helm parameter
-                            type: string
-                          value:
-                            description: Value is the value for the helm parameter
-                            type: string
-                        type: object
-                      type: array
-                    releaseName:
-                      description: The Helm release name. If omitted it will use the application name
-                      type: string
-                    valueFiles:
-                      description: ValuesFiles is a list of Helm value files to use when generating a template
-                      items:
-                        type: string
-                      type: array
-                    values:
-                      description: Values is Helm values, typically defined as a block
-                      type: string
-                  type: object
-                ksonnet:
-                  description: Ksonnet holds ksonnet specific options
-                  properties:
-                    environment:
-                      description: Environment is a ksonnet application environment name
-                      type: string
-                    parameters:
-                      description: Parameters are a list of ksonnet component parameter override values
-                      items:
-                        description: KsonnetParameter is a ksonnet component parameter
-                        properties:
-                          component:
-                            type: string
-                          name:
-                            type: string
-                          value:
-                            type: string
-                        required:
-                        - name
-                        - value
-                        type: object
-                      type: array
-                  type: object
-                kustomize:
-                  description: Kustomize holds kustomize specific options
-                  properties:
-                    commonLabels:
-                      additionalProperties:
-                        type: string
-                      description: CommonLabels adds additional kustomize commonLabels
-                      type: object
-                    images:
-                      description: Images are kustomize image overrides
-                      items:
-                        type: string
-                      type: array
-                    namePrefix:
-                      description: NamePrefix is a prefix appended to resources for kustomize apps
-                      type: string
-                    nameSuffix:
-                      description: NameSuffix is a suffix appended to resources for kustomize apps
-                      type: string
-                    version:
-                      description: Version contains optional Kustomize version
-                      type: string
-                  type: object
-                path:
-                  description: Path is a directory path within the Git repository
-                  type: string
-                plugin:
-                  description: ConfigManagementPlugin holds config management plugin specific options
-                  properties:
-                    env:
-                      items:
-                        properties:
-                          name:
-                            description: the name, usually uppercase
-                            type: string
-                          value:
-                            description: the value
-                            type: string
-                        required:
-                        - name
-                        - value
-                        type: object
-                      type: array
-                    name:
-                      type: string
-                  type: object
-                repoURL:
-                  description: RepoURL is the repository URL of the application manifests
-                  type: string
-                targetRevision:
-                  description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
-                  type: string
-              required:
-              - repoURL
-              type: object
-            syncPolicy:
-              description: SyncPolicy controls when a sync will be performed
-              properties:
-                automated:
-                  description: Automated will keep an application synced to the target revision
-                  properties:
-                    prune:
-                      description: 'Prune will prune resources automatically as part of automated sync (default: false)'
-                      type: boolean
-                    selfHeal:
-                      description: 'SelfHeal enables auto-syncing if  (default: false)'
-                      type: boolean
-                  type: object
-                retry:
-                  description: Retry controls failed sync retry behavior
-                  properties:
-                    backoff:
-                      description: Backoff is a backoff strategy
-                      properties:
-                        duration:
-                          description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                        group:
                           type: string
-                        factor:
-                          description: Factor is a factor to multiply the base duration after each failed retry
-                          format: int64
-                          type: integer
-                        maxDuration:
-                          description: MaxDuration is the maximum amount of time allowed for the backoff strategy
+                        kind:
                           type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                      - kind
+                      - name
                       type: object
-                    limit:
-                      description: Limit is the maximum number of attempts when retrying a container
-                      format: int64
-                      type: integer
-                  type: object
-                syncOptions:
-                  description: Options allow you to specify whole app sync-options
-                  items:
-                    type: string
-                  type: array
-              type: object
-          required:
-          - destination
-          - project
-          - source
-          type: object
-        status:
-          description: ApplicationStatus contains information about application sync, health status
-          properties:
-            conditions:
-              items:
-                description: ApplicationCondition contains details about current application condition
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the time the condition was first observed.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Message contains human-readable message indicating details about condition
-                    type: string
-                  type:
-                    description: Type is an application condition type
-                    type: string
-                required:
-                - message
-                - type
-                type: object
-              type: array
-            health:
-              properties:
-                message:
-                  type: string
-                status:
-                  description: Represents resource health status
-                  type: string
-              type: object
-            history:
-              description: RevisionHistories is a array of history, oldest first and newest last
-              items:
-                description: RevisionHistory contains information relevant to an application deployment
-                properties:
-                  deployStartedAt:
-                    description: DeployStartedAt holds the time the deployment started
-                    format: date-time
-                    type: string
-                  deployedAt:
-                    description: DeployedAt holds the time the deployment completed
-                    format: date-time
-                    type: string
-                  id:
-                    description: ID is an auto incrementing identifier of the RevisionHistory
-                    format: int64
-                    type: integer
+                    type: array
                   revision:
-                    description: Revision holds the revision of the sync
+                    description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
                     type: string
                   source:
-                    description: ApplicationSource contains information about github repository, path within repository and target application environment.
+                    description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
                     properties:
                       chart:
-                        description: Chart is a Helm chart name
+                        description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                         type: string
                       directory:
                         description: Directory holds path/directory specific options
                         properties:
+                          exclude:
+                            description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                            type: string
+                          include:
+                            description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                            type: string
                           jsonnet:
-                            description: ApplicationSourceJsonnet holds jsonnet specific options
+                            description: Jsonnet holds options specific to Jsonnet
                             properties:
                               extVars:
                                 description: ExtVars is a list of Jsonnet External Variables
                                 items:
-                                  description: JsonnetVar is a jsonnet variable
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                   properties:
                                     code:
                                       type: boolean
@@ -675,7 +166,7 @@ spec:
                               tlas:
                                 description: TLAS is a list of Jsonnet Top-level Arguments
                                 items:
-                                  description: JsonnetVar is a jsonnet variable
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                   properties:
                                     code:
                                       type: boolean
@@ -690,6 +181,7 @@ spec:
                                 type: array
                             type: object
                           recurse:
+                            description: Recurse specifies whether to scan a directory recursively for manifests
                             type: boolean
                         type: object
                       helm:
@@ -698,34 +190,34 @@ spec:
                           fileParameters:
                             description: FileParameters are file parameters to the helm template
                             items:
-                              description: HelmFileParameter is a file parameter to a helm template
+                              description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                               properties:
                                 name:
-                                  description: Name is the name of the helm parameter
+                                  description: Name is the name of the Helm parameter
                                   type: string
                                 path:
-                                  description: Path is the path value for the helm parameter
+                                  description: Path is the path to the file containing the values for the Helm parameter
                                   type: string
                               type: object
                             type: array
                           parameters:
-                            description: Parameters are parameters to the helm template
+                            description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                             items:
-                              description: HelmParameter is a parameter to a helm template
+                              description: HelmParameter is a parameter that's passed to helm template during manifest generation
                               properties:
                                 forceString:
                                   description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                   type: boolean
                                 name:
-                                  description: Name is the name of the helm parameter
+                                  description: Name is the name of the Helm parameter
                                   type: string
                                 value:
-                                  description: Value is the value for the helm parameter
+                                  description: Value is the value for the Helm parameter
                                   type: string
                               type: object
                             type: array
                           releaseName:
-                            description: The Helm release name. If omitted it will use the application name
+                            description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                             type: string
                           valueFiles:
                             description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -733,7 +225,10 @@ spec:
                               type: string
                             type: array
                           values:
-                            description: Values is Helm values, typically defined as a block
+                            description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                            type: string
+                          version:
+                            description: Version is the Helm version to use for templating (either "2" or "3")
                             type: string
                         type: object
                       ksonnet:
@@ -762,40 +257,48 @@ spec:
                       kustomize:
                         description: Kustomize holds kustomize specific options
                         properties:
+                          commonAnnotations:
+                            additionalProperties:
+                              type: string
+                            description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                            type: object
                           commonLabels:
                             additionalProperties:
                               type: string
-                            description: CommonLabels adds additional kustomize commonLabels
+                            description: CommonLabels is a list of additional labels to add to rendered manifests
                             type: object
                           images:
-                            description: Images are kustomize image overrides
+                            description: Images is a list of Kustomize image override specifications
                             items:
+                              description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                               type: string
                             type: array
                           namePrefix:
-                            description: NamePrefix is a prefix appended to resources for kustomize apps
+                            description: NamePrefix is a prefix appended to resources for Kustomize apps
                             type: string
                           nameSuffix:
-                            description: NameSuffix is a suffix appended to resources for kustomize apps
+                            description: NameSuffix is a suffix appended to resources for Kustomize apps
                             type: string
                           version:
-                            description: Version contains optional Kustomize version
+                            description: Version controls which version of Kustomize to use for rendering manifests
                             type: string
                         type: object
                       path:
-                        description: Path is a directory path within the Git repository
+                        description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                         type: string
                       plugin:
                         description: ConfigManagementPlugin holds config management plugin specific options
                         properties:
                           env:
+                            description: Env is a list of environment variable entries
                             items:
+                              description: EnvEntry represents an entry in the application's environment
                               properties:
                                 name:
-                                  description: the name, usually uppercase
+                                  description: Name is the name of the variable, usually expressed in uppercase
                                   type: string
                                 value:
-                                  description: the value
+                                  description: Value is the value of the variable
                                   type: string
                               required:
                               - name
@@ -806,639 +309,414 @@ spec:
                             type: string
                         type: object
                       repoURL:
-                        description: RepoURL is the repository URL of the application manifests
+                        description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                         type: string
                       targetRevision:
-                        description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                        description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                         type: string
                     required:
                     - repoURL
                     type: object
-                required:
-                - deployedAt
-                - id
-                - revision
-                type: object
-              type: array
-            observedAt:
-              description: 'ObservedAt indicates when the application state was updated without querying latest git state Deprecated: controller no longer updates ObservedAt field'
-              format: date-time
-              type: string
-            operationState:
-              description: OperationState contains information about state of currently performing operation on application.
-              properties:
-                finishedAt:
-                  description: FinishedAt contains time of operation completion
-                  format: date-time
-                  type: string
-                message:
-                  description: Message hold any pertinent messages when attempting to perform operation (typically errors).
-                  type: string
-                operation:
-                  description: Operation is the original requested operation
-                  properties:
-                    info:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          value:
-                            type: string
-                        required:
-                        - name
-                        - value
-                        type: object
-                      type: array
-                    initiatedBy:
-                      description: OperationInitiator holds information about the operation initiator
-                      properties:
-                        automated:
-                          description: Automated is set to true if operation was initiated automatically by the application controller.
-                          type: boolean
-                        username:
-                          description: Name of a user who started operation.
-                          type: string
-                      type: object
-                    retry:
-                      description: Retry controls failed sync retry behavior
-                      properties:
-                        backoff:
-                          description: Backoff is a backoff strategy
-                          properties:
-                            duration:
-                              description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
-                              type: string
-                            factor:
-                              description: Factor is a factor to multiply the base duration after each failed retry
-                              format: int64
-                              type: integer
-                            maxDuration:
-                              description: MaxDuration is the maximum amount of time allowed for the backoff strategy
-                              type: string
-                          type: object
-                        limit:
-                          description: Limit is the maximum number of attempts when retrying a container
-                          format: int64
-                          type: integer
-                      type: object
-                    sync:
-                      description: SyncOperation contains sync operation details.
-                      properties:
-                        dryRun:
-                          description: DryRun will perform a `kubectl apply --dry-run` without actually performing the sync
-                          type: boolean
-                        manifests:
-                          description: Manifests is an optional field that overrides sync source with a local directory for development
-                          items:
-                            type: string
-                          type: array
-                        prune:
-                          description: Prune deletes resources that are no longer tracked in git
-                          type: boolean
-                        resources:
-                          description: Resources describes which resources to sync
-                          items:
-                            description: SyncOperationResource contains resources to sync.
-                            properties:
-                              group:
-                                type: string
-                              kind:
-                                type: string
-                              name:
-                                type: string
-                              namespace:
-                                type: string
-                            required:
-                            - kind
-                            - name
-                            type: object
-                          type: array
-                        revision:
-                          description: Revision is the revision in which to sync the application to. If omitted, will use the revision specified in app spec.
-                          type: string
-                        source:
-                          description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and nil during a Sync operation
-                          properties:
-                            chart:
-                              description: Chart is a Helm chart name
-                              type: string
-                            directory:
-                              description: Directory holds path/directory specific options
-                              properties:
-                                jsonnet:
-                                  description: ApplicationSourceJsonnet holds jsonnet specific options
-                                  properties:
-                                    extVars:
-                                      description: ExtVars is a list of Jsonnet External Variables
-                                      items:
-                                        description: JsonnetVar is a jsonnet variable
-                                        properties:
-                                          code:
-                                            type: boolean
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    libs:
-                                      description: Additional library search dirs
-                                      items:
-                                        type: string
-                                      type: array
-                                    tlas:
-                                      description: TLAS is a list of Jsonnet Top-level Arguments
-                                      items:
-                                        description: JsonnetVar is a jsonnet variable
-                                        properties:
-                                          code:
-                                            type: boolean
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                  type: object
-                                recurse:
-                                  type: boolean
-                              type: object
-                            helm:
-                              description: Helm holds helm specific options
-                              properties:
-                                fileParameters:
-                                  description: FileParameters are file parameters to the helm template
-                                  items:
-                                    description: HelmFileParameter is a file parameter to a helm template
-                                    properties:
-                                      name:
-                                        description: Name is the name of the helm parameter
-                                        type: string
-                                      path:
-                                        description: Path is the path value for the helm parameter
-                                        type: string
-                                    type: object
-                                  type: array
-                                parameters:
-                                  description: Parameters are parameters to the helm template
-                                  items:
-                                    description: HelmParameter is a parameter to a helm template
-                                    properties:
-                                      forceString:
-                                        description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
-                                        type: boolean
-                                      name:
-                                        description: Name is the name of the helm parameter
-                                        type: string
-                                      value:
-                                        description: Value is the value for the helm parameter
-                                        type: string
-                                    type: object
-                                  type: array
-                                releaseName:
-                                  description: The Helm release name. If omitted it will use the application name
-                                  type: string
-                                valueFiles:
-                                  description: ValuesFiles is a list of Helm value files to use when generating a template
-                                  items:
-                                    type: string
-                                  type: array
-                                values:
-                                  description: Values is Helm values, typically defined as a block
-                                  type: string
-                              type: object
-                            ksonnet:
-                              description: Ksonnet holds ksonnet specific options
-                              properties:
-                                environment:
-                                  description: Environment is a ksonnet application environment name
-                                  type: string
-                                parameters:
-                                  description: Parameters are a list of ksonnet component parameter override values
-                                  items:
-                                    description: KsonnetParameter is a ksonnet component parameter
-                                    properties:
-                                      component:
-                                        type: string
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                              type: object
-                            kustomize:
-                              description: Kustomize holds kustomize specific options
-                              properties:
-                                commonLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: CommonLabels adds additional kustomize commonLabels
-                                  type: object
-                                images:
-                                  description: Images are kustomize image overrides
-                                  items:
-                                    type: string
-                                  type: array
-                                namePrefix:
-                                  description: NamePrefix is a prefix appended to resources for kustomize apps
-                                  type: string
-                                nameSuffix:
-                                  description: NameSuffix is a suffix appended to resources for kustomize apps
-                                  type: string
-                                version:
-                                  description: Version contains optional Kustomize version
-                                  type: string
-                              type: object
-                            path:
-                              description: Path is a directory path within the Git repository
-                              type: string
-                            plugin:
-                              description: ConfigManagementPlugin holds config management plugin specific options
-                              properties:
-                                env:
-                                  items:
-                                    properties:
-                                      name:
-                                        description: the name, usually uppercase
-                                        type: string
-                                      value:
-                                        description: the value
-                                        type: string
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                                name:
-                                  type: string
-                              type: object
-                            repoURL:
-                              description: RepoURL is the repository URL of the application manifests
-                              type: string
-                            targetRevision:
-                              description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
-                              type: string
-                          required:
-                          - repoURL
-                          type: object
-                        syncOptions:
-                          description: SyncOptions provide per-sync sync-options, e.g. Validate=false
-                          items:
-                            type: string
-                          type: array
-                        syncStrategy:
-                          description: SyncStrategy describes how to perform the sync
-                          properties:
-                            apply:
-                              description: Apply wil perform a `kubectl apply` to perform the sync.
-                              properties:
-                                force:
-                                  description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
-                                  type: boolean
-                              type: object
-                            hook:
-                              description: Hook will submit any referenced resources to perform the sync. This is the default strategy
-                              properties:
-                                force:
-                                  description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
-                                  type: boolean
-                              type: object
-                          type: object
-                      type: object
-                  type: object
-                phase:
-                  description: Phase is the current phase of the operation
-                  type: string
-                retryCount:
-                  description: RetryCount contains time of operation retries
-                  format: int64
-                  type: integer
-                startedAt:
-                  description: StartedAt contains time of operation start
-                  format: date-time
-                  type: string
-                syncResult:
-                  description: SyncResult is the result of a Sync operation
-                  properties:
-                    resources:
-                      description: Resources holds the sync result of each individual resource
-                      items:
-                        description: ResourceResult holds the operation result details of a specific resource
-                        properties:
-                          group:
-                            type: string
-                          hookPhase:
-                            description: 'the state of any operation associated with this resource OR hook note: can contain values for non-hook resources'
-                            type: string
-                          hookType:
-                            description: the type of the hook, empty for non-hook resources
-                            type: string
-                          kind:
-                            type: string
-                          message:
-                            description: message for the last sync OR operation
-                            type: string
-                          name:
-                            type: string
-                          namespace:
-                            type: string
-                          status:
-                            description: the final result of the sync, this is be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
-                            type: string
-                          syncPhase:
-                            description: indicates the particular phase of the sync that this is for
-                            type: string
-                          version:
-                            type: string
-                        required:
-                        - group
-                        - kind
-                        - name
-                        - namespace
-                        - version
-                        type: object
-                      type: array
-                    revision:
-                      description: Revision holds the revision of the sync
+                  syncOptions:
+                    description: SyncOptions provide per-sync sync-options, e.g. Validate=false
+                    items:
                       type: string
-                    source:
-                      description: Source records the application source information of the sync, used for comparing auto-sync
-                      properties:
-                        chart:
-                          description: Chart is a Helm chart name
-                          type: string
-                        directory:
-                          description: Directory holds path/directory specific options
-                          properties:
-                            jsonnet:
-                              description: ApplicationSourceJsonnet holds jsonnet specific options
-                              properties:
-                                extVars:
-                                  description: ExtVars is a list of Jsonnet External Variables
-                                  items:
-                                    description: JsonnetVar is a jsonnet variable
-                                    properties:
-                                      code:
-                                        type: boolean
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                                libs:
-                                  description: Additional library search dirs
-                                  items:
-                                    type: string
-                                  type: array
-                                tlas:
-                                  description: TLAS is a list of Jsonnet Top-level Arguments
-                                  items:
-                                    description: JsonnetVar is a jsonnet variable
-                                    properties:
-                                      code:
-                                        type: boolean
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                              type: object
-                            recurse:
-                              type: boolean
-                          type: object
-                        helm:
-                          description: Helm holds helm specific options
-                          properties:
-                            fileParameters:
-                              description: FileParameters are file parameters to the helm template
-                              items:
-                                description: HelmFileParameter is a file parameter to a helm template
-                                properties:
-                                  name:
-                                    description: Name is the name of the helm parameter
-                                    type: string
-                                  path:
-                                    description: Path is the path value for the helm parameter
-                                    type: string
-                                type: object
-                              type: array
-                            parameters:
-                              description: Parameters are parameters to the helm template
-                              items:
-                                description: HelmParameter is a parameter to a helm template
-                                properties:
-                                  forceString:
-                                    description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
-                                    type: boolean
-                                  name:
-                                    description: Name is the name of the helm parameter
-                                    type: string
-                                  value:
-                                    description: Value is the value for the helm parameter
-                                    type: string
-                                type: object
-                              type: array
-                            releaseName:
-                              description: The Helm release name. If omitted it will use the application name
-                              type: string
-                            valueFiles:
-                              description: ValuesFiles is a list of Helm value files to use when generating a template
-                              items:
-                                type: string
-                              type: array
-                            values:
-                              description: Values is Helm values, typically defined as a block
-                              type: string
-                          type: object
-                        ksonnet:
-                          description: Ksonnet holds ksonnet specific options
-                          properties:
-                            environment:
-                              description: Environment is a ksonnet application environment name
-                              type: string
-                            parameters:
-                              description: Parameters are a list of ksonnet component parameter override values
-                              items:
-                                description: KsonnetParameter is a ksonnet component parameter
-                                properties:
-                                  component:
-                                    type: string
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - name
-                                - value
-                                type: object
-                              type: array
-                          type: object
-                        kustomize:
-                          description: Kustomize holds kustomize specific options
-                          properties:
-                            commonLabels:
-                              additionalProperties:
-                                type: string
-                              description: CommonLabels adds additional kustomize commonLabels
-                              type: object
-                            images:
-                              description: Images are kustomize image overrides
-                              items:
-                                type: string
-                              type: array
-                            namePrefix:
-                              description: NamePrefix is a prefix appended to resources for kustomize apps
-                              type: string
-                            nameSuffix:
-                              description: NameSuffix is a suffix appended to resources for kustomize apps
-                              type: string
-                            version:
-                              description: Version contains optional Kustomize version
-                              type: string
-                          type: object
-                        path:
-                          description: Path is a directory path within the Git repository
-                          type: string
-                        plugin:
-                          description: ConfigManagementPlugin holds config management plugin specific options
-                          properties:
-                            env:
-                              items:
-                                properties:
-                                  name:
-                                    description: the name, usually uppercase
-                                    type: string
-                                  value:
-                                    description: the value
-                                    type: string
-                                required:
-                                - name
-                                - value
-                                type: object
-                              type: array
-                            name:
-                              type: string
-                          type: object
-                        repoURL:
-                          description: RepoURL is the repository URL of the application manifests
-                          type: string
-                        targetRevision:
-                          description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
-                          type: string
-                      required:
-                      - repoURL
-                      type: object
-                  required:
-                  - revision
-                  type: object
-              required:
-              - operation
-              - phase
-              - startedAt
-              type: object
-            reconciledAt:
-              description: ReconciledAt indicates when the application state was reconciled using the latest git version
-              format: date-time
-              type: string
-            resources:
-              items:
-                description: ResourceStatus holds the current sync and health status of a resource
-                properties:
-                  group:
-                    type: string
-                  health:
+                    type: array
+                  syncStrategy:
+                    description: SyncStrategy describes how to perform the sync
                     properties:
-                      message:
-                        type: string
-                      status:
-                        description: Represents resource health status
-                        type: string
+                      apply:
+                        description: Apply will perform a `kubectl apply` to perform the sync.
+                        properties:
+                          force:
+                            description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
+                            type: boolean
+                        type: object
+                      hook:
+                        description: Hook will submit any referenced resources to perform the sync. This is the default strategy
+                        properties:
+                          force:
+                            description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
+                            type: boolean
+                        type: object
                     type: object
-                  hook:
-                    type: boolean
-                  kind:
-                    type: string
+                type: object
+            type: object
+          spec:
+            description: ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
+            properties:
+              destination:
+                description: Destination is a reference to the target Kubernetes server and namespace
+                properties:
                   name:
+                    description: Name is an alternate way of specifying the target cluster by its symbolic name
                     type: string
                   namespace:
+                    description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                     type: string
-                  requiresPruning:
-                    type: boolean
-                  status:
-                    description: SyncStatusCode is a type which represents possible comparison results
-                    type: string
-                  version:
+                  server:
+                    description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                     type: string
                 type: object
-              type: array
-            sourceType:
-              type: string
-            summary:
-              properties:
-                externalURLs:
-                  description: ExternalURLs holds all external URLs of application child resources.
-                  items:
-                    type: string
-                  type: array
-                images:
-                  description: Images holds all images of application child resources.
-                  items:
-                    type: string
-                  type: array
-              type: object
-            sync:
-              description: SyncStatus is a comparison result of application spec and deployed application.
-              properties:
-                comparedTo:
-                  description: ComparedTo contains application source and target which was used for resources comparison
+              ignoreDifferences:
+                description: IgnoreDifferences is a list of resources and their fields which should be ignored during comparison
+                items:
+                  description: ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.
                   properties:
-                    destination:
-                      description: ApplicationDestination contains deployment destination information
-                      properties:
-                        name:
-                          description: Name of the destination cluster which can be used instead of server (url) field
+                    group:
+                      type: string
+                    jsonPointers:
+                      items:
+                        type: string
+                      type: array
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                  - jsonPointers
+                  - kind
+                  type: object
+                type: array
+              info:
+                description: Info contains a list of information (URLs, email addresses, and plain text) that relates to the application
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              project:
+                description: Project is a reference to the project this application belongs to. The empty string means that application belongs to the 'default' project.
+                type: string
+              revisionHistoryLimit:
+                description: RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
+                format: int64
+                type: integer
+              source:
+                description: Source is a reference to the location of the application's manifests or chart
+                properties:
+                  chart:
+                    description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
+                    type: string
+                  directory:
+                    description: Directory holds path/directory specific options
+                    properties:
+                      exclude:
+                        description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                        type: string
+                      include:
+                        description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                        type: string
+                      jsonnet:
+                        description: Jsonnet holds options specific to Jsonnet
+                        properties:
+                          extVars:
+                            description: ExtVars is a list of Jsonnet External Variables
+                            items:
+                              description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                              properties:
+                                code:
+                                  type: boolean
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          libs:
+                            description: Additional library search dirs
+                            items:
+                              type: string
+                            type: array
+                          tlas:
+                            description: TLAS is a list of Jsonnet Top-level Arguments
+                            items:
+                              description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                              properties:
+                                code:
+                                  type: boolean
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                        type: object
+                      recurse:
+                        description: Recurse specifies whether to scan a directory recursively for manifests
+                        type: boolean
+                    type: object
+                  helm:
+                    description: Helm holds helm specific options
+                    properties:
+                      fileParameters:
+                        description: FileParameters are file parameters to the helm template
+                        items:
+                          description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
+                          properties:
+                            name:
+                              description: Name is the name of the Helm parameter
+                              type: string
+                            path:
+                              description: Path is the path to the file containing the values for the Helm parameter
+                              type: string
+                          type: object
+                        type: array
+                      parameters:
+                        description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
+                        items:
+                          description: HelmParameter is a parameter that's passed to helm template during manifest generation
+                          properties:
+                            forceString:
+                              description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                              type: boolean
+                            name:
+                              description: Name is the name of the Helm parameter
+                              type: string
+                            value:
+                              description: Value is the value for the Helm parameter
+                              type: string
+                          type: object
+                        type: array
+                      releaseName:
+                        description: ReleaseName is the Helm release name to use. If omitted it will use the application name
+                        type: string
+                      valueFiles:
+                        description: ValuesFiles is a list of Helm value files to use when generating a template
+                        items:
                           type: string
-                        namespace:
-                          description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                        type: array
+                      values:
+                        description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                        type: string
+                      version:
+                        description: Version is the Helm version to use for templating (either "2" or "3")
+                        type: string
+                    type: object
+                  ksonnet:
+                    description: Ksonnet holds ksonnet specific options
+                    properties:
+                      environment:
+                        description: Environment is a ksonnet application environment name
+                        type: string
+                      parameters:
+                        description: Parameters are a list of ksonnet component parameter override values
+                        items:
+                          description: KsonnetParameter is a ksonnet component parameter
+                          properties:
+                            component:
+                              type: string
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                    type: object
+                  kustomize:
+                    description: Kustomize holds kustomize specific options
+                    properties:
+                      commonAnnotations:
+                        additionalProperties:
                           type: string
-                        server:
-                          description: Server overrides the environment server value in the ksonnet app.yaml
+                        description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                        type: object
+                      commonLabels:
+                        additionalProperties:
                           type: string
-                      type: object
+                        description: CommonLabels is a list of additional labels to add to rendered manifests
+                        type: object
+                      images:
+                        description: Images is a list of Kustomize image override specifications
+                        items:
+                          description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
+                          type: string
+                        type: array
+                      namePrefix:
+                        description: NamePrefix is a prefix appended to resources for Kustomize apps
+                        type: string
+                      nameSuffix:
+                        description: NameSuffix is a suffix appended to resources for Kustomize apps
+                        type: string
+                      version:
+                        description: Version controls which version of Kustomize to use for rendering manifests
+                        type: string
+                    type: object
+                  path:
+                    description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
+                    type: string
+                  plugin:
+                    description: ConfigManagementPlugin holds config management plugin specific options
+                    properties:
+                      env:
+                        description: Env is a list of environment variable entries
+                        items:
+                          description: EnvEntry represents an entry in the application's environment
+                          properties:
+                            name:
+                              description: Name is the name of the variable, usually expressed in uppercase
+                              type: string
+                            value:
+                              description: Value is the value of the variable
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      name:
+                        type: string
+                    type: object
+                  repoURL:
+                    description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
+                    type: string
+                  targetRevision:
+                    description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
+                    type: string
+                required:
+                - repoURL
+                type: object
+              syncPolicy:
+                description: SyncPolicy controls when and how a sync will be performed
+                properties:
+                  automated:
+                    description: Automated will keep an application synced to the target revision
+                    properties:
+                      allowEmpty:
+                        description: 'AllowEmpty allows apps have zero live resources (default: false)'
+                        type: boolean
+                      prune:
+                        description: 'Prune specifies whether to delete resources from the cluster that are not found in the sources anymore as part of automated sync (default: false)'
+                        type: boolean
+                      selfHeal:
+                        description: 'SelfHeal specifes whether to revert resources back to their desired state upon modification in the cluster (default: false)'
+                        type: boolean
+                    type: object
+                  retry:
+                    description: Retry controls failed sync retry behavior
+                    properties:
+                      backoff:
+                        description: Backoff controls how to backoff on subsequent retries of failed syncs
+                        properties:
+                          duration:
+                            description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                            type: string
+                          factor:
+                            description: Factor is a factor to multiply the base duration after each failed retry
+                            format: int64
+                            type: integer
+                          maxDuration:
+                            description: MaxDuration is the maximum amount of time allowed for the backoff strategy
+                            type: string
+                        type: object
+                      limit:
+                        description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
+                        format: int64
+                        type: integer
+                    type: object
+                  syncOptions:
+                    description: Options allow you to specify whole app sync-options
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - destination
+            - project
+            - source
+            type: object
+          status:
+            description: ApplicationStatus contains status information for the application
+            properties:
+              conditions:
+                description: Conditions is a list of currently observed application conditions
+                items:
+                  description: ApplicationCondition contains details about an application condition, which is usally an error or warning
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the time the condition was last observed
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message contains human-readable message indicating details about condition
+                      type: string
+                    type:
+                      description: Type is an application condition type
+                      type: string
+                  required:
+                  - message
+                  - type
+                  type: object
+                type: array
+              health:
+                description: Health contains information about the application's current health status
+                properties:
+                  message:
+                    description: Message is a human-readable informational message describing the health status
+                    type: string
+                  status:
+                    description: Status holds the status code of the application or resource
+                    type: string
+                type: object
+              history:
+                description: History contains information about the application's sync history
+                items:
+                  description: RevisionHistory contains history information about a previous sync
+                  properties:
+                    deployStartedAt:
+                      description: DeployStartedAt holds the time the sync operation started
+                      format: date-time
+                      type: string
+                    deployedAt:
+                      description: DeployedAt holds the time the sync operation completed
+                      format: date-time
+                      type: string
+                    id:
+                      description: ID is an auto incrementing identifier of the RevisionHistory
+                      format: int64
+                      type: integer
+                    revision:
+                      description: Revision holds the revision the sync was performed against
+                      type: string
                     source:
-                      description: ApplicationSource contains information about github repository, path within repository and target application environment.
+                      description: Source is a reference to the application source used for the sync operation
                       properties:
                         chart:
-                          description: Chart is a Helm chart name
+                          description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                           type: string
                         directory:
                           description: Directory holds path/directory specific options
                           properties:
+                            exclude:
+                              description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                              type: string
+                            include:
+                              description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                              type: string
                             jsonnet:
-                              description: ApplicationSourceJsonnet holds jsonnet specific options
+                              description: Jsonnet holds options specific to Jsonnet
                               properties:
                                 extVars:
                                   description: ExtVars is a list of Jsonnet External Variables
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1459,7 +737,7 @@ spec:
                                 tlas:
                                   description: TLAS is a list of Jsonnet Top-level Arguments
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1474,6 +752,7 @@ spec:
                                   type: array
                               type: object
                             recurse:
+                              description: Recurse specifies whether to scan a directory recursively for manifests
                               type: boolean
                           type: object
                         helm:
@@ -1482,34 +761,34 @@ spec:
                             fileParameters:
                               description: FileParameters are file parameters to the helm template
                               items:
-                                description: HelmFileParameter is a file parameter to a helm template
+                                description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                 properties:
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   path:
-                                    description: Path is the path value for the helm parameter
+                                    description: Path is the path to the file containing the values for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             parameters:
-                              description: Parameters are parameters to the helm template
+                              description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                               items:
-                                description: HelmParameter is a parameter to a helm template
+                                description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                 properties:
                                   forceString:
                                     description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                     type: boolean
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   value:
-                                    description: Value is the value for the helm parameter
+                                    description: Value is the value for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             releaseName:
-                              description: The Helm release name. If omitted it will use the application name
+                              description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                               type: string
                             valueFiles:
                               description: ValuesFiles is a list of Helm value files to use when generating a template
@@ -1517,7 +796,10 @@ spec:
                                 type: string
                               type: array
                             values:
-                              description: Values is Helm values, typically defined as a block
+                              description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                              type: string
+                            version:
+                              description: Version is the Helm version to use for templating (either "2" or "3")
                               type: string
                           type: object
                         ksonnet:
@@ -1546,40 +828,48 @@ spec:
                         kustomize:
                           description: Kustomize holds kustomize specific options
                           properties:
+                            commonAnnotations:
+                              additionalProperties:
+                                type: string
+                              description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                              type: object
                             commonLabels:
                               additionalProperties:
                                 type: string
-                              description: CommonLabels adds additional kustomize commonLabels
+                              description: CommonLabels is a list of additional labels to add to rendered manifests
                               type: object
                             images:
-                              description: Images are kustomize image overrides
+                              description: Images is a list of Kustomize image override specifications
                               items:
+                                description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                 type: string
                               type: array
                             namePrefix:
-                              description: NamePrefix is a prefix appended to resources for kustomize apps
+                              description: NamePrefix is a prefix appended to resources for Kustomize apps
                               type: string
                             nameSuffix:
-                              description: NameSuffix is a suffix appended to resources for kustomize apps
+                              description: NameSuffix is a suffix appended to resources for Kustomize apps
                               type: string
                             version:
-                              description: Version contains optional Kustomize version
+                              description: Version controls which version of Kustomize to use for rendering manifests
                               type: string
                           type: object
                         path:
-                          description: Path is a directory path within the Git repository
+                          description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                           type: string
                         plugin:
                           description: ConfigManagementPlugin holds config management plugin specific options
                           properties:
                             env:
+                              description: Env is a list of environment variable entries
                               items:
+                                description: EnvEntry represents an entry in the application's environment
                                 properties:
                                   name:
-                                    description: the name, usually uppercase
+                                    description: Name is the name of the variable, usually expressed in uppercase
                                     type: string
                                   value:
-                                    description: the value
+                                    description: Value is the value of the variable
                                     type: string
                                 required:
                                 - name
@@ -1590,33 +880,881 @@ spec:
                               type: string
                           type: object
                         repoURL:
-                          description: RepoURL is the repository URL of the application manifests
+                          description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                          description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
                       type: object
                   required:
-                  - destination
-                  - source
+                  - deployedAt
+                  - id
+                  - revision
                   type: object
-                revision:
-                  type: string
-                status:
-                  description: SyncStatusCode is a type which represents possible comparison results
-                  type: string
-              required:
-              - status
-              type: object
-          type: object
-      required:
-      - metadata
-      - spec
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+                type: array
+              observedAt:
+                description: 'ObservedAt indicates when the application state was updated without querying latest git state Deprecated: controller no longer updates ObservedAt field'
+                format: date-time
+                type: string
+              operationState:
+                description: OperationState contains information about any ongoing operations, such as a sync
+                properties:
+                  finishedAt:
+                    description: FinishedAt contains time of operation completion
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message holds any pertinent messages when attempting to perform operation (typically errors).
+                    type: string
+                  operation:
+                    description: Operation is the original requested operation
+                    properties:
+                      info:
+                        description: Info is a list of informational items for this operation
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      initiatedBy:
+                        description: InitiatedBy contains information about who initiated the operations
+                        properties:
+                          automated:
+                            description: Automated is set to true if operation was initiated automatically by the application controller.
+                            type: boolean
+                          username:
+                            description: Username contains the name of a user who started operation
+                            type: string
+                        type: object
+                      retry:
+                        description: Retry controls the strategy to apply if a sync fails
+                        properties:
+                          backoff:
+                            description: Backoff controls how to backoff on subsequent retries of failed syncs
+                            properties:
+                              duration:
+                                description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                                type: string
+                              factor:
+                                description: Factor is a factor to multiply the base duration after each failed retry
+                                format: int64
+                                type: integer
+                              maxDuration:
+                                description: MaxDuration is the maximum amount of time allowed for the backoff strategy
+                                type: string
+                            type: object
+                          limit:
+                            description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
+                            format: int64
+                            type: integer
+                        type: object
+                      sync:
+                        description: Sync contains parameters for the operation
+                        properties:
+                          dryRun:
+                            description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
+                            type: boolean
+                          manifests:
+                            description: Manifests is an optional field that overrides sync source with a local directory for development
+                            items:
+                              type: string
+                            type: array
+                          prune:
+                            description: Prune specifies to delete resources from the cluster that are no longer tracked in git
+                            type: boolean
+                          resources:
+                            description: Resources describes which resources shall be part of the sync
+                            items:
+                              description: SyncOperationResource contains resources to sync.
+                              properties:
+                                group:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            type: array
+                          revision:
+                            description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
+                            type: string
+                          source:
+                            description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
+                            properties:
+                              chart:
+                                description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
+                                type: string
+                              directory:
+                                description: Directory holds path/directory specific options
+                                properties:
+                                  exclude:
+                                    description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                                    type: string
+                                  include:
+                                    description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                                    type: string
+                                  jsonnet:
+                                    description: Jsonnet holds options specific to Jsonnet
+                                    properties:
+                                      extVars:
+                                        description: ExtVars is a list of Jsonnet External Variables
+                                        items:
+                                          description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      libs:
+                                        description: Additional library search dirs
+                                        items:
+                                          type: string
+                                        type: array
+                                      tlas:
+                                        description: TLAS is a list of Jsonnet Top-level Arguments
+                                        items:
+                                          description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                    type: object
+                                  recurse:
+                                    description: Recurse specifies whether to scan a directory recursively for manifests
+                                    type: boolean
+                                type: object
+                              helm:
+                                description: Helm holds helm specific options
+                                properties:
+                                  fileParameters:
+                                    description: FileParameters are file parameters to the helm template
+                                    items:
+                                      description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
+                                      properties:
+                                        name:
+                                          description: Name is the name of the Helm parameter
+                                          type: string
+                                        path:
+                                          description: Path is the path to the file containing the values for the Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  parameters:
+                                    description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
+                                    items:
+                                      description: HelmParameter is a parameter that's passed to helm template during manifest generation
+                                      properties:
+                                        forceString:
+                                          description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                                          type: boolean
+                                        name:
+                                          description: Name is the name of the Helm parameter
+                                          type: string
+                                        value:
+                                          description: Value is the value for the Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  releaseName:
+                                    description: ReleaseName is the Helm release name to use. If omitted it will use the application name
+                                    type: string
+                                  valueFiles:
+                                    description: ValuesFiles is a list of Helm value files to use when generating a template
+                                    items:
+                                      type: string
+                                    type: array
+                                  values:
+                                    description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                                    type: string
+                                  version:
+                                    description: Version is the Helm version to use for templating (either "2" or "3")
+                                    type: string
+                                type: object
+                              ksonnet:
+                                description: Ksonnet holds ksonnet specific options
+                                properties:
+                                  environment:
+                                    description: Environment is a ksonnet application environment name
+                                    type: string
+                                  parameters:
+                                    description: Parameters are a list of ksonnet component parameter override values
+                                    items:
+                                      description: KsonnetParameter is a ksonnet component parameter
+                                      properties:
+                                        component:
+                                          type: string
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                type: object
+                              kustomize:
+                                description: Kustomize holds kustomize specific options
+                                properties:
+                                  commonAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                                    type: object
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels is a list of additional labels to add to rendered manifests
+                                    type: object
+                                  images:
+                                    description: Images is a list of Kustomize image override specifications
+                                    items:
+                                      description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                      type: string
+                                    type: array
+                                  namePrefix:
+                                    description: NamePrefix is a prefix appended to resources for Kustomize apps
+                                    type: string
+                                  nameSuffix:
+                                    description: NameSuffix is a suffix appended to resources for Kustomize apps
+                                    type: string
+                                  version:
+                                    description: Version controls which version of Kustomize to use for rendering manifests
+                                    type: string
+                                type: object
+                              path:
+                                description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
+                                type: string
+                              plugin:
+                                description: ConfigManagementPlugin holds config management plugin specific options
+                                properties:
+                                  env:
+                                    description: Env is a list of environment variable entries
+                                    items:
+                                      description: EnvEntry represents an entry in the application's environment
+                                      properties:
+                                        name:
+                                          description: Name is the name of the variable, usually expressed in uppercase
+                                          type: string
+                                        value:
+                                          description: Value is the value of the variable
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                type: object
+                              repoURL:
+                                description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
+                                type: string
+                              targetRevision:
+                                description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
+                                type: string
+                            required:
+                            - repoURL
+                            type: object
+                          syncOptions:
+                            description: SyncOptions provide per-sync sync-options, e.g. Validate=false
+                            items:
+                              type: string
+                            type: array
+                          syncStrategy:
+                            description: SyncStrategy describes how to perform the sync
+                            properties:
+                              apply:
+                                description: Apply will perform a `kubectl apply` to perform the sync.
+                                properties:
+                                  force:
+                                    description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
+                                    type: boolean
+                                type: object
+                              hook:
+                                description: Hook will submit any referenced resources to perform the sync. This is the default strategy
+                                properties:
+                                  force:
+                                    description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
+                                    type: boolean
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  phase:
+                    description: Phase is the current phase of the operation
+                    type: string
+                  retryCount:
+                    description: RetryCount contains time of operation retries
+                    format: int64
+                    type: integer
+                  startedAt:
+                    description: StartedAt contains time of operation start
+                    format: date-time
+                    type: string
+                  syncResult:
+                    description: SyncResult is the result of a Sync operation
+                    properties:
+                      resources:
+                        description: Resources contains a list of sync result items for each individual resource in a sync operation
+                        items:
+                          description: ResourceResult holds the operation result details of a specific resource
+                          properties:
+                            group:
+                              description: Group specifies the API group of the resource
+                              type: string
+                            hookPhase:
+                              description: HookPhase contains the state of any operation associated with this resource OR hook This can also contain values for non-hook resources.
+                              type: string
+                            hookType:
+                              description: HookType specifies the type of the hook. Empty for non-hook resources
+                              type: string
+                            kind:
+                              description: Kind specifies the API kind of the resource
+                              type: string
+                            message:
+                              description: Message contains an informational or error message for the last sync OR operation
+                              type: string
+                            name:
+                              description: Name specifies the name of the resource
+                              type: string
+                            namespace:
+                              description: Namespace specifies the target namespace of the resource
+                              type: string
+                            status:
+                              description: Status holds the final result of the sync. Will be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
+                              type: string
+                            syncPhase:
+                              description: SyncPhase indicates the particular phase of the sync that this result was acquired in
+                              type: string
+                            version:
+                              description: Version specifies the API version of the resource
+                              type: string
+                          required:
+                          - group
+                          - kind
+                          - name
+                          - namespace
+                          - version
+                          type: object
+                        type: array
+                      revision:
+                        description: Revision holds the revision this sync operation was performed to
+                        type: string
+                      source:
+                        description: Source records the application source information of the sync, used for comparing auto-sync
+                        properties:
+                          chart:
+                            description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
+                            type: string
+                          directory:
+                            description: Directory holds path/directory specific options
+                            properties:
+                              exclude:
+                                description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                                type: string
+                              include:
+                                description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                                type: string
+                              jsonnet:
+                                description: Jsonnet holds options specific to Jsonnet
+                                properties:
+                                  extVars:
+                                    description: ExtVars is a list of Jsonnet External Variables
+                                    items:
+                                      description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  libs:
+                                    description: Additional library search dirs
+                                    items:
+                                      type: string
+                                    type: array
+                                  tlas:
+                                    description: TLAS is a list of Jsonnet Top-level Arguments
+                                    items:
+                                      description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                type: object
+                              recurse:
+                                description: Recurse specifies whether to scan a directory recursively for manifests
+                                type: boolean
+                            type: object
+                          helm:
+                            description: Helm holds helm specific options
+                            properties:
+                              fileParameters:
+                                description: FileParameters are file parameters to the helm template
+                                items:
+                                  description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
+                                  properties:
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    path:
+                                      description: Path is the path to the file containing the values for the Helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              parameters:
+                                description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
+                                items:
+                                  description: HelmParameter is a parameter that's passed to helm template during manifest generation
+                                  properties:
+                                    forceString:
+                                      description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                                      type: boolean
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    value:
+                                      description: Value is the value for the Helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              releaseName:
+                                description: ReleaseName is the Helm release name to use. If omitted it will use the application name
+                                type: string
+                              valueFiles:
+                                description: ValuesFiles is a list of Helm value files to use when generating a template
+                                items:
+                                  type: string
+                                type: array
+                              values:
+                                description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                                type: string
+                              version:
+                                description: Version is the Helm version to use for templating (either "2" or "3")
+                                type: string
+                            type: object
+                          ksonnet:
+                            description: Ksonnet holds ksonnet specific options
+                            properties:
+                              environment:
+                                description: Environment is a ksonnet application environment name
+                                type: string
+                              parameters:
+                                description: Parameters are a list of ksonnet component parameter override values
+                                items:
+                                  description: KsonnetParameter is a ksonnet component parameter
+                                  properties:
+                                    component:
+                                      type: string
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          kustomize:
+                            description: Kustomize holds kustomize specific options
+                            properties:
+                              commonAnnotations:
+                                additionalProperties:
+                                  type: string
+                                description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                                type: object
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                description: CommonLabels is a list of additional labels to add to rendered manifests
+                                type: object
+                              images:
+                                description: Images is a list of Kustomize image override specifications
+                                items:
+                                  description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                  type: string
+                                type: array
+                              namePrefix:
+                                description: NamePrefix is a prefix appended to resources for Kustomize apps
+                                type: string
+                              nameSuffix:
+                                description: NameSuffix is a suffix appended to resources for Kustomize apps
+                                type: string
+                              version:
+                                description: Version controls which version of Kustomize to use for rendering manifests
+                                type: string
+                            type: object
+                          path:
+                            description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
+                            type: string
+                          plugin:
+                            description: ConfigManagementPlugin holds config management plugin specific options
+                            properties:
+                              env:
+                                description: Env is a list of environment variable entries
+                                items:
+                                  description: EnvEntry represents an entry in the application's environment
+                                  properties:
+                                    name:
+                                      description: Name is the name of the variable, usually expressed in uppercase
+                                      type: string
+                                    value:
+                                      description: Value is the value of the variable
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                            type: object
+                          repoURL:
+                            description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
+                            type: string
+                          targetRevision:
+                            description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
+                            type: string
+                        required:
+                        - repoURL
+                        type: object
+                    required:
+                    - revision
+                    type: object
+                required:
+                - operation
+                - phase
+                - startedAt
+                type: object
+              reconciledAt:
+                description: ReconciledAt indicates when the application state was reconciled using the latest git version
+                format: date-time
+                type: string
+              resources:
+                description: Resources is a list of Kubernetes resources managed by this application
+                items:
+                  description: 'ResourceStatus holds the current sync and health status of a resource TODO: describe members of this type'
+                  properties:
+                    group:
+                      type: string
+                    health:
+                      description: HealthStatus contains information about the currently observed health state of an application or resource
+                      properties:
+                        message:
+                          description: Message is a human-readable informational message describing the health status
+                          type: string
+                        status:
+                          description: Status holds the status code of the application or resource
+                          type: string
+                      type: object
+                    hook:
+                      type: boolean
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    requiresPruning:
+                      type: boolean
+                    status:
+                      description: SyncStatusCode is a type which represents possible comparison results
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                type: array
+              sourceType:
+                description: SourceType specifies the type of this application
+                type: string
+              summary:
+                description: Summary contains a list of URLs and container images used by this application
+                properties:
+                  externalURLs:
+                    description: ExternalURLs holds all external URLs of application child resources.
+                    items:
+                      type: string
+                    type: array
+                  images:
+                    description: Images holds all images of application child resources.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              sync:
+                description: Sync contains information about the application's current sync status
+                properties:
+                  comparedTo:
+                    description: ComparedTo contains information about what has been compared
+                    properties:
+                      destination:
+                        description: Destination is a reference to the application's destination used for comparison
+                        properties:
+                          name:
+                            description: Name is an alternate way of specifying the target cluster by its symbolic name
+                            type: string
+                          namespace:
+                            description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
+                            type: string
+                          server:
+                            description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
+                            type: string
+                        type: object
+                      source:
+                        description: Source is a reference to the application's source used for comparison
+                        properties:
+                          chart:
+                            description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
+                            type: string
+                          directory:
+                            description: Directory holds path/directory specific options
+                            properties:
+                              exclude:
+                                description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                                type: string
+                              include:
+                                description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                                type: string
+                              jsonnet:
+                                description: Jsonnet holds options specific to Jsonnet
+                                properties:
+                                  extVars:
+                                    description: ExtVars is a list of Jsonnet External Variables
+                                    items:
+                                      description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  libs:
+                                    description: Additional library search dirs
+                                    items:
+                                      type: string
+                                    type: array
+                                  tlas:
+                                    description: TLAS is a list of Jsonnet Top-level Arguments
+                                    items:
+                                      description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                type: object
+                              recurse:
+                                description: Recurse specifies whether to scan a directory recursively for manifests
+                                type: boolean
+                            type: object
+                          helm:
+                            description: Helm holds helm specific options
+                            properties:
+                              fileParameters:
+                                description: FileParameters are file parameters to the helm template
+                                items:
+                                  description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
+                                  properties:
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    path:
+                                      description: Path is the path to the file containing the values for the Helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              parameters:
+                                description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
+                                items:
+                                  description: HelmParameter is a parameter that's passed to helm template during manifest generation
+                                  properties:
+                                    forceString:
+                                      description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                                      type: boolean
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    value:
+                                      description: Value is the value for the Helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              releaseName:
+                                description: ReleaseName is the Helm release name to use. If omitted it will use the application name
+                                type: string
+                              valueFiles:
+                                description: ValuesFiles is a list of Helm value files to use when generating a template
+                                items:
+                                  type: string
+                                type: array
+                              values:
+                                description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                                type: string
+                              version:
+                                description: Version is the Helm version to use for templating (either "2" or "3")
+                                type: string
+                            type: object
+                          ksonnet:
+                            description: Ksonnet holds ksonnet specific options
+                            properties:
+                              environment:
+                                description: Environment is a ksonnet application environment name
+                                type: string
+                              parameters:
+                                description: Parameters are a list of ksonnet component parameter override values
+                                items:
+                                  description: KsonnetParameter is a ksonnet component parameter
+                                  properties:
+                                    component:
+                                      type: string
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          kustomize:
+                            description: Kustomize holds kustomize specific options
+                            properties:
+                              commonAnnotations:
+                                additionalProperties:
+                                  type: string
+                                description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                                type: object
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                description: CommonLabels is a list of additional labels to add to rendered manifests
+                                type: object
+                              images:
+                                description: Images is a list of Kustomize image override specifications
+                                items:
+                                  description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                  type: string
+                                type: array
+                              namePrefix:
+                                description: NamePrefix is a prefix appended to resources for Kustomize apps
+                                type: string
+                              nameSuffix:
+                                description: NameSuffix is a suffix appended to resources for Kustomize apps
+                                type: string
+                              version:
+                                description: Version controls which version of Kustomize to use for rendering manifests
+                                type: string
+                            type: object
+                          path:
+                            description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
+                            type: string
+                          plugin:
+                            description: ConfigManagementPlugin holds config management plugin specific options
+                            properties:
+                              env:
+                                description: Env is a list of environment variable entries
+                                items:
+                                  description: EnvEntry represents an entry in the application's environment
+                                  properties:
+                                    name:
+                                      description: Name is the name of the variable, usually expressed in uppercase
+                                      type: string
+                                    value:
+                                      description: Value is the value of the variable
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                            type: object
+                          repoURL:
+                            description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
+                            type: string
+                          targetRevision:
+                            description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
+                            type: string
+                        required:
+                        - repoURL
+                        type: object
+                    required:
+                    - destination
+                    - source
+                    type: object
+                  revision:
+                    description: Revision contains information about the revision the comparison has been performed to
+                    type: string
+                  status:
+                    description: Status is the sync state of the comparison
+                    type: string
+                required:
+                - status
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
     served: true
     storage: true
+    subresources: {}

--- a/deploy/crds/argoproj.io_appprojects_crd.yaml
+++ b/deploy/crds/argoproj.io_appprojects_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -16,214 +16,242 @@ spec:
     - appprojs
     singular: appproject
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: 'AppProject provides a logical grouping of applications, providing controls for: * where the apps may deploy to (cluster whitelist) * what may be deployed (repository whitelist, resource whitelist/blacklist) * who can access these applications (roles, OIDC group claims bindings) * and what they can do (RBAC policies) * automation access to these roles (JWT tokens)'
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: AppProjectSpec is the specification of an AppProject
-          properties:
-            clusterResourceBlacklist:
-              description: ClusterResourceBlacklist contains list of blacklisted cluster level resources
-              items:
-                description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
-                properties:
-                  group:
-                    type: string
-                  kind:
-                    type: string
-                required:
-                - group
-                - kind
-                type: object
-              type: array
-            clusterResourceWhitelist:
-              description: ClusterResourceWhitelist contains list of whitelisted cluster level resources
-              items:
-                description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
-                properties:
-                  group:
-                    type: string
-                  kind:
-                    type: string
-                required:
-                - group
-                - kind
-                type: object
-              type: array
-            description:
-              description: Description contains optional project description
-              type: string
-            destinations:
-              description: Destinations contains list of destinations available for deployment
-              items:
-                description: ApplicationDestination contains deployment destination information
-                properties:
-                  name:
-                    description: Name of the destination cluster which can be used instead of server (url) field
-                    type: string
-                  namespace:
-                    description: Namespace overrides the environment namespace value in the ksonnet app.yaml
-                    type: string
-                  server:
-                    description: Server overrides the environment server value in the ksonnet app.yaml
-                    type: string
-                type: object
-              type: array
-            namespaceResourceBlacklist:
-              description: NamespaceResourceBlacklist contains list of blacklisted namespace level resources
-              items:
-                description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
-                properties:
-                  group:
-                    type: string
-                  kind:
-                    type: string
-                required:
-                - group
-                - kind
-                type: object
-              type: array
-            namespaceResourceWhitelist:
-              description: NamespaceResourceWhitelist contains list of whitelisted namespace level resources
-              items:
-                description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
-                properties:
-                  group:
-                    type: string
-                  kind:
-                    type: string
-                required:
-                - group
-                - kind
-                type: object
-              type: array
-            orphanedResources:
-              description: OrphanedResources specifies if controller should monitor orphaned resources of apps in this project
-              properties:
-                ignore:
-                  items:
-                    properties:
-                      group:
-                        type: string
-                      kind:
-                        type: string
-                      name:
-                        type: string
-                    type: object
-                  type: array
-                warn:
-                  description: Warn indicates if warning condition should be created for apps which have orphaned resources
-                  type: boolean
-              type: object
-            roles:
-              description: Roles are user defined RBAC roles associated with this project
-              items:
-                description: ProjectRole represents a role that has access to a project
-                properties:
-                  description:
-                    description: Description is a description of the role
-                    type: string
-                  groups:
-                    description: Groups are a list of OIDC group claims bound to this role
-                    items:
-                      type: string
-                    type: array
-                  jwtTokens:
-                    description: JWTTokens are a list of generated JWT tokens bound to this role
-                    items:
-                      description: JWTToken holds the issuedAt and expiresAt values of a token
-                      properties:
-                        exp:
-                          format: int64
-                          type: integer
-                        iat:
-                          format: int64
-                          type: integer
-                        id:
-                          type: string
-                      required:
-                      - iat
-                      type: object
-                    type: array
-                  name:
-                    description: Name is a name for this role
-                    type: string
-                  policies:
-                    description: Policies Stores a list of casbin formated strings that define access policies for the role in the project
-                    items:
-                      type: string
-                    type: array
-                required:
-                - name
-                type: object
-              type: array
-            signatureKeys:
-              description: List of PGP key IDs that commits to be synced to must be signed with
-              items:
-                description: SignatureKey is the specification of a key required to verify commit signatures with
-                properties:
-                  keyID:
-                    description: The ID of the key in hexadecimal notation
-                    type: string
-                required:
-                - keyID
-                type: object
-              type: array
-            sourceRepos:
-              description: SourceRepos contains list of repository URLs which can be used for deployment
-              items:
-                type: string
-              type: array
-            syncWindows:
-              description: SyncWindows controls when syncs can be run for apps in this project
-              items:
-                description: SyncWindow contains the kind, time, duration and attributes that are used to assign the syncWindows to apps
-                properties:
-                  applications:
-                    description: Applications contains a list of applications that the window will apply to
-                    items:
-                      type: string
-                    type: array
-                  clusters:
-                    description: Clusters contains a list of clusters that the window will apply to
-                    items:
-                      type: string
-                    type: array
-                  duration:
-                    description: Duration is the amount of time the sync window will be open
-                    type: string
-                  kind:
-                    description: Kind defines if the window allows or blocks syncs
-                    type: string
-                  manualSync:
-                    description: ManualSync enables manual syncs when they would otherwise be blocked
-                    type: boolean
-                  namespaces:
-                    description: Namespaces contains a list of namespaces that the window will apply to
-                    items:
-                      type: string
-                    type: array
-                  schedule:
-                    description: Schedule is the time the window will begin, specified in cron format
-                    type: string
-                type: object
-              type: array
-          type: object
-      required:
-      - metadata
-      - spec
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'AppProject provides a logical grouping of applications, providing controls for: * where the apps may deploy to (cluster whitelist) * what may be deployed (repository whitelist, resource whitelist/blacklist) * who can access these applications (roles, OIDC group claims bindings) * and what they can do (RBAC policies) * automation access to these roles (JWT tokens)'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AppProjectSpec is the specification of an AppProject
+            properties:
+              clusterResourceBlacklist:
+                description: ClusterResourceBlacklist contains list of blacklisted cluster level resources
+                items:
+                  description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                type: array
+              clusterResourceWhitelist:
+                description: ClusterResourceWhitelist contains list of whitelisted cluster level resources
+                items:
+                  description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                type: array
+              description:
+                description: Description contains optional project description
+                type: string
+              destinations:
+                description: Destinations contains list of destinations available for deployment
+                items:
+                  description: ApplicationDestination holds information about the application's destination
+                  properties:
+                    name:
+                      description: Name is an alternate way of specifying the target cluster by its symbolic name
+                      type: string
+                    namespace:
+                      description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
+                      type: string
+                    server:
+                      description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
+                      type: string
+                  type: object
+                type: array
+              namespaceResourceBlacklist:
+                description: NamespaceResourceBlacklist contains list of blacklisted namespace level resources
+                items:
+                  description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                type: array
+              namespaceResourceWhitelist:
+                description: NamespaceResourceWhitelist contains list of whitelisted namespace level resources
+                items:
+                  description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                type: array
+              orphanedResources:
+                description: OrphanedResources specifies if controller should monitor orphaned resources of apps in this project
+                properties:
+                  ignore:
+                    description: Ignore contains a list of resources that are to be excluded from orphaned resources monitoring
+                    items:
+                      description: OrphanedResourceKey is a reference to a resource to be ignored from
+                      properties:
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  warn:
+                    description: Warn indicates if warning condition should be created for apps which have orphaned resources
+                    type: boolean
+                type: object
+              roles:
+                description: Roles are user defined RBAC roles associated with this project
+                items:
+                  description: ProjectRole represents a role that has access to a project
+                  properties:
+                    description:
+                      description: Description is a description of the role
+                      type: string
+                    groups:
+                      description: Groups are a list of OIDC group claims bound to this role
+                      items:
+                        type: string
+                      type: array
+                    jwtTokens:
+                      description: JWTTokens are a list of generated JWT tokens bound to this role
+                      items:
+                        description: JWTToken holds the issuedAt and expiresAt values of a token
+                        properties:
+                          exp:
+                            format: int64
+                            type: integer
+                          iat:
+                            format: int64
+                            type: integer
+                          id:
+                            type: string
+                        required:
+                        - iat
+                        type: object
+                      type: array
+                    name:
+                      description: Name is a name for this role
+                      type: string
+                    policies:
+                      description: Policies Stores a list of casbin formated strings that define access policies for the role in the project
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  type: object
+                type: array
+              signatureKeys:
+                description: SignatureKeys contains a list of PGP key IDs that commits in Git must be signed with in order to be allowed for sync
+                items:
+                  description: SignatureKey is the specification of a key required to verify commit signatures with
+                  properties:
+                    keyID:
+                      description: The ID of the key in hexadecimal notation
+                      type: string
+                  required:
+                  - keyID
+                  type: object
+                type: array
+              sourceRepos:
+                description: SourceRepos contains list of repository URLs which can be used for deployment
+                items:
+                  type: string
+                type: array
+              syncWindows:
+                description: SyncWindows controls when syncs can be run for apps in this project
+                items:
+                  description: SyncWindow contains the kind, time, duration and attributes that are used to assign the syncWindows to apps
+                  properties:
+                    applications:
+                      description: Applications contains a list of applications that the window will apply to
+                      items:
+                        type: string
+                      type: array
+                    clusters:
+                      description: Clusters contains a list of clusters that the window will apply to
+                      items:
+                        type: string
+                      type: array
+                    duration:
+                      description: Duration is the amount of time the sync window will be open
+                      type: string
+                    kind:
+                      description: Kind defines if the window allows or blocks syncs
+                      type: string
+                    manualSync:
+                      description: ManualSync enables manual syncs when they would otherwise be blocked
+                      type: boolean
+                    namespaces:
+                      description: Namespaces contains a list of namespaces that the window will apply to
+                      items:
+                        type: string
+                      type: array
+                    schedule:
+                      description: Schedule is the time the window will begin, specified in cron format
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: AppProjectStatus contains status information for AppProject CRs
+            properties:
+              jwtTokensByRole:
+                additionalProperties:
+                  description: JWTTokens represents a list of JWT tokens
+                  properties:
+                    items:
+                      items:
+                        description: JWTToken holds the issuedAt and expiresAt values of a token
+                        properties:
+                          exp:
+                            format: int64
+                            type: integer
+                          iat:
+                            format: int64
+                            type: integer
+                          id:
+                            type: string
+                        required:
+                        - iat
+                        type: object
+                      type: array
+                  type: object
+                description: JWTTokensByRole contains a list of JWT tokens issued for a given role
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
     served: true
     storage: true

--- a/deploy/crds/pipelines.openshift.io_gitopsservices_crd.yaml
+++ b/deploy/crds/pipelines.openshift.io_gitopsservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: gitopsservices.pipelines.openshift.io
@@ -12,31 +12,30 @@ spec:
   scope: Cluster
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      description: GitopsService is the Schema for the gitopsservices API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: GitopsServiceSpec defines the desired state of GitopsService
-          type: object
-        status:
-          description: GitopsServiceStatus defines the observed state of GitopsService
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: GitopsService is the Schema for the gitopsservices API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GitopsServiceSpec defines the desired state of GitopsService
+            type: object
+          status:
+            description: GitopsServiceStatus defines the observed state of GitopsService
+            type: object
+        type: object
     served: true
     storage: true

--- a/deploy/olm-catalog/gitops-operator/manifests/pipelines.openshift.io_gitopsservices_crd.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/pipelines.openshift.io_gitopsservices_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: gitopsservices.pipelines.openshift.io
@@ -12,31 +12,30 @@ spec:
   scope: Cluster
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      description: GitopsService is the Schema for the gitopsservices API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: GitopsServiceSpec defines the desired state of GitopsService
-          type: object
-        status:
-          description: GitopsServiceStatus defines the observed state of GitopsService
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: GitopsService is the Schema for the gitopsservices API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GitopsServiceSpec defines the desired state of GitopsService
+            type: object
+          status:
+            description: GitopsServiceStatus defines the observed state of GitopsService
+            type: object
+        type: object
     served: true
     storage: true

--- a/deploy/olm-catalog/gitops-operator/metadata/annotations.yaml
+++ b/deploy/olm-catalog/gitops-operator/metadata/annotations.yaml
@@ -5,3 +5,6 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: gitops-operator
+  operators.operatorframework.io.metrics.builder: operator-sdk-v0.19.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
/kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
This PR upgrades current CRDs from apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1beta1 so that operator becomes compliant with OCP 4.9 which uses k8s v1.22 and doesn't support the v1beta1 version of CRD

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-1296

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
