### PR TITLE
fix: fix openshift haproxy crash

### DIFF
--- a/controllers/argocd/openshift/openshift.go
+++ b/controllers/argocd/openshift/openshift.go
@@ -39,6 +39,9 @@ func ReconcilerHook(cr *argoprojv1alpha1.ArgoCD, v interface{}, hint string) err
 		} else if o.ObjectMeta.Name == cr.ObjectMeta.Name+"-redis-ha-haproxy" {
 			logv.Info("configuring openshift redis haproxy")
 			o.Spec.Template.Spec.Containers[0].Command = append(getCommandForRedhatRedisHaProxy(), o.Spec.Template.Spec.Containers[0].Command...)
+			o.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities.Add = []corev1.Capability{
+				"NET_BIND_SERVICE",
+			}
 		}
 	case *appsv1.StatefulSet:
 		if o.ObjectMeta.Name == cr.ObjectMeta.Name+"-redis-ha-server" {

--- a/controllers/argocd/openshift/openshift_test.go
+++ b/controllers/argocd/openshift/openshift_test.go
@@ -131,11 +131,20 @@ func TestReconcileArgoCD_reconcileRedisHaProxyDeployment(t *testing.T) {
 	testDeployment := makeTestDeployment()
 
 	testDeployment.ObjectMeta.Name = a.Name + "-redis-ha-haproxy"
+	testDeployment.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+		Capabilities: &corev1.Capabilities{},
+	}
 	want := append(getCommandForRedhatRedisHaProxy(), testDeployment.Spec.Template.Spec.Containers[0].Command...)
+	wantc := corev1.Capabilities{
+		Add: []corev1.Capability{
+			"NET_BIND_SERVICE",
+		},
+	}
 
 	assert.NoError(t, ReconcilerHook(a, testDeployment, ""))
 	assert.Equal(t, testDeployment.Spec.Template.Spec.Containers[0].Command, want)
 	assert.Equal(t, 0, len(testDeployment.Spec.Template.Spec.Containers[0].Args))
+	assert.Equal(t, wantc, *testDeployment.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities)
 
 	testDeployment = makeTestDeployment()
 	testDeployment.ObjectMeta.Name = a.Name + "-" + "not-redis-ha-haproxy"


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:

The OpenShift version of the haproxy image sets the `net_bind_service` capability on the haproxy binary.  The haproxy deployment needs to configure this capability in the security context in order to allow the binary to run.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [x] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:

Run the operator with the OpenShift images
```bash
ARGOCD_REDIS_IMAGE=registry.redhat.io/rhel8/redis-6@sha256:7d4cb67a6416cb43d4b84663e9ede302f25df149febec132134dea5302c7c692 \
ARGOCD_REDIS_HA_IMAGE=registry.redhat.io/rhel8/redis-6@sha256:7d4cb67a6416cb43d4b84663e9ede302f25df149febec132134dea5302c7c692 \
ARGOCD_REDIS_HA_PROXY_IMAGE=registry.redhat.io/openshift4/ose-haproxy-router@sha256:1d33cabad34c9b9b600036a660d712ae3834a45ed1ca272cc207031d46e8360e \
make install run
```
Install an Argo CD instance
```yaml
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: argocd
spec:
  ha:
    enabled: true
```
Check that the `argocd-redis-ha-haproxy` starts successfully.