### PR TITLE
fix: issues with redis upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.16
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.2.1
+	github.com/argoproj-labs/argocd-operator v0.2.2
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.0
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/argoproj-labs/argocd-operator v0.2.1 h1:OP6OOLfKixFZfPKwzyEZv0Nsgkpt3DzQc75iddUqRF0=
 github.com/argoproj-labs/argocd-operator v0.2.1/go.mod h1:l214z29p7ViikfRikLcZN4isJTJQ2ExCfCIPzf4CgpA=
+github.com/argoproj-labs/argocd-operator v0.2.2 h1:v3LjSQKNgCBMqJ2HA7AT0CCQm9LJY+ua9urRWt8LkqY=
+github.com/argoproj-labs/argocd-operator v0.2.2/go.mod h1:l214z29p7ViikfRikLcZN4isJTJQ2ExCfCIPzf4CgpA=
 github.com/argoproj/argo-cd/v2 v2.2.5 h1:Amthb2SRNixwl6q/1dk+3SbfXouNApk+eS0Zy9TsYqc=
 github.com/argoproj/argo-cd/v2 v2.2.5/go.mod h1:J51If+krhtBEbNP/Y/l9sh9HctPHiiGueqPAkfFXXBo=
 github.com/argoproj/gitops-engine v0.5.2/go.mod h1:K2RYpGXh11VdFwDksS23SyFTOJaPcsF+MVJ/FHlqEOE=


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

> /kind bug

**What does this PR do / why we need it**:
Redis Image upgrade is not work as expected. There is an issue with the current implementation that does not allow the operator to upgrade the redis image.

This PR will fix the above issue.

**Have you updated the necessary documentation?**
NA

**How to test changes / Special notes to the reviewer**:
1. Run the below UnitTest
`/usr/local/go/bin/go test -timeout 30s -run ^TestReconcileArgoCD_reconcileRedisDeployment_testImageUpgrade$ github.com/argoproj-labs/argocd-operator/controllers/argocd`

or

2. Run the operator locally using `make install run`
    - Create an Argo CD instance.
    - Stop the operator
    - Rerun the operator using the below command
       `ARGOCD_REDIS_IMAGE=docker.io/redis/redis` make run
    - Verify the redis deployment is recreated with new Image.
