### PR TITLE
chore: update repo server resource limit in argocd sample

### DIFF
--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -94,7 +94,7 @@ metadata:
               "resources": {
                 "limits": {
                   "cpu": "1000m",
-                  "memory": "512Mi"
+                  "memory": "1024Mi"
                 },
                 "requests": {
                   "cpu": "250m",

--- a/config/samples/argoproj.io_v1alpha1_argocd.yaml
+++ b/config/samples/argoproj.io_v1alpha1_argocd.yaml
@@ -17,7 +17,7 @@ spec:
     resources:
       limits:
         cpu: 1000m
-        memory: 512Mi
+        memory: 1024Mi
       requests:
         cpu: 250m
         memory: 256Mi


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

> For example, `> /kind bug` would simply become: `/kind bug`
> /kind enhancement

**What does this PR do / why we need it**:
The PR #205 missed to update the repo server resource limit in the argo cd sample. This PR addresses the issue.

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:
This PR completes the PR #205 

**How to test changes / Special notes to the reviewer**:
1. Use the steps provided in the README.md to create an index image.
https://github.com/redhat-developer/gitops-operator#re-build-and-deploy
2. Install the new operator from OperatorHub
3. Go to the project of your choice and move to `Installed Operators` section in the console.
4. Click on `Red Hat OpenShift GitOps`.
5. Click on `Argo CD`
6. Select YAML view and click `create`.
7. Up on the installation, you can verify that the `openshift-gitops-repo-server` deployment or pod should have resource limit of 1024Mi


