### PR TITLE
feat: Configure OpenShift Login for Dex OOTB

### DIFF
--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -48,6 +48,7 @@ metadata:
               }
             },
             "dex": {
+              "openShiftOAuth": true,
               "resources": {
                 "limits": {
                   "cpu": "500m",
@@ -71,6 +72,11 @@ metadata:
                   "memory": "128Mi"
                 }
               }
+            },
+            "rbac": {
+              "defaultPolicy": "",
+              "policy": "g, system:cluster-admins, role:admin\n",
+              "scopes": "[groups]"
             },
             "redis": {
               "resources": {

--- a/config/samples/argoproj.io_v1alpha1_argocd.yaml
+++ b/config/samples/argoproj.io_v1alpha1_argocd.yaml
@@ -22,6 +22,7 @@ spec:
         cpu: 250m
         memory: 256Mi
   dex:
+    openShiftOAuth: true
     resources:
       limits:
         cpu: 500m
@@ -38,6 +39,11 @@ spec:
       requests:
         cpu: 250m
         memory: 128Mi
+  rbac:
+    defaultPolicy: ''
+    policy: |
+      g, system:cluster-admins, role:admin
+    scopes: '[groups]'
   redis:
     resources:
       limits:

--- a/controllers/argocd/argocd.go
+++ b/controllers/argocd/argocd.go
@@ -25,6 +25,11 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+var (
+	defaultAdminPolicy = "g, system:cluster-admins, role:admin"
+	defaultScope       = "[groups]"
+)
+
 // resource exclusions for the ArgoCD CR.
 type resource struct {
 	APIGroups []string `json:"apiGroups"`
@@ -64,6 +69,7 @@ func getArgoControllerSpec() argoapp.ArgoCDApplicationControllerSpec {
 
 func getArgoDexSpec() argoapp.ArgoCDDexSpec {
 	return argoapp.ArgoCDDexSpec{
+		OpenShiftOAuth: true,
 		Resources: &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
 				v1.ResourceMemory: resourcev1.MustParse("128Mi"),
@@ -154,6 +160,13 @@ func getArgoServerSpec() argoapp.ArgoCDServerSpec {
 	}
 }
 
+func getDefaultRBAC() argoapp.ArgoCDRBACSpec {
+	return argoapp.ArgoCDRBACSpec{
+		Policy: &defaultAdminPolicy,
+		Scopes: &defaultScope,
+	}
+}
+
 // NewCR returns an ArgoCD reference optimized for use in OpenShift
 // with Tekton
 func NewCR(name, ns string) (*argoapp.ArgoCD, error) {
@@ -178,15 +191,15 @@ func NewCR(name, ns string) (*argoapp.ArgoCD, error) {
 			Namespace: ns,
 		},
 		Spec: argoapp.ArgoCDSpec{
-			ApplicationSet: getArgoApplicationSetSpec(),
-			Controller:     getArgoControllerSpec(),
-			Dex:            getArgoDexSpec(),
-			Grafana:        getArgoGrafanaSpec(),
-			HA:             getArgoHASpec(),
-			Redis:          getArgoRedisSpec(),
-			Repo:           getArgoRepoServerSpec(),
-			Server:         getArgoServerSpec(),
-
+			ApplicationSet:     getArgoApplicationSetSpec(),
+			Controller:         getArgoControllerSpec(),
+			Dex:                getArgoDexSpec(),
+			Grafana:            getArgoGrafanaSpec(),
+			HA:                 getArgoHASpec(),
+			Redis:              getArgoRedisSpec(),
+			Repo:               getArgoRepoServerSpec(),
+			Server:             getArgoServerSpec(),
+			RBAC:               getDefaultRBAC(),
 			ResourceExclusions: string(b),
 		},
 	}, nil

--- a/controllers/argocd/argocd_test.go
+++ b/controllers/argocd/argocd_test.go
@@ -19,6 +19,7 @@ package argocd
 import (
 	"testing"
 
+	argoapp "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	"gotest.tools/assert"
 	v1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
@@ -123,4 +124,21 @@ func TestArgoCD(t *testing.T) {
 		},
 	}
 	assert.DeepEqual(t, testArgoCD.Spec.Server.Resources, testServerResources)
+}
+
+func TestDexConfiguration(t *testing.T) {
+	testArgoCD, _ := NewCR("openshift-gitops", "openshift-gitops")
+
+	// Verify Dex OpenShift Configuration
+	assert.Equal(t, testArgoCD.Spec.Dex.OpenShiftOAuth, true)
+
+	// Verify the default RBAC
+	testAdminPolicy := "g, system:cluster-admins, role:admin"
+	testDefaultScope := "[groups]"
+
+	testRBAC := argoapp.ArgoCDRBACSpec{
+		Policy: &testAdminPolicy,
+		Scopes: &testDefaultScope,
+	}
+	assert.DeepEqual(t, testArgoCD.Spec.RBAC, testRBAC)
 }


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
#190 installs the dex service out of the box. This PR would additionally configure `OpenShift Login` as a default. 

This PR would allow users to login to the Argo CD using their OpenShift users without any manual intervention or additional steps. This PR also sets the users which belong to `system:cluster-admins` as Argo CD admins. For example, `kubeadmin` user belongs to the `system:cluster-admins` group, which allows users/admins to login using the `kubeadmin` and perform admin activities.

**Have you updated the necessary documentation?**
NA

Documentation:
https://github.com/argoproj-labs/argocd-operator/pull/418

**Test acceptance criteria**:
* [x] Unit Test

**How to test changes / Special notes to the reviewer**:
Install or run the gitops-operator locally using `operator-sdk run local`.
Verify the Argo CD creation. 
Verify a deployment is created for Dex(opeshift-gitops-dex-server).
Proceed to Login to Argo CD. Either using the Console
-> Network -> Routes -> openshift-gitops-server 
(or)
using the CLI
`oc get routes openshift-gitops-server -n openshift-gitops`
Click on `Login with OpenShift`