### PR TITLE
fix: add security context for kam and cluster pods

### DIFF
--- a/controllers/gitopsservice_controller_test.go
+++ b/controllers/gitopsservice_controller_test.go
@@ -403,6 +403,71 @@ func TestReconcile_BackendResourceLimits(t *testing.T) {
 	assert.Equal(t, resources.Limits[corev1.ResourceMemory], resourcev1.MustParse("256Mi"))
 }
 
+func TestReconcile_BackendSecurityContext(t *testing.T) {
+	logf.SetLogger(argocd.ZapLogger(true))
+	s := scheme.Scheme
+	addKnownTypesToScheme(s)
+
+	fakeClient := fake.NewFakeClientWithScheme(s, util.NewClusterVersion("4.12.1"), newGitopsService())
+	reconciler := newReconcileGitOpsService(fakeClient, s)
+
+	_, err := reconciler.Reconcile(context.TODO(), newRequest("test", "test"))
+	assertNoError(t, err)
+
+	deployment := appsv1.Deployment{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}, &deployment)
+	assertNoError(t, err)
+
+	securityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
+	want := &corev1.SecurityContext{
+		AllowPrivilegeEscalation: util.BoolPtr(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+		},
+		RunAsNonRoot: util.BoolPtr(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+	assert.DeepEqual(t, securityContext, want)
+}
+
+func TestReconcile_KamSecurityContext(t *testing.T) {
+	logf.SetLogger(argocd.ZapLogger(true))
+	s := scheme.Scheme
+	addKnownTypesToScheme(s)
+
+	util.SetConsoleAPIFound(true)
+	defer util.SetConsoleAPIFound(false)
+
+	fakeClient := fake.NewFakeClientWithScheme(s, util.NewClusterVersion("4.12.1"), newGitopsService())
+	reconciler := newReconcileGitOpsService(fakeClient, s)
+
+	_, err := reconciler.Reconcile(context.TODO(), newRequest("test", "test"))
+	assertNoError(t, err)
+
+	deployment := appsv1.Deployment{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: cliName, Namespace: serviceNamespace}, &deployment)
+	assertNoError(t, err)
+
+	securityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
+	want := &corev1.SecurityContext{
+		AllowPrivilegeEscalation: util.BoolPtr(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+		},
+		RunAsNonRoot: util.BoolPtr(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+	assert.DeepEqual(t, securityContext, want)
+}
+
 func TestReconcile_testArgoCDForOperatorUpgrade(t *testing.T) {
 	logf.SetLogger(argocd.ZapLogger(true))
 	s := scheme.Scheme

--- a/controllers/kam.go
+++ b/controllers/kam.go
@@ -74,6 +74,18 @@ func newDeploymentForCLI() *appsv1.Deployment {
 						corev1.ResourceCPU:    resourcev1.MustParse("500m"),
 					},
 				},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: util.BoolPtr(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{
+							"ALL",
+						},
+					},
+					RunAsNonRoot: util.BoolPtr(true),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 			},
 		},
 	}
@@ -183,6 +195,9 @@ func (r *ReconcileGitopsService) reconcileCLIServer(cr *pipelinesv1alpha1.Gitops
 	}
 
 	deploymentObj := newDeploymentForCLI()
+
+	// Add SeccompProfile based on cluster version
+	util.AddSeccompProfileForOpenShift(r.Client, &deploymentObj.Spec.Template.Spec)
 
 	deploymentObj.Spec.Template.Spec.NodeSelector = argocommon.DefaultNodeSelector()
 

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -18,12 +18,14 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 	configv1 "github.com/openshift/api/config/v1"
 	console "github.com/openshift/api/console/v1"
+	"golang.org/x/mod/semver"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -115,4 +117,25 @@ func caseInsensitiveGetenv(s string) (string, string) {
 		return ls, v
 	}
 	return "", ""
+}
+
+// BoolPtr returns a pointer to val
+func BoolPtr(val bool) *bool {
+	return &val
+}
+
+func AddSeccompProfileForOpenShift(client client.Client, podspec *corev1.PodSpec) {
+
+	version, _ := GetClusterVersion(client)
+	if version == "" || semver.Compare(fmt.Sprintf("v%s", version), "v4.10.999") > 0 {
+		if podspec.SecurityContext == nil {
+			podspec.SecurityContext = &corev1.PodSecurityContext{}
+		}
+		if podspec.SecurityContext.SeccompProfile == nil {
+			podspec.SecurityContext.SeccompProfile = &corev1.SeccompProfile{}
+		}
+		if len(podspec.SecurityContext.SeccompProfile.Type) == 0 {
+			podspec.SecurityContext.SeccompProfile.Type = corev1.SeccompProfileTypeRuntimeDefault
+		}
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

 /kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
port changes from #451 into v1.8 release branch

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
