### PR TITLE
fix: argocd-tls-certs-cm gets overwritten by the operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.16
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20220120141718-74f1877ddbc3
+	github.com/argoproj-labs/argocd-operator v0.2.1
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.0
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -154,10 +154,10 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20220120141718-74f1877ddbc3 h1:YcDVY8Drnx0OKnpJkjtmfILab+XkxuLtpQaHv43XfiA=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20220120141718-74f1877ddbc3/go.mod h1:AeLeUZmGqk9deCZKR9i7dW1GTBkS8v6y4G0JpARpSx8=
-github.com/argoproj/argo-cd/v2 v2.2.2 h1:sKfiJuGiG85dBRYZz20n+y3tqs+F7yuLAKkxTH0Y260=
-github.com/argoproj/argo-cd/v2 v2.2.2/go.mod h1:J51If+krhtBEbNP/Y/l9sh9HctPHiiGueqPAkfFXXBo=
+github.com/argoproj-labs/argocd-operator v0.2.1 h1:OP6OOLfKixFZfPKwzyEZv0Nsgkpt3DzQc75iddUqRF0=
+github.com/argoproj-labs/argocd-operator v0.2.1/go.mod h1:l214z29p7ViikfRikLcZN4isJTJQ2ExCfCIPzf4CgpA=
+github.com/argoproj/argo-cd/v2 v2.2.5 h1:Amthb2SRNixwl6q/1dk+3SbfXouNApk+eS0Zy9TsYqc=
+github.com/argoproj/argo-cd/v2 v2.2.5/go.mod h1:J51If+krhtBEbNP/Y/l9sh9HctPHiiGueqPAkfFXXBo=
 github.com/argoproj/gitops-engine v0.5.2/go.mod h1:K2RYpGXh11VdFwDksS23SyFTOJaPcsF+MVJ/FHlqEOE=
 github.com/argoproj/pkg v0.11.1-0.20211203175135-36c59d8fafe0/go.mod h1:ra+bQPmbVAoEL+gYSKesuigt4m49i3Qa3mE/xQcjCiA=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
fixes #271 

**Which issue(s) this PR fixes**:
Fixes #271 

**How to test changes / Special notes to the reviewer**:
-------------------------

1. Run the operator locally using `make install run`
2. Create an Argo CD Instance or use the default Argo CD instance.
3. Add a cert to argocd-tls-certs-cm configmap.
```
..........
data:
  test.example.com: '-----BEGIN CERTIFICATE-----  -----END CERTIFICATE-----'
```
4. operator SHOULD NOT remove the configmap changes added manually in step 3.



