### PR TITLE
fix: remove predicate from some watches

### DIFF
--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -93,11 +93,11 @@ func (r *ReconcileGitopsService) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&pipelinesv1alpha1.GitopsService{}).
-		Owns(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(pred)).
-		Owns(&rbacv1.ClusterRole{}, builder.WithPredicates(pred)).
-		Owns(&corev1.ServiceAccount{}, builder.WithPredicates(pred)).
-		Owns(&corev1.ConfigMap{}, builder.WithPredicates(pred)).
+		For(&pipelinesv1alpha1.GitopsService{}, builder.WithPredicates(pred)).
+		Owns(&rbacv1.ClusterRoleBinding{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&corev1.ConfigMap{}).
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(pred)).
 		Owns(&corev1.Service{}, builder.WithPredicates(pred)).
 		Owns(&routev1.Route{}, builder.WithPredicates(pred)).


### PR DESCRIPTION
Before the operator sdk upgrade, only some of the watches set by the
gitops service controller included a predicate.  After the upgrade,
all of the watches use the predicate.  This causes some user-made
changes to resources like the cluster roles not to be reverted
by the operator.

This fix removes the predicate from the watches which didn't have it
before.  It also adds the predicate to the primary resource, which did
have it before the upgrade, but was missing after.

Signed-off-by: John Pitman <jpitman@redhat.com>

**What type of PR is this?**
> /kind bug


**What does this PR do / why we need it**:

Fixes a regression where user changes to the cluster roles would not be reverted by the operator

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:

Install the operator.  Edit the permissions of the `gitops-service-cluster` cluster role.  Ensure that the operator reverts the changes.