### PR TITLE
feat: propogate crd changes from argocd-operator to gitops-operator

### DIFF
--- a/hack/propogate.sh
+++ b/hack/propogate.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -e
+
+trap cleanup EXIT
+
+function cleanup {
+  echo "Removing /tmp/argocd-operator-hack"
+  rm  -rf /tmp/argocd-operator-hack
+}
+
+function installgit { 
+
+ pkgname=git
+ which $pkgname > /dev/null;isPackage=$?
+ if [ $isPackage != 0 ];then
+        echo "$pkgname not installed"
+        sleep 1
+        read -r -p "${1:-$pkgname will be installed. Are you sure? [y/N]} " response
+        case "$response" in
+            [yY][eE][sS]|[yY]) 
+                sudo apt-get install $pkgname
+                ;;
+            *)
+                false
+                ;;
+        esac
+
+ else
+        echo "$pkgname is installed"
+        sleep 1
+ fi
+
+}
+
+
+installgit
+
+
+mkdir -p /tmp/argocd-operator-hack
+
+git clone https://github.com/argoproj-labs/argocd-operator.git /tmp/argocd-operator-hack/
+
+changedFiles=$(diff -qr /tmp/argocd-operator-hack/config/crd/bases/  ../config/crd/bases/ | grep -v argoproj.io_argocdexports.yaml | grep differ | awk -F ' ' '{print $2}')
+
+echo "Changed Files"
+echo $changedFiles
+
+if [ -z "$changedFiles" ]
+then
+      echo "No difference found"
+else
+      cp ${changedFiles} ../config/crd/bases/ 
+      cd ..
+      go mod vendor
+      make bundle
+fi


### PR DESCRIPTION
Signed-off-by: rishabh625 <rishabhmishra625@gmail.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
This PR contains a shell script that clones upstream ooperator compares config/crd and add those changes in gitops-operator and run make bundle


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
To test this PR make changes in config/crd/bases/ files and run below commands
cd hack
sh propogate.sh
