### PR TITLE
Add reconcile plugin condition

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -29,6 +29,8 @@ const (
 	DefaultConsoleImage = "quay.io/redhat-developer/gitops-console-plugin"
 	// Default console plugin version
 	DefaultConsoleVersion = "v0.1.0"
+	// Default console plugin installation OCP version
+	DefaultDynamicPluginStartOCPVersion = "4.15.0"
 )
 
 // InfraNodeSelector returns openshift label for infrastructure nodes

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.8
+	github.com/hashicorp/go-version v1.2.1
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible

--- a/go.sum
+++ b/go.sum
@@ -687,6 +687,8 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
+github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:
To avoid multiple "Environments" button showing up in left menu on Developer tab in DevConsole.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes GITOPS-2415

**Test acceptance criteria**:

* [x] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
1. On OCP 4.15 or greater, observe that Console Plugin section is showing up on GitOps-operator installation page. Only one "Environments" button exists on Developer tab left menu.
2. On OCP 4.14 or lower, observe that Console Plugin section is not showing up on GitOps-operator installation page. Only one "Environments" button exists on Developer tab left menu.