### PR TITLE
#222 fix incorrect machineconfiguration APIGroups

### DIFF
--- a/controllers/argocd/openshift/openshift.go
+++ b/controllers/argocd/openshift/openshift.go
@@ -285,7 +285,7 @@ func policyRulesForClusterConfig() []rbacv1.PolicyRule {
 			},
 		}, {
 			APIGroups: []string{
-				"machineconfig.openshift.io",
+				"machineconfiguration.openshift.io",
 			},
 			Resources: []string{
 				"*",


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
This fixes the APIGroup permissions for the argocd application controller to use the correct APIGroup for machineconfiguration.

**Have you updated the necessary documentation?**

Not needed

**Which issue(s) this PR fixes**:

Fixes #222 

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
