### PR TITLE
test: use `t.Setenv` to set env vars

### DIFF
--- a/controllers/argocd/openshift/clusterconfig_test.go
+++ b/controllers/argocd/openshift/clusterconfig_test.go
@@ -2,7 +2,7 @@ package openshift
 
 import (
 	"fmt"
-	"os"
+	"testing"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -56,12 +56,8 @@ func makeTestArgoCD() *argoapp.ArgoCD {
 	return a
 }
 
-func setClusterConfigNamespaces() {
-	os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "argocd,foo,bar")
-}
-
-func unSetClusterConfigNamespaces() {
-	os.Unsetenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES")
+func setClusterConfigNamespaces(t *testing.T) {
+	t.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "argocd,foo,bar")
 }
 
 func makeTestClusterRole() *rbacv1.ClusterRole {

--- a/controllers/argocd/openshift/openshift_test.go
+++ b/controllers/argocd/openshift/openshift_test.go
@@ -12,8 +12,7 @@ import (
 
 func TestReconcileArgoCD_reconcileApplicableClusterRole(t *testing.T) {
 
-	setClusterConfigNamespaces()
-	defer unSetClusterConfigNamespaces()
+	setClusterConfigNamespaces(t)
 
 	a := makeTestArgoCDForClusterConfig()
 	testClusterRole := &rbacv1.ClusterRole{
@@ -30,8 +29,7 @@ func TestReconcileArgoCD_reconcileApplicableClusterRole(t *testing.T) {
 
 func TestReconcileArgoCD_reconcileNotApplicableClusterRole(t *testing.T) {
 
-	setClusterConfigNamespaces()
-	defer unSetClusterConfigNamespaces()
+	setClusterConfigNamespaces(t)
 
 	a := makeTestArgoCDForClusterConfig()
 	testClusterRole := makeTestClusterRole()
@@ -42,8 +40,7 @@ func TestReconcileArgoCD_reconcileNotApplicableClusterRole(t *testing.T) {
 
 func TestReconcileArgoCD_reconcileMultipleClusterRoles(t *testing.T) {
 
-	setClusterConfigNamespaces()
-	defer unSetClusterConfigNamespaces()
+	setClusterConfigNamespaces(t)
 
 	a := makeTestArgoCDForClusterConfig()
 	testApplicableClusterRole := &rbacv1.ClusterRole{
@@ -66,8 +63,7 @@ func TestReconcileArgoCD_reconcileMultipleClusterRoles(t *testing.T) {
 
 func TestReconcileArgoCD_testDeployment(t *testing.T) {
 
-	setClusterConfigNamespaces()
-	defer unSetClusterConfigNamespaces()
+	setClusterConfigNamespaces(t)
 
 	a := makeTestArgoCDForClusterConfig()
 	testDeployment := makeTestDeployment()
@@ -77,8 +73,7 @@ func TestReconcileArgoCD_testDeployment(t *testing.T) {
 
 func TestReconcileArgoCD_notInClusterConfigNamespaces(t *testing.T) {
 
-	setClusterConfigNamespaces()
-	defer unSetClusterConfigNamespaces()
+	setClusterConfigNamespaces(t)
 
 	a := makeTestArgoCD()
 	testClusterRole := &rbacv1.ClusterRole{
@@ -193,8 +188,7 @@ func TestReconcileArgoCD_reconcileRedisHaServerStatefulSet(t *testing.T) {
 }
 
 func TestReconcileArgoCD_reconcileSecrets(t *testing.T) {
-	setClusterConfigNamespaces()
-	defer unSetClusterConfigNamespaces()
+	setClusterConfigNamespaces(t)
 
 	a := makeTestArgoCDForClusterConfig()
 	testSecret := &corev1.Secret{

--- a/controllers/gitopsservice_controller_test.go
+++ b/controllers/gitopsservice_controller_test.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	argoapp "github.com/argoproj-labs/argocd-operator/api/v1beta1"
@@ -54,8 +53,7 @@ func TestImageFromEnvVariable(t *testing.T) {
 	ns := types.NamespacedName{Name: "test", Namespace: "test"}
 	t.Run("Image present as env variable", func(t *testing.T) {
 		image := "quay.io/org/test"
-		os.Setenv(backendImageEnvName, image)
-		defer os.Unsetenv(backendImageEnvName)
+		t.Setenv(backendImageEnvName, image)
 
 		deployment := newBackendDeployment(ns)
 
@@ -75,8 +73,7 @@ func TestImageFromEnvVariable(t *testing.T) {
 
 	t.Run("Kam Image present as env variable", func(t *testing.T) {
 		image := "quay.io/org/test"
-		os.Setenv(cliImageEnvName, image)
-		defer os.Unsetenv(cliImageEnvName)
+		t.Setenv(cliImageEnvName, image)
 
 		deployment := newDeploymentForCLI()
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What does this PR do / why we need it**:

Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

```go
func TestFoo(t *testing.T) {
	// before
	os.Setenv(key, "new value")
	defer os.Unsetenv(key)
	
	// after
	t.Setenv(key, "new value")
}
```

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

**Test acceptance criteria**:

* [x] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
