### PR TITLE
Revert "Changing naming conventions for v1.8"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.8.0
+VERSION ?= 0.0.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")
@@ -27,7 +27,7 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # IMAGE defines the base image to be used for operator, bundle and catalog.
-IMAGE ?= quay.io/redhat-developer/gitops-operator
+IMAGE ?= quay.io/redhat-developer/gitops-backend-operator
 
 # IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
 # This variable is used to construct full image tags for bundle and catalog images.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: 'Gitops Service by Red Hat'
-  image: 'quay.io/<quay-username>/gitops-operator-index:v0.0.1'
+  image: 'quay.io/<quay-username>/gitops-backend-operator-index:v0.0.1'
   publisher: 'Red Hat Developer'
   sourceType: grpc
 ```
@@ -71,7 +71,7 @@ mode. You could update your image "payload" and re-install the operator.
 Set the base image and version for building operator, bundle and index images.
 
 ```
-export IMAGE=quay.io/<quay-username>/gitops-operator VERSION=1.8.0
+export IMAGE=quay.io/<quay-username>/gitops-backend-operator VERSION=0.0.4
 ```
 
 1. Build and push the operator image.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=gitops-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=latest,gitops-1.8
 LABEL operators.operatorframework.io.bundle.channel.default.v1=latest
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.22.0-ocp
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.10.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -134,15 +134,15 @@ metadata:
       ]
     capabilities: Deep Insights
     console.openshift.io/plugins: '["gitops-plugin"]'
-    containerImage: quay.io/redhat-developer/gitops-operator:v1.8.0
+    containerImage: quay.io/redhat-developer/gitops-backend-operator:v0.0.3
     description: Enables teams to adopt GitOps principles for managing cluster configurations
       and application delivery across hybrid multi-cluster Kubernetes environments.
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.22.0-ocp
+    operators.operatorframework.io/builder: operator-sdk-v1.10.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/redhat-developer/gitops-operator
     support: Red Hat
-  name: gitops-operator.v1.8.0
+  name: gitops-operator.v0.0.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -581,9 +581,7 @@ spec:
           - create
         serviceAccountName: gitops-operator-controller-manager
       deployments:
-      - label:
-          control-plane: argocd-operator
-        name: gitops-operator-controller-manager
+      - name: gitops-operator-controller-manager
         spec:
           replicas: 1
           selector:
@@ -603,7 +601,7 @@ spec:
                   value: openshift-gitops
                 - name: OPERATOR_NAME
                   value: gitops-operator
-                image: quay.io/redhat-developer/gitops-operator:v1.8.0
+                image: quay.io/redhat-developer/gitops-backend-operator:v0.0.3
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -688,5 +686,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat Inc
-  replaces: gitops-operator.v1.7.3
-  version: 1.8.0
+  replaces: gitops-operator.v0.0.2
+  version: 0.0.3

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -3,10 +3,10 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: gitops-operator
+  operators.operatorframework.io.bundle.package.v1: openshift-gitops-operator
   operators.operatorframework.io.bundle.channels.v1: latest,gitops-1.8
   operators.operatorframework.io.bundle.channel.default.v1: latest
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.22.0-ocp
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.10.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/redhat-developer/gitops-operator
-  newTag: v1.8.0
+  newName: quay.io/redhat-developer/gitops-backend-operator
+  newTag: v0.0.3

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           value: openshift-gitops
         - name: OPERATOR_NAME
           value: gitops-operator
-        image: quay.io/redhat-developer/gitops-operator:v1.8.0
+        image: quay.io/redhat-developer/gitops-backend-operator:v0.0.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manifests/bases/gitops-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/gitops-operator.clusterserviceversion.yaml
@@ -4,13 +4,13 @@ metadata:
   annotations:
     capabilities: Deep Insights
     console.openshift.io/plugins: '["gitops-plugin"]'
-    containerImage: quay.io/redhat-developer/gitops-operator:v1.8.0
+    containerImage: quay.io/redhat-developer/gitops-backend-operator:v0.0.3
     description: Enables teams to adopt GitOps principles for managing cluster configurations
       and application delivery across hybrid multi-cluster Kubernetes environments.
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/redhat-developer/gitops-operator
     support: Red Hat
-  name: gitops-operator.v1.8.0
+  name: gitops-operator.v0.0.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -117,5 +117,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat Inc
-  replaces: gitops-operator.v1.7.3
-  version: 1.8.0
+  replaces: gitops-operator.v0.0.2
+  version: 0.0.3

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -31,11 +31,11 @@ patchesJson6902:
     group: operators.coreos.com
     version: v1alpha1
     kind: ClusterServiceVersion
-    name: gitops-operator.v1.8.0
+    name: gitops-operator.v0.0.3
   path: patches/icon.yaml
 - target:
     group: operators.coreos.com
     version: v1alpha1
     kind: ClusterServiceVersion
-    name: gitops-operator.v1.8.0
+    name: gitops-operator.v0.0.3
   path: patches/description.yaml

--- a/scripts/openshiftci-olm-kuttl-tests.sh
+++ b/scripts/openshiftci-olm-kuttl-tests.sh
@@ -30,8 +30,8 @@ E2E_SKIP_OPERATOR_INSTALLATION=${E2E_SKIP_OPERATOR_INSTALLATION:-false}
 IGNORE_PARALLEL_TESTS=${IGNORE_PARALLEL_TESTS:-false}
 
 E2E_SKIP_BUILD_TOOL_INSTALLATION=${E2E_SKIP_BUILD_TOOL_INSTALLATION:-false} # This flag helps to skip build tool installation on your local system
-IMAGE=${IMAGE:-"quay.io/redhat-developer/gitops-operator"}
-VERSION=${VERSION:-"1.8.0"}
+IMAGE=${IMAGE:-"quay.io/redhat-developer/gitops-backend-operator"}
+VERSION=${VERSION:-"0.0.3"}
 CATALOG_SOURCE=${CATALOG_SOURCE:-"openshift-gitops-operator"}
 CHANNEL=${CHANNEL:-"latest"}
 


### PR DESCRIPTION
Reverts redhat-developer/gitops-operator#467

This is for avoiding changes w.r.t unit tests
[Logs](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/37666/rehearse-37666-pull-ci-redhat-developer-gitops-operator-v1.8-unit/1639335005085765632)
