### PR TITLE
fix: issues with resource quota and resource requirements

### DIFF
--- a/controllers/argocd/argocd.go
+++ b/controllers/argocd/argocd.go
@@ -137,7 +137,7 @@ func getArgoRepoServerSpec() argoapp.ArgoCDRepoSpec {
 				v1.ResourceCPU:    resourcev1.MustParse("250m"),
 			},
 			Limits: v1.ResourceList{
-				v1.ResourceMemory: resourcev1.MustParse("512Mi"),
+				v1.ResourceMemory: resourcev1.MustParse("1024Mi"),
 				v1.ResourceCPU:    resourcev1.MustParse("1000m"),
 			},
 		},

--- a/controllers/argocd/argocd_test.go
+++ b/controllers/argocd/argocd_test.go
@@ -107,7 +107,7 @@ func TestArgoCD(t *testing.T) {
 			v1.ResourceCPU:    resourcev1.MustParse("250m"),
 		},
 		Limits: v1.ResourceList{
-			v1.ResourceMemory: resourcev1.MustParse("512Mi"),
+			v1.ResourceMemory: resourcev1.MustParse("1024Mi"),
 			v1.ResourceCPU:    resourcev1.MustParse("1000m"),
 		},
 	}

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -294,37 +294,26 @@ func (r *ReconcileGitopsService) reconcileDefaultArgoCDInstance(instance *pipeli
 		} else {
 			return reconcile.Result{}, err
 		}
-	}
-
-	// Ensure compute resource quotas are set for the default ArgoCD namespace
-	resourceQuotaName := argocdNS.Name + "-compute-resources"
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: resourceQuotaName, Namespace: argocdNS.Name}, &corev1.ResourceQuota{})
-	if err != nil && errors.IsNotFound(err) {
-		reqLogger.Info("Setting compute resource quotas for ArgoCD namespace", "Name", argocdNS.Name)
-		resourceQuota := corev1.ResourceQuota{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "ResourceQuota",
-				APIVersion: "v1",
-			},
+	} else {
+		// Delete if resource quota is set on the default ArgoCD instance namespace.
+		// Fix for v1.2 - https://github.com/redhat-developer/gitops-operator/issues/206
+		resourceQuotaName := argocdNS.Name + "-compute-resources"
+		resourceQuotaObj := &corev1.ResourceQuota{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resourceQuotaName,
 				Namespace: argocdNS.Name,
 			},
-			Spec: corev1.ResourceQuotaSpec{
-				Hard: corev1.ResourceList{
-					corev1.ResourceMemory:       resourcev1.MustParse("4544Mi"),
-					corev1.ResourceCPU:          resourcev1.MustParse("6688m"),
-					corev1.ResourceLimitsMemory: resourcev1.MustParse("9070Mi"),
-					corev1.ResourceLimitsCPU:    resourcev1.MustParse("13750m"),
-				},
-				Scopes: []corev1.ResourceQuotaScope{
-					"NotTerminating",
-				},
-			},
 		}
-		err = r.Client.Create(context.TODO(), &resourceQuota)
+		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: resourceQuotaName, Namespace: argocdNS.Name}, resourceQuotaObj)
 		if err != nil {
-			return reconcile.Result{}, err
+			if errors.IsNotFound(err) {
+				reqLogger.Info("No ResourceQuota set for namespace", "Name", argocdNS.Name)
+			}
+		} else {
+			err = r.Client.Delete(context.TODO(), resourceQuotaObj)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
 		}
 	}
 
@@ -346,59 +335,8 @@ func (r *ReconcileGitopsService) reconcileDefaultArgoCDInstance(instance *pipeli
 		} else {
 			return reconcile.Result{}, err
 		}
-	} else {
-		changed := false
-
-		if existingArgoCD.Spec.ApplicationSet != nil {
-			if existingArgoCD.Spec.ApplicationSet.Resources == nil {
-				existingArgoCD.Spec.ApplicationSet.Resources = defaultArgoCDInstance.Spec.ApplicationSet.Resources
-				changed = true
-			}
-		}
-
-		if existingArgoCD.Spec.Controller.Resources == nil {
-			existingArgoCD.Spec.Controller.Resources = defaultArgoCDInstance.Spec.Controller.Resources
-			changed = true
-		}
-
-		if existingArgoCD.Spec.Dex.Resources == nil {
-			existingArgoCD.Spec.Dex.Resources = defaultArgoCDInstance.Spec.Dex.Resources
-			changed = true
-		}
-
-		if existingArgoCD.Spec.Grafana.Resources == nil {
-			existingArgoCD.Spec.Grafana.Resources = defaultArgoCDInstance.Spec.Grafana.Resources
-			changed = true
-		}
-
-		if existingArgoCD.Spec.HA.Resources == nil {
-			existingArgoCD.Spec.HA.Resources = defaultArgoCDInstance.Spec.HA.Resources
-			changed = true
-		}
-
-		if existingArgoCD.Spec.Redis.Resources == nil {
-			existingArgoCD.Spec.Redis.Resources = defaultArgoCDInstance.Spec.Redis.Resources
-			changed = true
-		}
-
-		if existingArgoCD.Spec.Repo.Resources == nil {
-			existingArgoCD.Spec.Repo.Resources = defaultArgoCDInstance.Spec.Repo.Resources
-			changed = true
-		}
-
-		if existingArgoCD.Spec.Server.Resources == nil {
-			existingArgoCD.Spec.Server.Resources = defaultArgoCDInstance.Spec.Server.Resources
-			changed = true
-		}
-
-		if changed {
-			reqLogger.Info("Reconciling ArgoCD", "Namespace", existingArgoCD.Namespace, "Name", existingArgoCD.Name)
-			err = r.Client.Update(context.TODO(), existingArgoCD)
-			if err != nil {
-				return reconcile.Result{}, err
-			}
-		}
 	}
+
 	return reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind bug
> /kind documentation

**Have you updated the necessary documentation?**
* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

Documentation is updated as part of the PR https://github.com/argoproj-labs/argocd-operator/pull/412

**Which issue(s) this PR fixes**:
#206 #207 #208 

Fixes #?
#206 #207 #208 

**Test acceptance criteria**:
* [x] Unit Test

**How to test changes / Special notes to the reviewer**:

1. run the operator locally using `operator-sdk run local`
2. verify that there is no resource quota on the `openshift-gitops` namespace.
3. verify that the repo server memory limit is increased from `512Mi` to `1024Mi`
4. verify that a well explained documentation is available for managing resource requirements of Argo CD workloads.

