### PR TITLE
fix: dex client secret is not updated in the argocd-secret intermitte…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.18
 
 require (
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20230227222526-cdcfcb7a6653
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20230309134052-c62aa60525a5
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/argoproj-labs/argocd-operator v0.0.16-0.20230227222526-cdcfcb7a6653 h1:pHg0tu0mSoXT/7mzzFdPe7TTYrZt1GU0X6LQGqZy+x8=
 github.com/argoproj-labs/argocd-operator v0.0.16-0.20230227222526-cdcfcb7a6653/go.mod h1:R5QjiIWh7KS5kNQ3lkAAgqEz8iCKawgl0SdicaC+ILA=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20230309134052-c62aa60525a5 h1:aF1VkLSeLORp0CB0yqGDwqBVH5sIEA/M9HcC4MmoRZQ=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20230309134052-c62aa60525a5/go.mod h1:R5QjiIWh7KS5kNQ3lkAAgqEz8iCKawgl0SdicaC+ILA=
 github.com/argoproj/argo-cd/v2 v2.6.3 h1:XEvGDnGRroAw5mKKUTcfIbTmjmhL0hEsVh1+vkytrLo=
 github.com/argoproj/argo-cd/v2 v2.6.3/go.mod h1:wkQAcIEXpgP8F45T/9UwwHhhLz2KgITba0NOby4NTPQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
This PR will fix the issue with `dex client secret is not updated in the argocd-secret intermittently.`
The actual enhancement of securing the dex client secret (OIDC) is part of #847 

This looks like a race condition or sometimes when operator tries to get the dex client secret from Argo CD dex service account (from the secret named token) the token secret is not created by then. This can be fixed in the reconciliation of existing Argo CD secret which is called much later multiple times.
This is an intermittent behavior and can be reproduced more on the bundle installation rather than the local installation.

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-2714

**How to test changes / Special notes to the reviewer**:
Please refer https://github.com/argoproj-labs/argocd-operator/pull/872