### PR TITLE
feat: pull argoproj-labs/argocd-operator#555 (RH-SSO enhancements)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.16
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20220120135155-711b6cf9403e
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20220323075615-6ebfe8431073
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.0
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -154,10 +154,10 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20220120135155-711b6cf9403e h1:62y3k8UCnxNGyTnI/T4mfS3GK9lsK2kUqGW7v/b22dk=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20220120135155-711b6cf9403e/go.mod h1:AeLeUZmGqk9deCZKR9i7dW1GTBkS8v6y4G0JpARpSx8=
-github.com/argoproj/argo-cd/v2 v2.2.2 h1:sKfiJuGiG85dBRYZz20n+y3tqs+F7yuLAKkxTH0Y260=
-github.com/argoproj/argo-cd/v2 v2.2.2/go.mod h1:J51If+krhtBEbNP/Y/l9sh9HctPHiiGueqPAkfFXXBo=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20220323075615-6ebfe8431073 h1:9u9dH5Ud+JalXpV4OgQY6glGvI73TP16jKupLNuNEvY=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20220323075615-6ebfe8431073/go.mod h1:XFTH8giszL7eDz8gZ9Sr+RuAJqQTf5y8RgJCAwbZ2qA=
+github.com/argoproj/argo-cd/v2 v2.2.4 h1:PoxrWuwGV8UhDkvOE2iYDRa799jnT68tU6XvDZzLzL0=
+github.com/argoproj/argo-cd/v2 v2.2.4/go.mod h1:J51If+krhtBEbNP/Y/l9sh9HctPHiiGueqPAkfFXXBo=
 github.com/argoproj/gitops-engine v0.5.2/go.mod h1:K2RYpGXh11VdFwDksS23SyFTOJaPcsF+MVJ/FHlqEOE=
 github.com/argoproj/pkg v0.11.1-0.20211203175135-36c59d8fafe0/go.mod h1:ra+bQPmbVAoEL+gYSKesuigt4m49i3Qa3mE/xQcjCiA=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:

pulls https://github.com/argoproj-labs/argocd-operator/pull/555

**This PR adds the below enhancements.**
-------------------------------------------
* Upgrades the default version of RH-SSO to 7.5.1
* Adds support to login with `kube:admin` OpenShift User.
* With this PR, RH-SSO can fetch the group details of OpenShift Users(You should see the group details of the logged in user in the Argo CD console). This will help admins define Group Level RBAC for their OpenShift groups. 
   https://github.com/keycloak/keycloak/pull/8381
* Kube:admin by default you only have. Not working previously. not an OS user.
   https://github.com/keycloak/keycloak/pull/8428
* RHSSO works in proxy enabled cluster with no additional or manual configuration.
   https://github.com/keycloak/keycloak/pull/8559
   
More technical details
------------------------
* Removed hardcoded OIDC client secrets and replaced them by generated random strings. These client secrets do not need to be stored. 
* Added `KeycloakIdentityProviderMapper` to workaround https://github.com/keycloak/keycloak-operator/issues/471. Without the workaround, tokens can't be translated to credentials that contain the group identity.
* Propagated proxy environment variables from operator to Keycloak containers so that outbound calls can go through cluster proxy if cluste proxy is configured.
* Delete OAuth client using foreground propagation policy to ensure that the garbage collector removes all instantiated objects before the TemplateInstance itself disappears.
* Add extra Delete OAuth client calls to workaround https://github.com/openshift/client-go/issues/209
* Add retries to handle RHSSO image upgrade

For more information please refer 
https://github.com/argoproj-labs/argocd-operator/pull/555