### PR TITLE
chore: Update argocd-operator to include ha reconciliation fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/argoproj-labs/argo-rollouts-manager v0.0.2-0.20230515023837-0632f3e856d5
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20230524130424-19b9bdc50655
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20230526065721-4913ddcfa3cc
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.2-0.20230515023837-0632f3e856d5 h1:SlFbeNb42H7DUGzE9B/uYYjlQjNSR4y+eaWiTqN3PGs=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.2-0.20230515023837-0632f3e856d5/go.mod h1:AiEjAr6e/DCDiicjoC7W7LaZdO28sfgoBhjbGryzEZ8=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20230524130424-19b9bdc50655 h1:bdjjkDA8b1lUlMjKZDOH3TA84bPaUUvDReGAjERg7Sc=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20230524130424-19b9bdc50655/go.mod h1:AfoHTRFS43YO25blmzicubPOIgApAVtW+RFBwcb8cyM=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20230526065721-4913ddcfa3cc h1:ONvefCIdysZI9H63TX+1MTvIJt0/qwjiOwgiRpfYkGI=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20230526065721-4913ddcfa3cc/go.mod h1:AfoHTRFS43YO25blmzicubPOIgApAVtW+RFBwcb8cyM=
 github.com/argoproj/argo-cd/v2 v2.7.1 h1:bioMqQ2HI95AWOI157ztppvyD0uPXGrB6h/7lHV2Fvo=
 github.com/argoproj/argo-cd/v2 v2.7.1/go.mod h1:bB2H6vHO29xf32Nzxg1CJKrJBE48r7frkzbzKxx1BKM=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
Updates argocd-operator version to include https://github.com/argoproj-labs/argocd-operator/pull/915 fix.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

