### PR TITLE
fix: handle kam security context during upgrades

### DIFF
--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -610,6 +610,10 @@ func (r *ReconcileGitopsService) reconcileBackend(gitopsserviceNamespacedName ty
 				found.Spec.Template.Spec.Containers[0].Resources = deploymentObj.Spec.Template.Spec.Containers[0].Resources
 				changed = true
 			}
+			if !reflect.DeepEqual(found.Spec.Template.Spec.Containers[0].SecurityContext, deploymentObj.Spec.Template.Spec.Containers[0].SecurityContext) {
+				found.Spec.Template.Spec.Containers[0].SecurityContext = deploymentObj.Spec.Template.Spec.Containers[0].SecurityContext
+				changed = true
+			}
 			if !reflect.DeepEqual(found.Spec.Template.Spec.NodeSelector, deploymentObj.Spec.Template.Spec.NodeSelector) {
 				found.Spec.Template.Spec.NodeSelector = deploymentObj.Spec.Template.Spec.NodeSelector
 				changed = true

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -618,6 +618,10 @@ func (r *ReconcileGitopsService) reconcileBackend(gitopsserviceNamespacedName ty
 				found.Spec.Template.Spec.Tolerations = deploymentObj.Spec.Template.Spec.Tolerations
 				changed = true
 			}
+			if !reflect.DeepEqual(found.Spec.Template.Spec.SecurityContext, deploymentObj.Spec.Template.Spec.SecurityContext) {
+				found.Spec.Template.Spec.SecurityContext = deploymentObj.Spec.Template.Spec.SecurityContext
+				changed = true
+			}
 
 			if changed {
 				reqLogger.Info("Reconciling existing backend Deployment", "Namespace", deploymentObj.Namespace, "Name", deploymentObj.Name)

--- a/controllers/kam.go
+++ b/controllers/kam.go
@@ -230,6 +230,10 @@ func (r *ReconcileGitopsService) reconcileCLIServer(cr *pipelinesv1alpha1.Gitops
 			existingDeployment.Spec.Template.Spec.SecurityContext = deploymentObj.Spec.Template.Spec.SecurityContext
 			changed = true
 		}
+		if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Containers[0].SecurityContext, deploymentObj.Spec.Template.Spec.Containers[0].SecurityContext) {
+			existingDeployment.Spec.Template.Spec.Containers[0].SecurityContext = deploymentObj.Spec.Template.Spec.Containers[0].SecurityContext
+			changed = true
+		}
 
 		if changed {
 			err = r.Client.Update(context.TODO(), existingDeployment)

--- a/controllers/kam.go
+++ b/controllers/kam.go
@@ -226,7 +226,6 @@ func (r *ReconcileGitopsService) reconcileCLIServer(cr *pipelinesv1alpha1.Gitops
 			existingDeployment.Spec.Template.Spec.Tolerations = deploymentObj.Spec.Template.Spec.Tolerations
 			changed = true
 		}
-
 		if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.SecurityContext, deploymentObj.Spec.Template.Spec.SecurityContext) {
 			existingDeployment.Spec.Template.Spec.SecurityContext = deploymentObj.Spec.Template.Spec.SecurityContext
 			changed = true

--- a/controllers/kam.go
+++ b/controllers/kam.go
@@ -227,6 +227,11 @@ func (r *ReconcileGitopsService) reconcileCLIServer(cr *pipelinesv1alpha1.Gitops
 			changed = true
 		}
 
+		if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.SecurityContext, deploymentObj.Spec.Template.Spec.SecurityContext) {
+			existingDeployment.Spec.Template.Spec.SecurityContext = deploymentObj.Spec.Template.Spec.SecurityContext
+			changed = true
+		}
+
 		if changed {
 			err = r.Client.Update(context.TODO(), existingDeployment)
 			if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
KAM security context was added as part of #451 which is working fine for `v1.8.0 release candidate` installation but fails when user tries to update from `1.7.2` to `1.8 release candidate`.

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:
Fixes https://issues.redhat.com/browse/GITOPS-2729

**How to test changes / Special notes to the reviewer**:
- Create the `v1.8.0-rc` by using the below steps.
  ```
  make docker-build IMG=quay.io/aveerama/gitops-backend-operator:1.8.0-rc
  make docker-push IMG=quay.io/aveerama/gitops-backend-operator:1.8.0-rc
  rm -fr bundle
  make bundle IMG=quay.io/aveerama/gitops-backend-operator:1.8.0-rc
  make bundle-build BUNDLE_IMG=quay.io/aveerama/gitops-backend-operator-bundle:1.8.0-rc
  make bundle-push BUNDLE_IMG=quay.io/aveerama/gitops-backend-operator-bundle:1.8.0-rc
  make catalog-build BUNDLE_IMG=quay.io/aveerama/gitops-backend-operator-bundle:1.8.0-rc CATALOG_IMG=quay.io/aveerama/gitops-backend-operator-index:1.8.0-rc
  make catalog-push CATALOG_IMG=quay.io/aveerama/gitops-backend-operator-index:1.8.0-rc
  ```
- Install the v1.7.2 version of the operator using the below subscription 
   ```
   apiVersion: operators.coreos.com/v1alpha1
    kind: Subscription
    metadata:
      name: openshift-gitops-operator
      namespace: openshift-gitops
   spec:
      channel: "gitops-1.7"
      installPlanApproval: Automatic
      name: openshift-gitops-operator
      source: redhat-operators
      sourceNamespace: openshift-marketplace
      config:
        env:
          - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
            value: 'openshift-gitops, defualt'
   ```
- Wait for the operator to create resources and then upgrade the operator to latest version using the upgrade option.
- Verify Pod Security Context is available for the KAM pod.
   
You can verify the Cluster deployment also using the same steps.