### PR TITLE
[WINP] Fix kuttl test parallel 055

### DIFF
--- a/test/openshift/e2e/parallel/1-055_validate_notification_controller/03-errors.yaml
+++ b/test/openshift/e2e/parallel/1-055_validate_notification_controller/03-errors.yaml
@@ -1,3 +1,10 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+status:
+  notificationsController:
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -27,10 +34,3 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-argocd-argocd-notifications-controller
----
-apiVersion: argoproj.io/v1alpha1
-kind: ArgoCD
-metadata:
-  name: example-argocd
-status:
-  notificationsController:

--- a/test/openshift/e2e/parallel/1-055_validate_notification_controller/04-check.yaml
+++ b/test/openshift/e2e/parallel/1-055_validate_notification_controller/04-check.yaml
@@ -1,5 +1,0 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-timeout: 1200
-error:
-- errors.yaml


### PR DESCRIPTION
Signed off: @ciiay 

**What type of PR is this?**
/kind failing-test

**What does this PR do / why we need it**:
Remove acceptance pipeline blockers in order to enable auto-release.

**Which issue(s) this PR fixes**:

Fixes [GITOPS-2857](https://issues.redhat.com/browse/GITOPS-2857)

**Test acceptance criteria**:

* [ ] Unit Test
* [x] E2E Test

**How to test changes / Special notes to the reviewer**:
1. Pull [operator-e2e](https://gitlab.cee.redhat.com/gitops/operator-e2e) repo to local and go to `gitops-operator` directory.
2. Apply changes from this PR
3. Run `kubectl kuttl test ./tests/parallel --config ./tests/parallel/kuttl-test.yaml --test 1-055_validate_notification_controller` command to confirm this test passes.

Output from my end:
```
➜  gitops-operator git:(master) ✗ kubectl kuttl test ./tests/parallel --config ./tests/parallel/kuttl-test.yaml --test 1-055_validate_notification_controller
2023/06/01 16:26:17 kutt-test config testdirs is overridden with args: [ ./tests/parallel ]
=== RUN   kuttl
    harness.go:462: starting setup
    harness.go:252: running tests using configured kubeconfig.
I0601 16:26:18.304116   93658 request.go:682] Waited for 1.048364333s due to client-side throttling, not priority and fairness, request: GET:https://api.rhoms-4.12-060104.dev.openshiftappsvc.org:6443/apis/autoscaling/v1?timeout=32s
    harness.go:275: Successful connection to cluster at: https://api.rhoms-4.12-060104.dev.openshiftappsvc.org:6443
I0601 16:26:28.306437   93658 request.go:682] Waited for 2.094510083s due to client-side throttling, not priority and fairness, request: GET:https://api.rhoms-4.12-060104.dev.openshiftappsvc.org:6443/apis/monitoring.coreos.com/v1beta1?timeout=32s
    harness.go:360: running tests
    harness.go:73: going to run test suite with timeout of 1200 seconds for each step
    harness.go:372: testsuite: ./tests/parallel has 68 tests
=== RUN   kuttl/harness
=== RUN   kuttl/harness/1-055_validate_notification_controller
=== PAUSE kuttl/harness/1-055_validate_notification_controller
=== CONT  kuttl/harness/1-055_validate_notification_controller
    logger.go:42: 16:26:30 | 1-055_validate_notification_controller | Ignoring check.yaml as it does not match file name regexp: ^(\d+)-(?:[^\.]+)(?:\.yaml)?$
    logger.go:42: 16:26:30 | 1-055_validate_notification_controller | Creating namespace: kuttl-test-huge-pony
    logger.go:42: 16:26:30 | 1-055_validate_notification_controller/1-install | starting test step 1-install
    logger.go:42: 16:26:35 | 1-055_validate_notification_controller/1-install | ArgoCD:kuttl-test-huge-pony/example-argocd created
    logger.go:42: 16:26:36 | 1-055_validate_notification_controller/1-install | test step completed 1-install
    logger.go:42: 16:26:36 | 1-055_validate_notification_controller/2-enable_notification | starting test step 2-enable_notification
I0601 16:26:38.320936   93658 request.go:682] Waited for 1.70655s due to client-side throttling, not priority and fairness, request: GET:https://api.rhoms-4.12-060104.dev.openshiftappsvc.org:6443/apis/migration.k8s.io/v1alpha1?timeout=32s
    logger.go:42: 16:26:41 | 1-055_validate_notification_controller/2-enable_notification | ArgoCD:kuttl-test-huge-pony/example-argocd updated
    logger.go:42: 16:26:45 | 1-055_validate_notification_controller/2-enable_notification | test step completed 2-enable_notification
    logger.go:42: 16:26:45 | 1-055_validate_notification_controller/3-disable_notification | starting test step 3-disable_notification
I0601 16:26:48.342740   93658 request.go:682] Waited for 3.045766875s due to client-side throttling, not priority and fairness, request: GET:https://api.rhoms-4.12-060104.dev.openshiftappsvc.org:6443/apis/psmdb.percona.com/v1-11-0?timeout=32s
    logger.go:42: 16:26:49 | 1-055_validate_notification_controller/3-disable_notification | ArgoCD:kuttl-test-huge-pony/example-argocd updated
    logger.go:42: 16:26:50 | 1-055_validate_notification_controller/3-disable_notification | test step completed 3-disable_notification
    logger.go:42: 16:26:50 | 1-055_validate_notification_controller | skipping kubernetes event logging
    logger.go:42: 16:26:50 | 1-055_validate_notification_controller | Deleting namespace: kuttl-test-huge-pony
=== CONT  kuttl
    harness.go:405: run tests finished
    harness.go:513: cleaning up
    harness.go:570: removing temp folder: ""
--- PASS: kuttl (40.65s)
    --- PASS: kuttl/harness (0.00s)
  ```