### PR TITLE
Add target and manifests for Core operator installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,10 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=true -f -
 
+deploy-core: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config,
+                                 ## overlapping env to avoid deploying default unecessary resources.
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/core | kubectl apply -f -
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.

--- a/config/core/default_env_patch.yaml
+++ b/config/core/default_env_patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: DISABLE_DEFAULT_ARGOCD_INSTANCE
+          value: "true"
+        - name: DISABLE_DEFAULT_ARGOCD_CONSOLELINK
+          value: "true"
+        - name: DISABLE_DEX
+          value: "true"
+  

--- a/config/core/kustomization.yaml
+++ b/config/core/kustomization.yaml
@@ -1,0 +1,22 @@
+# Adds namespace to all resources.
+namespace: gitops-operator-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: gitops-operator-
+
+# Bases for kustomization:
+bases:
+- ../crd
+- ../rbac
+- ../manager
+
+# This patches the environment variables of the
+# deployment "gitops-operator-controller-manager"
+# to remove all unnecessary components.
+patchesStrategicMerge:
+- default_env_patch.yaml
+

--- a/docs/OpenShift GitOps Usage Guide.md
+++ b/docs/OpenShift GitOps Usage Guide.md
@@ -38,7 +38,7 @@ Click the "Install" button to finish the installation.
 * * *
 
 
-### Operator Install CLI
+### Operator Install CLI (using [OLM](https://olm.operatorframework.io/))
 
 To install the Operator via the CLI, you will need to create a Subscription.
 
@@ -74,6 +74,16 @@ openshift-gitops-redis-74bd8d7d96-49bjf                   	1/1 	Running   0     
 openshift-gitops-repo-server-c999f75d5-l4rsg              	1/1 	Running   0      	65m
 openshift-gitops-server-5785f7668b-wj57t                  	1/1 	Running   0      	53m
 ```
+
+### Core Operator Install from IIB
+
+To install the Operator without OLM, you just need to pick up a new Image Index Bundle (IIB) and provide it as an argument for the proper make target:
+
+```
+make deploy-core IMG="quay.io/<your_quay_org>/gitops-operator-nightly:20230512"
+```
+
+Keep in mind that the cluster will need access to the container registry where the images compounding the bundle are stored. Otherwise, you will need to provide with the proper authentication to make OpenShift able to pull those images.
 
 ### Installation of OpenShift GitOps without ready-to-use Argo CD instance, for ROSA/OSD
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind enhancement
> /kind bug
> /kind cleanup
> /kind failing-test
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

You can find the new changes in the documentation [here](https://github.com/bluengo/gitops-operator/blob/GITOPSRVCE-376/docs/OpenShift%20GitOps%20Usage%20Guide.md?plain=1#L78-L86)

More information in issue [GITOPSRVCE-376](https://issues.redhat.com/browse/GITOPSRVCE-376) 

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:

Pick up a successful GitOps operator nightly build, and run the new make target to install the core operator in your current OpenShift cluster:

`make deploy-core IMG=<gitops_operator_bundle_image>` 

Remember that this method, as the old `make deploy`, assumes that the cluster already has credentials to access the registry where the images within the bundle are stored.