### PR TITLE
Support console api being optional

### DIFF
--- a/controllers/argocd_controller.go
+++ b/controllers/argocd_controller.go
@@ -30,6 +30,7 @@ import (
 	console "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/redhat-developer/gitops-operator/common"
+	"github.com/redhat-developer/gitops-operator/controllers/util"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -116,6 +117,11 @@ func (r *ReconcileArgoCDRoute) Reconcile(ctx context.Context, request reconcile.
 	var logs = logf.Log.WithName("controller_argocd_route")
 	reqLogger := logs.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling ArgoCD Route")
+
+	if !util.IsConsoleAPIFound() {
+		reqLogger.Info("Skip argocd route reconcile: OpenShift Console API not found")
+		return reconcile.Result{}, nil
+	}
 
 	// Fetch ArgoCD server route
 	argoCDRoute := &routev1.Route{}

--- a/controllers/kam.go
+++ b/controllers/kam.go
@@ -30,6 +30,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	pipelinesv1alpha1 "github.com/redhat-developer/gitops-operator/api/v1alpha1"
 	"github.com/redhat-developer/gitops-operator/common"
+	"github.com/redhat-developer/gitops-operator/controllers/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -175,6 +176,11 @@ func newConsoleCLIDownload(consoleLinkName, href, text string) *console.ConsoleC
 func (r *ReconcileGitopsService) reconcileCLIServer(cr *pipelinesv1alpha1.GitopsService, request reconcile.Request) (reconcile.Result, error) {
 
 	reqLogger := logs.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+
+	if !util.IsConsoleAPIFound() {
+		reqLogger.Info("Skip cli server reconcile: OpenShift Console API not found")
+		return reconcile.Result{}, nil
+	}
 
 	deploymentObj := newDeploymentForCLI()
 

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -19,7 +19,9 @@ package util
 import (
 	"context"
 
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 	configv1 "github.com/openshift/api/config/v1"
+	console "github.com/openshift/api/console/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,6 +30,10 @@ import (
 
 const (
 	clusterVersionName = "version"
+)
+
+var (
+	consoleAPIFound = false
 )
 
 // GetClusterVersion returns the OpenShift Cluster version in which the operator is installed
@@ -58,4 +64,29 @@ func NewClusterVersion(version string) *configv1.ClusterVersion {
 			},
 		},
 	}
+}
+
+func InspectCluster() error {
+	if err := verifyConsoleAPI(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func IsConsoleAPIFound() bool {
+	return consoleAPIFound
+}
+
+// *** THIS SHOULD ONLY BE USED FOR UNIT TESTING ***
+func SetConsoleAPIFound(found bool) {
+	consoleAPIFound = found
+}
+
+func verifyConsoleAPI() error {
+	found, err := argoutil.VerifyAPI(console.GroupName, console.GroupVersion.Version)
+	if err != nil {
+		return err
+	}
+	consoleAPIFound = found
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/redhat-developer/gitops-operator/common"
 	"github.com/redhat-developer/gitops-operator/controllers"
 	"github.com/redhat-developer/gitops-operator/controllers/argocd/openshift"
+	"github.com/redhat-developer/gitops-operator/controllers/util"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	//+kubebuilder:scaffold:imports
 )
@@ -85,6 +86,10 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	if err := util.InspectCluster(); err != nil {
+		setupLog.Info("unable to inspect cluster")
+	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -41,6 +41,7 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	pipelinesv1alpha1 "github.com/redhat-developer/gitops-operator/api/v1alpha1"
 	"github.com/redhat-developer/gitops-operator/controllers"
+	"github.com/redhat-developer/gitops-operator/controllers/util"
 	"github.com/redhat-developer/gitops-operator/test/helper"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -140,6 +141,9 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).NotTo(BeNil())
 
 	err = helper.EnsureCleanSlate(k8sClient)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = util.InspectCluster()
 	Expect(err).NotTo(HaveOccurred())
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{

--- a/test/nondefaulte2e/suite_test.go
+++ b/test/nondefaulte2e/suite_test.go
@@ -43,6 +43,7 @@ import (
 	pipelinesv1alpha1 "github.com/redhat-developer/gitops-operator/api/v1alpha1"
 	"github.com/redhat-developer/gitops-operator/common"
 	"github.com/redhat-developer/gitops-operator/controllers"
+	"github.com/redhat-developer/gitops-operator/controllers/util"
 	"github.com/redhat-developer/gitops-operator/test/helper"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -124,6 +125,9 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).NotTo(BeNil())
 
 	err = helper.EnsureCleanSlate(k8sClient)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = util.InspectCluster()
 	Expect(err).NotTo(HaveOccurred())
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

Support console api being optional

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [x] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
