### PR TITLE
fix: issues with resource quota and resource requirements (v1.2.1)

### DIFF
--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -68,7 +68,7 @@ metadata:
               "resources": {
                 "limits": {
                   "cpu": "1000m",
-                  "memory": "512Mi"
+                  "memory": "1024Mi"
                 },
                 "requests": {
                   "cpu": "250m",

--- a/pkg/controller/argocd/argocd.go
+++ b/pkg/controller/argocd/argocd.go
@@ -115,7 +115,7 @@ func getArgoRepoServerSpec() argoapp.ArgoCDRepoSpec {
 				v1.ResourceCPU:    resourcev1.MustParse("250m"),
 			},
 			Limits: v1.ResourceList{
-				v1.ResourceMemory: resourcev1.MustParse("512Mi"),
+				v1.ResourceMemory: resourcev1.MustParse("1024Mi"),
 				v1.ResourceCPU:    resourcev1.MustParse("1000m"),
 			},
 		},

--- a/pkg/controller/argocd/argocd_test.go
+++ b/pkg/controller/argocd/argocd_test.go
@@ -90,7 +90,7 @@ func TestArgoCD(t *testing.T) {
 			v1.ResourceCPU:    resourcev1.MustParse("250m"),
 		},
 		Limits: v1.ResourceList{
-			v1.ResourceMemory: resourcev1.MustParse("512Mi"),
+			v1.ResourceMemory: resourcev1.MustParse("1024Mi"),
 			v1.ResourceCPU:    resourcev1.MustParse("1000m"),
 		},
 	}

--- a/pkg/controller/gitopsservice/gitopsservice_controller.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller.go
@@ -357,6 +357,58 @@ func (r *ReconcileGitopsService) reconcileDefaultArgoCDInstance(instance *pipeli
 		} else {
 			return reconcile.Result{}, err
 		}
+	} else {
+		changed := false
+
+		if existingArgoCD.Spec.ApplicationSet != nil {
+			if existingArgoCD.Spec.ApplicationSet.Resources == nil {
+				existingArgoCD.Spec.ApplicationSet.Resources = defaultArgoCDInstance.Spec.ApplicationSet.Resources
+				changed = true
+			}
+		}
+
+		if existingArgoCD.Spec.Controller.Resources == nil {
+			existingArgoCD.Spec.Controller.Resources = defaultArgoCDInstance.Spec.Controller.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.Dex.Resources == nil {
+			existingArgoCD.Spec.Dex.Resources = defaultArgoCDInstance.Spec.Dex.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.Grafana.Resources == nil {
+			existingArgoCD.Spec.Grafana.Resources = defaultArgoCDInstance.Spec.Grafana.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.HA.Resources == nil {
+			existingArgoCD.Spec.HA.Resources = defaultArgoCDInstance.Spec.HA.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.Redis.Resources == nil {
+			existingArgoCD.Spec.Redis.Resources = defaultArgoCDInstance.Spec.Redis.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.Repo.Resources == nil {
+			existingArgoCD.Spec.Repo.Resources = defaultArgoCDInstance.Spec.Repo.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.Server.Resources == nil {
+			existingArgoCD.Spec.Server.Resources = defaultArgoCDInstance.Spec.Server.Resources
+			changed = true
+		}
+
+		if changed {
+			reqLogger.Info("Reconciling ArgoCD", "Namespace", existingArgoCD.Namespace, "Name", existingArgoCD.Name)
+			err = r.client.Update(context.TODO(), existingArgoCD)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		}
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/controller/gitopsservice/gitopsservice_controller_test.go
+++ b/pkg/controller/gitopsservice/gitopsservice_controller_test.go
@@ -2,6 +2,7 @@ package gitopsservice
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -19,7 +20,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -288,28 +289,6 @@ func TestReconcile_GitOpsNamespace(t *testing.T) {
 	}
 }
 
-func TestReconcile_GitOpsNamespaceResourceQuotas(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
-	s := scheme.Scheme
-	addKnownTypesToScheme(s)
-
-	fakeClient := fake.NewFakeClientWithScheme(s, util.NewClusterVersion("4.7.1"), newGitopsService())
-	reconciler := newReconcileGitOpsService(fakeClient, s)
-
-	_, err := reconciler.Reconcile(newRequest("test", "test"))
-	assertNoError(t, err)
-
-	resourceQuota := corev1.ResourceQuota{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceNamespace + "-compute-resources", Namespace: serviceNamespace}, &resourceQuota)
-	assertNoError(t, err)
-
-	assert.Equal(t, resourceQuota.Spec.Hard[corev1.ResourceCPU], resourcev1.MustParse("6688m"))
-	assert.Equal(t, resourceQuota.Spec.Hard[corev1.ResourceMemory], resourcev1.MustParse("4544Mi"))
-	assert.Equal(t, resourceQuota.Spec.Hard[corev1.ResourceLimitsCPU], resourcev1.MustParse("13750m"))
-	assert.Equal(t, resourceQuota.Spec.Hard[corev1.ResourceLimitsMemory], resourcev1.MustParse("9070Mi"))
-	assert.DeepEqual(t, resourceQuota.Spec.Scopes, []corev1.ResourceQuotaScope{"NotTerminating"})
-}
-
 func TestReconcile_BackendResourceLimits(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	s := scheme.Scheme
@@ -332,7 +311,7 @@ func TestReconcile_BackendResourceLimits(t *testing.T) {
 	assert.Equal(t, resources.Limits[corev1.ResourceMemory], resourcev1.MustParse("256Mi"))
 }
 
-func TestReconcile_testArgoCDForOperatorUpgrade(t *testing.T) {
+func TestReconcile_VerifyResourceQuotaDeletionForUpgrade(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	s := scheme.Scheme
 	addKnownTypesToScheme(s)
@@ -340,44 +319,29 @@ func TestReconcile_testArgoCDForOperatorUpgrade(t *testing.T) {
 	fakeClient := fake.NewFakeClientWithScheme(s, util.NewClusterVersion("4.7.1"), newGitopsService())
 	reconciler := newReconcileGitOpsService(fakeClient, s)
 
-	// Create a basic ArgoCD CR. ArgoCD created by Operator version less than v1.2
-	existingArgoCD := &argoapp.ArgoCD{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      serviceNamespace,
+	// Create namespace object for default ArgoCD instance and set resource quota to it.
+	defaultArgoNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceNamespace,
+		},
+	}
+	fakeClient.Create(context.TODO(), defaultArgoNS)
+
+	dummyResourceObj := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-compute-resources", serviceNamespace),
 			Namespace: serviceNamespace,
 		},
-		Spec: argoapp.ArgoCDSpec{
-			Server: argoapp.ArgoCDServerSpec{
-				Route: argoapp.ArgoCDRouteSpec{
-					Enabled: true,
-				},
-			},
-			ApplicationSet: &argoapp.ArgoCDApplicationSet{},
-		},
 	}
+	fakeClient.Create(context.TODO(), dummyResourceObj)
 
-	err := fakeClient.Create(context.TODO(), existingArgoCD)
+	_, err := reconciler.Reconcile(newRequest("test", "test"))
 	assertNoError(t, err)
 
-	_, err = reconciler.Reconcile(newRequest("test", "test"))
-	assertNoError(t, err)
-
-	// ArgoCD instance SHOULD be updated with resource request/limits for each workload.
-	updateArgoCD := &argoapp.ArgoCD{}
-
-	if err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: common.ArgoCDInstanceName, Namespace: serviceNamespace},
-		updateArgoCD); err != nil {
-		t.Fatalf("ArgoCD instance should exist in namespace, error: %v", err)
-	}
-
-	assert.Check(t, updateArgoCD.Spec.ApplicationSet.Resources != nil)
-	assert.Check(t, updateArgoCD.Spec.Controller.Resources != nil)
-	assert.Check(t, updateArgoCD.Spec.Dex.Resources != nil)
-	assert.Check(t, updateArgoCD.Spec.Grafana.Resources != nil)
-	assert.Check(t, updateArgoCD.Spec.HA.Resources != nil)
-	assert.Check(t, updateArgoCD.Spec.Redis.Resources != nil)
-	assert.Check(t, updateArgoCD.Spec.Repo.Resources != nil)
-	assert.Check(t, updateArgoCD.Spec.Server.Resources != nil)
+	// Verify that resource quota object is deleted after reconciliation.
+	resourceQuota := corev1.ResourceQuota{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceNamespace + "-compute-resources", Namespace: serviceNamespace}, &resourceQuota)
+	assert.Error(t, err, "resourcequotas \"openshift-gitops-compute-resources\" not found")
 }
 
 func TestGetBackendNamespace(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind bug
> /kind documentation

**Have you updated the necessary documentation?**
* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

Documentation is updated as part of the PR https://github.com/argoproj-labs/argocd-operator/pull/412

**Which issue(s) this PR fixes**:
 * Remove resource quota in the namespace openshift-gitops in the controller reconciler.  When the operator is upgraded, existing resource quota is removed.
 * Increase the default memory limit to 1024M in the repo server.  It only affects new installation.  Existing derault argocd instance workload is not affected.

Fixes #?
#206 #207 #208 

**Test acceptance criteria**:
* [x] Unit Test

**How to test changes / Special notes to the reviewer**:

1. run the operator locally using `operator-sdk run local`
2. verify that there is no resource quota on the `openshift-gitops` namespace.
3. verify that the repo server memory limit is increased from `512Mi` to `1024Mi`
4. verify that a well explained documentation is available for managing resource requirements of Argo CD workloads.