### PR TITLE
update argocd-operator to latest commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.16
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210903095109-98d63115ac77
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20210914092817-393689919953
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210903095109-98d63115ac77 h1:3Lxo2apiAqo8tsRpUDgivunIqVTsqhOYhlkZ8fFG688=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20210903095109-98d63115ac77/go.mod h1:gH3XKh1LoFH5Gxy6u07N/UJ3O0fscvzG6UgQTaUwalo=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210914092817-393689919953 h1:8ckVKjM6QxNoAP6fCmM9eDIyMyvxw5oC7iD/joBVqmY=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20210914092817-393689919953/go.mod h1:giR01w2SS5Yci3qigAPPshEiHCk4QhBZPerSED0xrAU=
 github.com/argoproj/argo-cd v1.8.7 h1:CkIu8p/gcTY/fOZWM2tHuSCIAV2HggXjJftrT1IIT3k=
 github.com/argoproj/argo-cd v1.8.7/go.mod h1:tqFZW5Lr9KBCDsvOaE5Fh8M1eJ1ThvR58pyyLv8Zqvs=
 github.com/argoproj/gitops-engine v0.2.2/go.mod h1:OxXp8YaT73rw9gEBnGBWg55af80nkV/uIjWCbJu1Nw0=


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
/kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
Points gitops-operator to the latest commit of argocd-operator which makes it OCP 4.9 compatible

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
