### PR TITLE
Update argocd to 2.4.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.18
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20220708063523-39d77c62f2b2
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20220712180904-9d44bb5121df
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.7
@@ -31,7 +31,7 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
-	github.com/argoproj/argo-cd/v2 v2.4.3 // indirect
+	github.com/argoproj/argo-cd/v2 v2.4.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -147,10 +147,10 @@ github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.m
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20220708063523-39d77c62f2b2 h1:uh3w9dwuwOoFocRnZzBqUNBJZxMCBxG3lpw2O2E85CA=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20220708063523-39d77c62f2b2/go.mod h1:1ILWWdhBk8du4uchzVJCmTm9CLfW6jDeuMcsh1XYoUg=
-github.com/argoproj/argo-cd/v2 v2.4.3 h1:fDxI3igc6u0QZXOzXCrAyU/CDmNpNprnefkGimkdbsY=
-github.com/argoproj/argo-cd/v2 v2.4.3/go.mod h1:CnD0D1JGTSFxkALblVZiSm8sVgEKH1oaFQoMtpC7EaE=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20220712180904-9d44bb5121df h1:YShh8T2ovxuhK5dAJCz4zc/WAn+LCqrLVqhYqhatTfk=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20220712180904-9d44bb5121df/go.mod h1:efb9iNW8QcAaN2gvsfjE9U2xIdDcxxvVEGaz9mkO3Vc=
+github.com/argoproj/argo-cd/v2 v2.4.5 h1:B2dkwERNkXtZbAUswEWKgdzu8mxzpXQz++NnHUXrtYg=
+github.com/argoproj/argo-cd/v2 v2.4.5/go.mod h1:CnD0D1JGTSFxkALblVZiSm8sVgEKH1oaFQoMtpC7EaE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

Update to the latest argocd-operator, which pulls in argocd version 2.4.5

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
