### PR TITLE
chore: update operator-sdk to v1.11.0

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=gitops-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.7.1+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.10.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -126,7 +126,7 @@ metadata:
     containerImage: quay.io/redhat-developer/gitops-backend-operator:v0.0.3
     description: Enables teams to adopt GitOps principles for managing cluster configurations
       and application delivery across hybrid multi-cluster Kubernetes environments.
-    operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
+    operators.operatorframework.io/builder: operator-sdk-v1.10.0+git
     operators.operatorframework.io/internal-objects: '["gitopsservices.pipelines.openshift.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: gitops-operator.v0.0.3

--- a/bundle/manifests/gitops-operator_v1_serviceaccount.yaml
+++ b/bundle/manifests/gitops-operator_v1_serviceaccount.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  name: gitops-operator

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: gitops-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.7.1+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.10.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -12,6 +12,9 @@ stages:
     labels:
       suite: basic
       test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
@@ -19,6 +22,9 @@ stages:
     labels:
       suite: olm
       test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
@@ -26,6 +32,9 @@ stages:
     labels:
       suite: olm
       test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
@@ -33,6 +42,9 @@ stages:
     labels:
       suite: olm
       test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
@@ -40,6 +52,9 @@ stages:
     labels:
       suite: olm
       test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
@@ -47,3 +62,9 @@ stages:
     labels:
       suite: olm
       test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
There's been a change in the operator-sdk version 1.10.1 to not generate a file (bundle/manifests/gitops-operator_v1_serviceaccount.yaml) when running make bundle, and in version 1.11.0 the presence of that file will actually cause make bundle to error out. This PR is to remove that file and regenerate the bundle artifacts using operator-sdk version 1.11.0

**How to test changes / Special notes to the reviewer**:
Install v1.11.0 version of operator-sdk
run `make bundle`. You should not run into any issues.
