### PR TITLE
fix: issues with redis upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.16
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20211213144122-1f8cf5364465
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20220624091040-09b69101207b
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/argoproj-labs/argocd-operator v0.0.16-0.20211213144122-1f8cf5364465 h1:vzQYJ0YG2dEwitdwWHaC8+k1LoueyZKFfnJpWWsA9Ss=
 github.com/argoproj-labs/argocd-operator v0.0.16-0.20211213144122-1f8cf5364465/go.mod h1:giR01w2SS5Yci3qigAPPshEiHCk4QhBZPerSED0xrAU=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20220624091040-09b69101207b h1:jZUaQdXnB8fOCmhGJlv9ubG7HHqIjXuHch7Rt1J1GDM=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20220624091040-09b69101207b/go.mod h1:giR01w2SS5Yci3qigAPPshEiHCk4QhBZPerSED0xrAU=
 github.com/argoproj/argo-cd v1.8.7 h1:CkIu8p/gcTY/fOZWM2tHuSCIAV2HggXjJftrT1IIT3k=
 github.com/argoproj/argo-cd v1.8.7/go.mod h1:tqFZW5Lr9KBCDsvOaE5Fh8M1eJ1ThvR58pyyLv8Zqvs=
 github.com/argoproj/gitops-engine v0.2.2/go.mod h1:OxXp8YaT73rw9gEBnGBWg55af80nkV/uIjWCbJu1Nw0=


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

> /kind bug

**What does this PR do / why we need it**:
Redis Image upgrade is not work as expected. There is an issue with the current implementation that does not allow the operator to upgrade the redis image.

This PR will fix the above issue.

**Have you updated the necessary documentation?**
NA

**How to test changes / Special notes to the reviewer**:
1. Run the below UnitTest
`/usr/local/go/bin/go test -timeout 30s -run ^TestReconcileArgoCD_reconcileRedisDeployment_testImageUpgrade$ github.com/argoproj-labs/argocd-operator/controllers/argocd`

or

2. Run the operator locally using `make install run`
    - Create an Argo CD instance.
    - Stop the operator
    - Rerun the operator using the below command
       `ARGOCD_REDIS_IMAGE=docker.io/redis/redis` make run
    - Verify the redis deployment is recreated with new Image.
