### PR TITLE
chore: Restore logic to add resource limits to workloads incase of operator upgrades.

### DIFF
--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -335,6 +335,58 @@ func (r *ReconcileGitopsService) reconcileDefaultArgoCDInstance(instance *pipeli
 		} else {
 			return reconcile.Result{}, err
 		}
+	} else {
+		changed := false
+
+		if existingArgoCD.Spec.ApplicationSet != nil {
+			if existingArgoCD.Spec.ApplicationSet.Resources == nil {
+				existingArgoCD.Spec.ApplicationSet.Resources = defaultArgoCDInstance.Spec.ApplicationSet.Resources
+				changed = true
+			}
+		}
+
+		if existingArgoCD.Spec.Controller.Resources == nil {
+			existingArgoCD.Spec.Controller.Resources = defaultArgoCDInstance.Spec.Controller.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.Dex.Resources == nil {
+			existingArgoCD.Spec.Dex.Resources = defaultArgoCDInstance.Spec.Dex.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.Grafana.Resources == nil {
+			existingArgoCD.Spec.Grafana.Resources = defaultArgoCDInstance.Spec.Grafana.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.HA.Resources == nil {
+			existingArgoCD.Spec.HA.Resources = defaultArgoCDInstance.Spec.HA.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.Redis.Resources == nil {
+			existingArgoCD.Spec.Redis.Resources = defaultArgoCDInstance.Spec.Redis.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.Repo.Resources == nil {
+			existingArgoCD.Spec.Repo.Resources = defaultArgoCDInstance.Spec.Repo.Resources
+			changed = true
+		}
+
+		if existingArgoCD.Spec.Server.Resources == nil {
+			existingArgoCD.Spec.Server.Resources = defaultArgoCDInstance.Spec.Server.Resources
+			changed = true
+		}
+
+		if changed {
+			reqLogger.Info("Reconciling ArgoCD", "Namespace", existingArgoCD.Namespace, "Name", existingArgoCD.Name)
+			err = r.Client.Update(context.TODO(), existingArgoCD)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		}
 	}
 
 	return reconcile.Result{}, nil

--- a/controllers/gitopsservice_controller_test.go
+++ b/controllers/gitopsservice_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -327,6 +328,54 @@ func TestReconcile_BackendResourceLimits(t *testing.T) {
 	assert.Equal(t, resources.Requests[corev1.ResourceMemory], resourcev1.MustParse("128Mi"))
 	assert.Equal(t, resources.Limits[corev1.ResourceCPU], resourcev1.MustParse("500m"))
 	assert.Equal(t, resources.Limits[corev1.ResourceMemory], resourcev1.MustParse("256Mi"))
+}
+
+func TestReconcile_testArgoCDForOperatorUpgrade(t *testing.T) {
+	logf.SetLogger(argocd.ZapLogger(true))
+	s := scheme.Scheme
+	addKnownTypesToScheme(s)
+
+	fakeClient := fake.NewFakeClientWithScheme(s, util.NewClusterVersion("4.7.1"), newGitopsService())
+	reconciler := newReconcileGitOpsService(fakeClient, s)
+
+	// Create a basic ArgoCD CR. ArgoCD created by Operator version less than v1.2
+	existingArgoCD := &argoapp.ArgoCD{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      serviceNamespace,
+			Namespace: serviceNamespace,
+		},
+		Spec: argoapp.ArgoCDSpec{
+			Server: argoapp.ArgoCDServerSpec{
+				Route: argoapp.ArgoCDRouteSpec{
+					Enabled: true,
+				},
+			},
+			ApplicationSet: &argoapp.ArgoCDApplicationSet{},
+		},
+	}
+
+	err := fakeClient.Create(context.TODO(), existingArgoCD)
+	assertNoError(t, err)
+
+	_, err = reconciler.Reconcile(context.TODO(), newRequest("test", "test"))
+	assertNoError(t, err)
+
+	// ArgoCD instance SHOULD be updated with resource request/limits for each workload.
+	updateArgoCD := &argoapp.ArgoCD{}
+
+	if err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: common.ArgoCDInstanceName, Namespace: serviceNamespace},
+		updateArgoCD); err != nil {
+		t.Fatalf("ArgoCD instance should exist in namespace, error: %v", err)
+	}
+
+	assert.Check(t, updateArgoCD.Spec.ApplicationSet.Resources != nil)
+	assert.Check(t, updateArgoCD.Spec.Controller.Resources != nil)
+	assert.Check(t, updateArgoCD.Spec.Dex.Resources != nil)
+	assert.Check(t, updateArgoCD.Spec.Grafana.Resources != nil)
+	assert.Check(t, updateArgoCD.Spec.HA.Resources != nil)
+	assert.Check(t, updateArgoCD.Spec.Redis.Resources != nil)
+	assert.Check(t, updateArgoCD.Spec.Repo.Resources != nil)
+	assert.Check(t, updateArgoCD.Spec.Server.Resources != nil)
 }
 
 func TestReconcile_VerifyResourceQuotaDeletionForUpgrade(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
A part[1] of PR #205 removes the logic to add resource limits to workloads during operator upgrade. This needs to reverted as we just want to delete the resource quota on the openshift-gitops(default) namespace and not change any of the existing behavior w.r.t resource limits.
1 - https://github.com/redhat-developer/gitops-operator/pull/205/files#r708223171

**Have you updated the necessary documentation?**
NA

**Test acceptance criteria**:

* [x] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
1. Upgrade the operator from v1.1.2 or less to v1.3
2. All the ArgoCD workloads should be set with resource requests/limits.