### PR TITLE
chore: update to latest argocd-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.18
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20220616023617-b6cc81b37f21
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20220617052355-966b84b20da4
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.2
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.m
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20220616023617-b6cc81b37f21 h1:phk1uzMIqfx8r7S2kmVfPHjT+6lJedMOXWG2Lx2N53M=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20220616023617-b6cc81b37f21/go.mod h1:ZtYlCP5+wlOvR0yHW4HVmgchJB365hyIMECDwvvl4BQ=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20220617052355-966b84b20da4 h1:B4Kwq5neiuV+5c8K6NIwPkdDplHRlTaUowHD4fz5lFA=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20220617052355-966b84b20da4/go.mod h1:ZtYlCP5+wlOvR0yHW4HVmgchJB365hyIMECDwvvl4BQ=
 github.com/argoproj/argo-cd/v2 v2.3.4 h1:mj+snMMf9LoHWMH3rLCkBWSRETv1Sq8lxuuyLxH+76A=
 github.com/argoproj/argo-cd/v2 v2.3.4/go.mod h1:EuPH0/rLe/FdHGwQ/EVucspMnF3v4qd7da6N6CG+oJA=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

**What type of PR is this?**

/kind cleanup

**What does this PR do / why we need it**:

Updates to the latest argocd-operator (release-0.4) branch

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.
