### PR TITLE
fix: operator resource labels should be unique

### DIFF
--- a/bundle/manifests/gitops-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/gitops-operator-controller-manager-metrics-service_v1_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    name: openshift-gitops-operator
+    control-plane: argocd-operator
   name: gitops-operator-controller-manager-metrics-service
 spec:
   ports:
@@ -11,6 +11,6 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    name: openshift-gitops-operator
+    control-plane: argocd-operator
 status:
   loadBalancer: {}

--- a/bundle/manifests/gitops-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/gitops-operator-controller-manager-metrics-service_v1_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    control-plane: controller-manager
+    name: openshift-gitops-operator
   name: gitops-operator-controller-manager-metrics-service
 spec:
   ports:
@@ -11,6 +11,6 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    name: openshift-gitops-operator
 status:
   loadBalancer: {}

--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -551,12 +551,12 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              name: openshift-gitops-operator
+              control-plane: argocd-operator
           strategy: {}
           template:
             metadata:
               labels:
-                name: openshift-gitops-operator
+                control-plane: argocd-operator
             spec:
               containers:
               - args:

--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -551,12 +551,12 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: controller-manager
+              name: openshift-gitops-operator
           strategy: {}
           template:
             metadata:
               labels:
-                control-plane: controller-manager
+                name: openshift-gitops-operator
             spec:
               containers:
               - args:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    name: openshift-gitops-operator
   name: system
 ---
 apiVersion: apps/v1
@@ -11,16 +11,16 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    name: openshift-gitops-operator
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      name: openshift-gitops-operator
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        name: openshift-gitops-operator
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    name: openshift-gitops-operator
+    control-plane: argocd-operator
   name: system
 ---
 apiVersion: apps/v1
@@ -11,16 +11,16 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    name: openshift-gitops-operator
+    control-plane: argocd-operator
 spec:
   selector:
     matchLabels:
-      name: openshift-gitops-operator
+      control-plane: argocd-operator
   replicas: 1
   template:
     metadata:
       labels:
-        name: openshift-gitops-operator
+        control-plane: argocd-operator
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    name: openshift-gitops-operator
+    control-plane: argocd-operator
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      name: openshift-gitops-operator
+      control-plane: argocd-operator

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    name: openshift-gitops-operator
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      name: openshift-gitops-operator

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: openshift-gitops-operator
+    control-plane: argocd-operator
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -11,4 +11,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    name: openshift-gitops-operator
+    control-plane: argocd-operator

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    name: openshift-gitops-operator
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -11,4 +11,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    name: openshift-gitops-operator

--- a/test/e2e/gitopsservice_test.go
+++ b/test/e2e/gitopsservice_test.go
@@ -466,7 +466,7 @@ var _ = Describe("GitOpsServiceController", func() {
 			err = cmd.Run()
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func() error {
+			/*Eventually(func() error {
 				err := helper.ApplicationHealthStatus("nginx", sourceNS)
 				if err != nil {
 					return err
@@ -476,7 +476,7 @@ var _ = Describe("GitOpsServiceController", func() {
 					return err
 				}
 				return nil
-			}, time.Second*180, interval).ShouldNot(HaveOccurred())
+			}, time.Second*180, interval).ShouldNot(HaveOccurred())*/
 		})
 
 		It("Clean up resources", func() {

--- a/test/e2e/gitopsservice_test.go
+++ b/test/e2e/gitopsservice_test.go
@@ -466,7 +466,7 @@ var _ = Describe("GitOpsServiceController", func() {
 			err = cmd.Run()
 			Expect(err).NotTo(HaveOccurred())
 
-			/*Eventually(func() error {
+			Eventually(func() error {
 				err := helper.ApplicationHealthStatus("nginx", sourceNS)
 				if err != nil {
 					return err
@@ -476,7 +476,7 @@ var _ = Describe("GitOpsServiceController", func() {
 					return err
 				}
 				return nil
-			}, time.Second*180, interval).ShouldNot(HaveOccurred())*/
+			}, time.Second*300, interval).ShouldNot(HaveOccurred())
 		})
 
 		It("Clean up resources", func() {


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
operator-sdk sets the default labels as `control-plane: controller-manager` in the manifests. This label is generic and should be modified according the operator.

One of the users has reported the below [issue](https://coreos.slack.com/archives/CMP95ST2N/p1658320079802799) on coreos slack.

```
I have a customer on ROSA on 4.9.37 who have got these operators installed from the OperatorHub.
Red Hat OpenShift GitOps  -----> 1.5.4 provided by Red Hat Inc.
GitLab Runner ----> 1.9.0 provided by GitLab, Inc.

The target namespace for these operators in "openshift-operators" and cannot be overridden.
The GitLab runner installs  3 services with a pod selector "control-plane=controller-manager".

This pod selector matches pods installed by both operators, hence customer is getting random deployment errors like:
one or more objects failed to apply, reason: Internal error occurred: 
failed calling webhook "mrunner.kb.io": 

failed to call webhook: Post "[https://gitlab-runner-controller-manager-service.openshift-operators.svc:443/mutate-apps-gitlab-com-v1beta2-runner?timeout=10s](https://gitlab-runner-controller-manager-service.openshift-operators.svc/mutate-apps-gitlab-com-v1beta2-runner?timeout=10s)": 
dial tcp 10.129.6.23:9443: connect: connection refused
```

**Have you updated the necessary documentation?**
* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
Fixes a part of [GITOPS-2144](https://issues.redhat.com/browse/GITOPS-2144)

**Test acceptance criteria**:
* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
1. Build the operator using the below commands (Please replace the username with yours and ensure the repos are pre-created and made public). You can also skip to next step and use the Image that I built.
```
make docker-build IMG=quay.io/aveerama/gitops-backend-operator:fixlabels
make docker-push IMG=quay.io/aveerama/gitops-backend-operator:fixlabels
rm -fr bundle
make bundle IMG=quay.io/aveerama/gitops-backend-operator:fixlabels
make bundle-build BUNDLE_IMG=quay.io/aveerama/gitops-backend-operator-bundle:fixlabels
make bundle-push BUNDLE_IMG=quay.io/aveerama/gitops-backend-operator-bundle:fixlabels
make catalog-build BUNDLE_IMG=quay.io/aveerama/gitops-backend-operator-bundle:fixlabels CATALOG_IMG=quay.io/aveerama/gitops-backend-operator-index:fixlabel
make catalog-push CATALOG_IMG=quay.io/aveerama/gitops-backend-operator-index:fixlabel
```
2. Deploy the catalog source using the catalog image built in the above step.
`quay.io/aveerama/gitops-backend-operator-index:fixlabel`.
3. Run the operator from OperatorHub section of your openshift cluster.
4. Ensure the operator is running.
5. Create an Argo CD Instance and ensure the pods are running.
6. If you have access to the KuTTL e2e tests, run them or try out some manual scenarios like creation of application.