### PR TITLE
fix: Add permissions to the operator to delete resourcequotas.

### DIFF
--- a/deploy/argocd_role.yaml
+++ b/deploy/argocd_role.yaml
@@ -90,6 +90,7 @@ rules:
   - list
   - get
   - create
+  - delete
   - watch
 - apiGroups:
   - route.openshift.io

--- a/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitops-operator/manifests/gitops-operator.clusterserviceversion.yaml
@@ -353,6 +353,7 @@ spec:
           - list
           - get
           - create
+          - delete
           - watch
         - apiGroups:
           - oauth.openshift.io


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
This PR adds permissions to the operator pod to delete the resourcequota objects.

**Have you updated the necessary documentation?**
NA

**How to test changes / Special notes to the reviewer**:
1. Upgrade the operator from v1.2 to v1.2.1 and see that the resourcequota on openshift-gitops namespace is not deleted.
After this change it should be deleted.
