### PR TITLE
Non OLM Installation script - Support for configurable parameters of controller manager and some bug fixes and improvements

### DIFF
--- a/hack/non-olm-install/README.md
+++ b/hack/non-olm-install/README.md
@@ -66,7 +66,16 @@ The following environment variables can be set to configure various options for 
 |**ARGOCD_REDIS_IMAGE**|Image override for Redis component|registry.redhat.io/rhel8/redis-6:1-110|
 |**ARGOCD_REDIS_HA_PROXY_IMAGE**|Image override for Redis HA proxy component|registry.redhat.io/openshift4/ose-haproxy-router:v4.12.0-202302280915.p0.g3065f65.assembly.stream|
 
-
+#### Variables for Operator parameters
+|Environment|Description|Default Value|
+|:----------|:---------:|:-----------:|
+|**DISABLE_DEFAULT_ARGOCD_INSTANCE**|When set to `true`, this will disable the default 'ready-to-use' installation of Argo CD in the `openshift-gitops` namespace.|false|
+|**DISABLE_DEX**|Flag to control if Dex needs to be disabled|false|
+|**ARGOCD_CLUSTER_CONFIG_NAMESPACES**|OpenShift GitOps instances in the identified namespaces are granted limited additional permissions to manage specific cluster-scoped resources, which include platform operators, optional OLM operators, user management, etc.
+Multiple namespaces can be specified via a comma delimited list.|openshift-gitops|
+|**WATCH_NAMESPACE**|namespaces in which Argo applications can be created|None|
+|**CONTROLLER_CLUSTER_ROLE**|This environment variable enables administrators to configure a common cluster role to use across all managed namespaces in the role bindings the operator creates for the Argo CD application controller.|None|
+|**SERVER_CLUSTER_ROLE**|This environment variable enables administrators to configure a common cluster role to use across all of the managed namespaces in the role bindings the operator creates for the Argo CD server.|None|
 ### Running the script
 
 #### Usage

--- a/hack/non-olm-install/README.md
+++ b/hack/non-olm-install/README.md
@@ -1,12 +1,12 @@
 ### Non OLM based operator installation
 
-The purpose of this script is to install and uninstall the Openshift GitOps Operator without using OLM. It uses latest version of the kustomize manifests available in the repository for creating the required k8s resources.
+The purpose of this script is to install, update or uninstall the Openshift GitOps Operator without using the Operator Lifecycle Manager (OLM). It uses latest version of the `kustomize` manifests available in the github repository for creating the required kubernetes resources.
 
 ### Usage
 
 The `install-gitops-operator.sh` script supports two methods of installation.
-1. Using operator and component images from environment variables (default method)
-2. Derive the operator and component images from the ClusterServiceVersion manifest present in the operator bundle (Note: This method requires podman binary to be available in the PATH)
+1. Using operator and component images set as environment variables (default method)
+2. Derive the operator and component images from the ClusterServiceVersion manifest present in the operator bundle (Note: This method requires podman or docker binary to be available in the PATH environment variable)
 
 
 ### Known issues and work arounds

--- a/hack/non-olm-install/install-gitops-operator.sh
+++ b/hack/non-olm-install/install-gitops-operator.sh
@@ -44,10 +44,10 @@ WATCH_NAMESPACE=${WATCH_NAMESPACE:-""}
 
 # Print help message
 function print_help() {
-  echo "Usage: $0 MODE [--install|-i] [-uninstall|-u] [--help|-h]"
+  echo "Usage: $0 [--install|-i] [--uninstall|-u] [--help|-h]"
   echo "  --install, -i		Install the openshift-gitops-operator manifests"
   echo "  --uninstall, -u	Uninstall the openshift-gitops-operator manifests"
-  echo "  --help, -h		Print this help message"
+  echo "  --help, -h      Print this help message"
 
   echo
   echo "Example usage: $0 --install"

--- a/hack/non-olm-install/install-gitops-operator.sh
+++ b/hack/non-olm-install/install-gitops-operator.sh
@@ -38,6 +38,9 @@ DISABLE_DEFAULT_ARGOCD_INSTANCE=${DISABLE_DEFAULT_ARGOCD_INSTANCE:-"false"}
 DISABLE_DEX=${DISABLE_DEX:-"false"}
 ARGOCD_CLUSTER_CONFIG_NAMESPACES=${ARGOCD_CLUSTER_CONFIG_NAMESPACES:-"openshift-gitops"}
 WATCH_NAMESPACE=${WATCH_NAMESPACE:-""}
+CONTROLLER_CLUSTER_ROLE=${CONTROLLER_CLUSTER_ROLE:-""}
+SERVER_CLUSTER_ROLE=${SERVER_CLUSTER_ROLE:-""}
+
 
 # Print help message
 function print_help() {
@@ -186,7 +189,11 @@ spec:
         - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
           value: \"${ARGOCD_CLUSTER_CONFIG_NAMESPACES}\"
         - name: WATCH_NAMESPACE
-          value: \"${WATCH_NAMESPACE}\"" > ${TEMP_DIR}/env-overrides.yaml
+          value: \"${WATCH_NAMESPACE}\"
+        - name: CONTROLLER_CLUSTER_ROLE
+          value: \"${CONTROLLER_CLUSTER_ROLE}\"
+        - name: SERVER_CLUSTER_ROLE
+          value: \"${SERVER_CLUSTER_ROLE}\"" > ${TEMP_DIR}/env-overrides.yaml
 }
 
 # Create a security context for the containers that are present in the deployment.
@@ -246,6 +253,8 @@ metadata:
   ${YQ} ".spec.template.spec.containers[0].env += {\"name\": \"DISABLE_DEFAULT_ARGOCD_INSTANCE\", \"value\": \"${DISABLE_DEFAULT_ARGOCD_INSTANCE}\"}" | \
   ${YQ} ".spec.template.spec.containers[0].env += {\"name\": \"ARGOCD_CLUSTER_CONFIG_NAMESPACES\", \"value\": \"${ARGOCD_CLUSTER_CONFIG_NAMESPACES}\"}" | \
   ${YQ} ".spec.template.spec.containers[0].env += {\"name\": \"WATCH_NAMESPACE\", \"value\": \"${WATCH_NAMESPACE}\"}" | \
+  ${YQ} ".spec.template.spec.containers[0].env += {\"name\": \"CONTROLLER_CLUSTER_ROLE\", \"value\": \"${CONTROLLER_CLUSTER_ROLE}\"}" | \
+  ${YQ} ".spec.template.spec.containers[0].env += {\"name\": \"SERVER_CLUSTER_ROLE\", \"value\": \"${SERVER_CLUSTER_ROLE}\"}" | \
   tail -n +2 >> "${TEMP_DIR}"/env-overrides.yaml
 
   ${YQ} -e -i '.spec.selector.matchLabels.control-plane = "argocd-operator"' "${TEMP_DIR}"/env-overrides.yaml

--- a/hack/non-olm-install/install-gitops-operator.sh
+++ b/hack/non-olm-install/install-gitops-operator.sh
@@ -92,7 +92,16 @@ function rollback() {
 
 # deletes the temp directory
 function cleanup() {
-  rm -rf "${TEMP_DIR}"
+  # Check if timeout binary is available in the PATH environment variable
+  timeout=$(which timeout)
+  if [ -z ${timeout} ]; then
+    echo "[INFO] Deleting directory ${TEMP_DIR} without timeout"
+    rm -rf "${TEMP_DIR}"
+  else
+    # If the command hangs for more than 20 minutes kill it
+    echo "[INFO] Deleting directory ${TEMP_DIR} with 10m timeout"
+    timeout 600 rm -rf "${TEMP_DIR}"||echo "[ERROR] Directory deletion timed out, please remove it manually"
+  fi
   echo "[INFO] Deleted temp working directory ${TEMP_DIR}"
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug


**What does this PR do / why we need it**:
Improvements and bug fixes for the non-OLM installation script
- Added support for providing configuration parameters to the Operator Controller manager through environment variables.
- Increase the timeout to download manifests from the github.com and add retries in case of network errors.
- During upgrade, the terminating pod would also be in the list of pods to validate the success of an upgrade and the upgrade would always fail due to the terminated pod.
- Reduced the log messages and using Runtime information containing all the required details. Like Image URIs used, mode - Install/Update/Uninstall.
- Better command line arguments `--install|-i` and `--uninstall|-u`
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [x] E2E Test

**How to test changes / Special notes to the reviewer**:
