### PR TITLE
update latest argocd-operator version

### DIFF
--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -233,7 +233,7 @@ spec:
     Audit trails of rollouts to the clusters\n* Monitoring and logging integration
     with OpenShift\n* Automated GitOps bootstrapping using Tekton and Argo CD with
     [GitOps Application Manager CLI](https://github.com/redhat-developer/kam)\n\n##
-    Components\n* Argo CD 2.6.2\n* GitOps Application Manager CLI ([download](https://github.com/redhat-developer/kam/releases))\n\n##
+    Components\n* Argo CD 2.6.3\n* GitOps Application Manager CLI ([download](https://github.com/redhat-developer/kam/releases))\n\n##
     How to Install \nAfter installing the OpenShift GitOps operator, an instance  of
     Argo CD is installed in the `openshift-gitops` namespace which has sufficent privileges
     for managing cluster configurations. You can create additional Argo CD instances

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.18
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20230213131945-d09994dd1256
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20230227222526-cdcfcb7a6653
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.9
@@ -31,7 +31,7 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/argoproj/argo-cd/v2 v2.6.1 // indirect
+	github.com/argoproj/argo-cd/v2 v2.6.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,10 +145,10 @@ github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.m
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20230213131945-d09994dd1256 h1:uhOtCtHO5MMMtpljdsiPi8b4jOc2dTBFuyM/pDWQCxs=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20230213131945-d09994dd1256/go.mod h1:qI2lrVpwm04GIQ7JZqKk9pFHFAZ5ct6PD1OspRPJkCU=
-github.com/argoproj/argo-cd/v2 v2.6.1 h1:fp+ounx6DczbWvfhZ7LCvVOxMQbksoKRFdfqdHHcu+U=
-github.com/argoproj/argo-cd/v2 v2.6.1/go.mod h1:wkQAcIEXpgP8F45T/9UwwHhhLz2KgITba0NOby4NTPQ=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20230227222526-cdcfcb7a6653 h1:pHg0tu0mSoXT/7mzzFdPe7TTYrZt1GU0X6LQGqZy+x8=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20230227222526-cdcfcb7a6653/go.mod h1:R5QjiIWh7KS5kNQ3lkAAgqEz8iCKawgl0SdicaC+ILA=
+github.com/argoproj/argo-cd/v2 v2.6.3 h1:XEvGDnGRroAw5mKKUTcfIbTmjmhL0hEsVh1+vkytrLo=
+github.com/argoproj/argo-cd/v2 v2.6.3/go.mod h1:wkQAcIEXpgP8F45T/9UwwHhhLz2KgITba0NOby4NTPQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
**What type of PR is this?**
 /kind enhancement

**What does this PR do / why we need it**:
Pulls the latest from argocd-operator (which upgrades argocd version to 2.6.3)
(https://github.com/argoproj-labs/argocd-operator/commit/cdcfcb7a6653a6d65fb780f8da2b8d26af8ca4fb) 
