### PR TITLE
fix: Add permissions to operator to delete ResourceQuota object on namespace

### DIFF
--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -299,6 +299,7 @@ spec:
           - resourcequotas
           verbs:
           - create
+          - delete
           - get
           - list
           - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -59,6 +59,7 @@ rules:
   - resourcequotas
   verbs:
   - create
+  - delete
   - get
   - list
   - watch

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -131,7 +131,7 @@ type ReconcileGitopsService struct {
 //+kubebuilder:rbac:groups="",resources=pods;pods/log,verbs=get
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get
 //+kubebuilder:rbac:groups="",resources=pods;services;services/finalizers;endpoints;persistentvolumeclaims;events;configmaps;secrets;namespaces,verbs=create;delete;get;list;patch;update;watch
-//+kubebuilder:rbac:groups="",resources=resourcequotas,verbs=get;list;watch;create
+//+kubebuilder:rbac:groups="",resources=resourcequotas,verbs=get;list;watch;create;delete
 
 //+kubebuilder:rbac:groups=apps,resources=deployments;replicasets;statefulsets,verbs=*
 //+kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=create;delete;get;list;patch;update;watch


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
This PR ports the changes #223 into master branch.

**Test acceptance criteria**:
NA

**How to test changes / Special notes to the reviewer**:
Upgrade the operator from v1.2 to v1.3 and see that the resourcequota on openshift-gitops namespace is not deleted.
After this change it should be deleted.
