### PR TITLE
fix: add cluster-admins to defualt argocd rbac policy

### DIFF
--- a/controllers/argocd/argocd.go
+++ b/controllers/argocd/argocd.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	defaultAdminPolicy = "g, system:cluster-admins, role:admin"
+	defaultAdminPolicy = "g, system:cluster-admins, role:admin\ng, cluster-admins, role:admin\n"
 	defaultScope       = "[groups]"
 )
 

--- a/controllers/argocd/argocd_test.go
+++ b/controllers/argocd/argocd_test.go
@@ -133,7 +133,7 @@ func TestDexConfiguration(t *testing.T) {
 	assert.Equal(t, testArgoCD.Spec.Dex.OpenShiftOAuth, true)
 
 	// Verify the default RBAC
-	testAdminPolicy := "g, system:cluster-admins, role:admin"
+	testAdminPolicy := "g, system:cluster-admins, role:admin\ng, cluster-admins, role:admin\n"
 	testDefaultScope := "[groups]"
 
 	testRBAC := argoapp.ArgoCDRBACSpec{


### PR DESCRIPTION
Signed-off-by: Yi Cai yicai@redhat.com

**What type of PR is this?**
/kind enhancement


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
Report from a user:
> Currently the following policy.csv is set to "g, system:cluster-admins, role:admin". This means when a cluster admin logs into openshift gitops via Dex/SSO they can't really do anything useful, and the errors when they do something like a Sync aren't obvious. A less astute openshift user wouldn't even realize that system:cluster-admin and cluster-admin are different groups. We should include cluster-admin as well as system:cluster-admin. 
This is achievable with the following patch
oc patch argocd openshift-gitops -n openshift-gitops --type=merge -p='{"spec":{"rbac":
{"policy":"g, system:cluster-admins, role:admin\ng, cluster-admins, role:admin\n"}
}}'

Fixes [GITOPS-1541](https://issues.redhat.com/browse/GITOPS-1541)

**Test acceptance criteria**:

* [x] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
1. Have a cluster ready
2. Create a user using HTPasswd as instructions in this [link](https://docs.openshift.com/container-platform/4.9/authentication/identity_providers/configuring-htpasswd-identity-provider.html#add-identity-provider_configuring-htpasswd-identity-provider)
3. Follow the steps in this [link](https://argocd-operator.readthedocs.io/en/latest/usage/dex/#role-mappings) to add the user  to cluster-admins group for Argo CD.
4. Install Openshift-Gitops operator and login to the default Argo CD instance with the new user created in step 2. Observe now the user is able to add, sync etc. apps as users in system: cluster-admins group.