### PR TITLE
clearer instruction to disable default argocd instance

### DIFF
--- a/docs/OpenShift GitOps Usage Guide.md
+++ b/docs/OpenShift GitOps Usage Guide.md
@@ -119,7 +119,20 @@ openshift-gitops-server-86df579bbf-zz9lx                     1/1     Running   0
 
 When installing the OpenShift GitOps operator to ROSA/OSD, cluster administrators may wish to exclude users from modifying resources within the *openshift-** namespaces, including the *openshift-gitops* namespace which is the default location for an Argo CD install.
 
-To disable the default ‘ready-to-use’ installation of Argo CD: as an admin, update the existing Subscription Object for Gitops Operator and add `DISABLE_DEFAULT_ARGOCD_INSTANCE = true` to the spec.
+To disable the default ‘ready-to-use’ installation of Argo CD: as an admin, update the existing Subscription Object for Gitops Operator and add `DISABLE_DEFAULT_ARGOCD_INSTANCE = true` to the `subscriptions.operators.coreos.com.spec.config.env` resource as follows - 
+
+```
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+  name: openshift-gitops-operator
+  namespace: openshift-operators
+spec:
+  config:
+    env:
+    - name: DISABLE_DEFAULT_ARGOCD_INSTANCE
+      value: "TRUE"
+
+```
 
 **Warning**: setting this option to true will cause the existing Argo CD install in the *openshift-gitops* namespace to be deleted. Argo CD instances in other namespaces should not be affected.
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What does this PR do / why we need it**:
Specifically mentioning to edit the `env` resource within the `subscriptions.operators.coreos.com.spec.config` CRD to add the associated env. var. in order to disable the default argocd  instance launch.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
