### PR TITLE
fix: update the bundle package name to openshift-gitops-operator

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -3,7 +3,7 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: gitops-operator
+  operators.operatorframework.io.bundle.package.v1: openshift-gitops-operator
   operators.operatorframework.io.bundle.channels.v1: latest,gitops-1.8
   operators.operatorframework.io.bundle.channel.default.v1: latest
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.10.0+git


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind bug

Updates the bundle package name to `openshift-gitops-operator` from `gitops-operator` to fix the failing operator bundle tests.