### PR TITLE
chore: Increase the default timeout for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,23 +89,23 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 test-all: manifests generate fmt vet ## Run all tests.
-	go test ./... -coverprofile cover.out
+	go test -timeout 1h ./... -coverprofile cover.out
 
 test-e2e: manifests generate fmt vet ## Run e2e tests.
-	go test ./test/e2e -coverprofile cover.out -ginkgo.v
-	go test ./test/nondefaulte2e -coverprofile cover.out -ginkgo.v
+	go test -timeout 30m ./test/e2e -coverprofile cover.out -ginkgo.v
+	go test -timeout 30m ./test/nondefaulte2e -coverprofile cover.out -ginkgo.v
 
 test-metrics:
-	go test ./test/e2e -ginkgo.focus="Argo CD metrics controller" -coverprofile cover.out -ginkgo.v
+	go test -timeout 30m ./test/e2e -ginkgo.focus="Argo CD metrics controller" -coverprofile cover.out -ginkgo.v
 
 test-route:
-	go test ./test/e2e -ginkgo.focus="Argo CD ConsoleLink controller" -coverprofile cover.out -ginkgo.v
+	go test -timeout 30m ./test/e2e -ginkgo.focus="Argo CD ConsoleLink controller" -coverprofile cover.out -ginkgo.v
 
 test-gitopsservice:
-	go test ./test/e2e -ginkgo.focus="GitOpsServiceController" -coverprofile cover.out -ginkgo.v
+	go test -timeout 30m ./test/e2e -ginkgo.focus="GitOpsServiceController" -coverprofile cover.out -ginkgo.v
 
 test-gitopsservice-nondefault:
-	go test ./test/nondefaulte2e -ginkgo.focus="GitOpsServiceNoDefaultInstall" -coverprofile cover.out -ginkgo.v
+	go test -timeout 30m ./test/nondefaulte2e -ginkgo.focus="GitOpsServiceNoDefaultInstall" -coverprofile cover.out -ginkgo.v
 
 test: manifests generate fmt vet ## Run unit tests.
 	go test `go list ./... | grep -v test` -coverprofile cover.out


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
The default timeout for `go test` is 10 mins which may lead to timeout and result in test suite failure. 
```
-timeout d
          If a test binary runs longer than duration d, panic.
          If d is 0, the timeout is disabled.
          The default is 10 minutes (10m).
```

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:

Fixes #?
#228 

**How to test changes / Special notes to the reviewer**:
NA
