### PR TITLE
fix: issues with redis upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.16
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20220413145640-22ba4220a63e
+	github.com/argoproj-labs/argocd-operator v0.3.1
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.0
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -154,10 +154,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20220325140653-2c781b2a038d h1:wCiRmO8qa8F4zU07z0SEbUrVdy5P2iGgjPjBGIMvcOI=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20220325140653-2c781b2a038d/go.mod h1:XFTH8giszL7eDz8gZ9Sr+RuAJqQTf5y8RgJCAwbZ2qA=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20220413145640-22ba4220a63e h1:CoxtH3ZOJnJRzLACkVbowkxka1dheUmjZfJsEqj25Qw=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20220413145640-22ba4220a63e/go.mod h1:XFTH8giszL7eDz8gZ9Sr+RuAJqQTf5y8RgJCAwbZ2qA=
+github.com/argoproj-labs/argocd-operator v0.3.1 h1://rCFLFq0j800dnq2012szfCAUwyBAsxITGAlfbFUrA=
+github.com/argoproj-labs/argocd-operator v0.3.1/go.mod h1:XFTH8giszL7eDz8gZ9Sr+RuAJqQTf5y8RgJCAwbZ2qA=
 github.com/argoproj/argo-cd/v2 v2.2.4 h1:PoxrWuwGV8UhDkvOE2iYDRa799jnT68tU6XvDZzLzL0=
 github.com/argoproj/argo-cd/v2 v2.2.4/go.mod h1:J51If+krhtBEbNP/Y/l9sh9HctPHiiGueqPAkfFXXBo=
 github.com/argoproj/gitops-engine v0.5.2/go.mod h1:K2RYpGXh11VdFwDksS23SyFTOJaPcsF+MVJ/FHlqEOE=


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

> /kind bug

**What does this PR do / why we need it**:
Redis Image upgrade is not work as expected. There is an issue with the current implementation that does not allow the operator to upgrade the redis image.

This PR will fix the above issue.

**Have you updated the necessary documentation?**
NA

**How to test changes / Special notes to the reviewer**:
1. Run the below UnitTest
`/usr/local/go/bin/go test -timeout 30s -run ^TestReconcileArgoCD_reconcileRedisDeployment_testImageUpgrade$ github.com/argoproj-labs/argocd-operator/controllers/argocd`

or

2. Run the operator locally using `make install run`
    - Create an Argo CD instance.
    - Stop the operator
    - Rerun the operator using the below command
       `ARGOCD_REDIS_IMAGE=docker.io/redis/redis` make run
    - Verify the redis deployment is recreated with new Image.
