### PR TITLE
Support migration to non-OLM installation and using regctl for extracting CSV info from bundle image

### DIFF
--- a/hack/non-olm-install/README.md
+++ b/hack/non-olm-install/README.md
@@ -7,19 +7,25 @@
 The `install-gitops-operator.sh` script supports two methods of installation.
 1. Using operator and component images set as environment variables (default method)
 2. Derive the operator and component images from the `ClusterServiceVersion` manifest present in the operator bundle
-**Note**: This method requires podman or docker binary to be available in the PATH environment variable. Use environment variables `USE_BUNDLE_IMG`, `BUNDLE_IMG` and `DOCKER` for this method of installation
+**Note**: Use environment variables `USE_BUNDLE_IMG`, `BUNDLE_IMG` for this method of installation
 
 
 ### Known issues and work arounds
 
-1. Missing RBAC access to update CRs in `argoproj.io` domain 
+1. Missing RBAC access to update CRs in `argoproj.io` domain
 
-Issue: (Now fixed)
+Affected versions:
+- 1.7.4 and older versions
+- 1.8.3 and older versions
 
+Fixed versions:
+- 1.8.4 and later versions
+- 1.9.0 and later versions
+
+Issue:
 https://github.com/redhat-developer/gitops-operator/issues/148
 
 Workaround:
-
 Run the following script to create the required `ClusterRole` and `ClusterRoleBinding`
 
 ```
@@ -32,7 +38,7 @@ ${KUBECTL} apply -f https://raw.githubusercontent.com/redhat-developer/gitops-op
 **Note**: If the above binaries are not present, the script installs them to temporary work directory and are removed once the script execution is complete.
 - bash (v5.0 or later)
 - git (v2.39.1 or later)
-- podman (v4.4.4 or later) or docker (Note: Required only if operator and component images need to be derived from a bundle image)
+- wget (v1.21.3 or later)
 
 ### Environment Variables
 The following environment variables can be set to configure various options for the installation/uninstallation process.
@@ -49,7 +55,6 @@ The following environment variables can be set to configure various options for 
 | **IMAGE_PREFIX** | Prefix used for internal images from rh-osbs org in the registry which generally is prefixed with the target organization name | "" |
 | **USE_BUNDLE_IMG** | If the operator image and other component image needs to be derived from a bundle image, set this flag to true. | false |
 | **BUNDLE_IMG** | used only when USE_BUNDLE_IMG is set to true | `${OPERATOR_REGISTRY}/openshift-gitops-1/gitops-operator-bundle:${GITOPS_OPERATOR_VER}` |
-| **DOCKER** | used only when USE_BUNDLE_IMG is set to true. CLI binary to be used for extracting ClusterServiceVersion manifest from the Bundle Image | podman |
 
 #### Variables for 3rd party tools used in the script
 | Environment | Description |Default Value |
@@ -57,6 +62,7 @@ The following environment variables can be set to configure various options for 
 | **KUSTOMIZE_VERSION** | Version of kustomize binary to be installed if not found in PATH | v4.5.7 |
 | **KUBECTL_VERSION** | Version of the kubectl client binary to be installed if not found in PATH | v1.26.0 |
 | **YQ_VERSION** | Version of the yq binary to be installed if not found in PATH | v4.31.2 |
+| **REGCTL_VERSION** | Version of the regctl binary to be installed if not found in PATH  | v0.4.8 |
 
 #### Variables for Component Image Overrides
 | Environment | Description |Default Value |
@@ -85,13 +91,14 @@ The following environment variables can be set to configure various options for 
 #### Usage
 
 ```
-install-gitops-operator.sh [--install|-i] [--uninstall|-u] [--help|-h]
+install-gitops-operator.sh [--install|-i] [--uninstall|-u] [--migrate|-m] [--help|-h]
 ```
 
 | Option | Description |
 | -------| ----------- |
 | --install, -i | installs the openshift-gitops-operator if no previous version is found, else updates (upgrade/dowgrade) the existing operator |
 | --uninstall, -u | uninstalls the openshift-gitops-operator |
+| --migrate, -m | migrates from an OLM based installation to non OLM manifests based installation|
 | --help, -h | prints the help message |
 
 #### Local Run
@@ -112,6 +119,17 @@ The below command installs the latest available openshift-gitops-operator versio
 [or]
 ```
 ./install-gitops-operator.sh --uninstall
+```
+
+##### Migration
+To migrate from an OLM based installation to the latest version using non OLM manifests based installation, run the following command.
+```
+./install-gitops-operator.sh -m
+
+```
+[or]
+```
+./install-gitops-operator.sh --migrate
 ```
 
 #### Running it from a remote URL
@@ -180,5 +198,16 @@ rm -f ${oldauth} ${newauth}
 
 ###### Install the nightly operator bundle
 ```
-OPERATOR_REGISTRY=brew.registry.redhat.io OPERATOR_REGISTRY_ORG=rh-osbs GITOPS_OPERATOR_VER=v99.9.0-88 IMAGE_PREFIX="openshift-gitops-1-" ./install-gitops-operator.sh -i
+OPERATOR_REGISTRY=brew.registry.redhat.io OPERATOR_REGISTRY_ORG=rh-osbs GITOPS_OPERATOR_VER=v99.9.0-<build_number> IMAGE_PREFIX="openshift-gitops-1-" ./install-gitops-operator.sh -i
+```
+
+###### Uninstall the nightly operator bundle
+```
+./install-gitops-operator.sh -u
+```
+
+##### Migrate from an OLM based install to non-OLM based installation (nightly-build)
+
+```
+OPERATOR_REGISTRY=brew.registry.redhat.io OPERATOR_REGISTRY_ORG=rh-osbs IMAGE_PREFIX=openshift-gitops-1- GITOPS_OPERATOR_VER=v99.9.0-<build_number> ./install-gitops-operator.sh -m
 ```

--- a/hack/non-olm-install/install-gitops-operator.sh
+++ b/hack/non-olm-install/install-gitops-operator.sh
@@ -6,7 +6,7 @@ MAX_RETRIES=3
 
 # gitops-operator version tagged images
 OPERATOR_REGISTRY=${OPERATOR_REGISTRY:-"registry.redhat.io"}
-GITOPS_OPERATOR_VER=${GITOPS_OPERATOR_VER:-"v1.8.2-5"}
+GITOPS_OPERATOR_VER=${GITOPS_OPERATOR_VER:-"v1.9.0-29"}
 OPERATOR_REGISTRY_ORG=${OPERATOR_REGISTRY_ORG:-"openshift-gitops-1"}
 IMAGE_PREFIX=${IMAGE_PREFIX:-""}  
 OPERATOR_IMG=${OPERATOR_IMG:-"${OPERATOR_REGISTRY}/${OPERATOR_REGISTRY_ORG}/${IMAGE_PREFIX}gitops-rhel8-operator:${GITOPS_OPERATOR_VER}"}
@@ -14,7 +14,6 @@ OPERATOR_IMG=${OPERATOR_IMG:-"${OPERATOR_REGISTRY}/${OPERATOR_REGISTRY_ORG}/${IM
 # If enabled, operator and component image URLs would be derived from within CSV present in the bundle image.
 USE_BUNDLE_IMG=${USE_BUNDLE_IMG:-"false"}
 BUNDLE_IMG=${BUNDLE_IMG:-"${OPERATOR_REGISTRY}/${OPERATOR_REGISTRY_ORG}/${IMAGE_PREFIX}gitops-operator-bundle:${GITOPS_OPERATOR_VER}"}
-DOCKER=${DOCKER:-"docker"}
 
 # Image overrides
 # gitops-operator version tagged images
@@ -33,6 +32,7 @@ ARGOCD_REDIS_HA_PROXY_IMAGE=${ARGOCD_REDIS_HA_PROXY_IMAGE:-"registry.redhat.io/o
 KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-"v4.5.7"}
 KUBECTL_VERSION=${KUBECTL_VERSION:-"v1.26.0"}
 YQ_VERSION=${YQ_VERSION:-"v4.31.2"}
+REGCTL_VERSION=${REGCTL_VERSION:-"v0.4.8"}
 
 # Operator configurations
 ARGOCD_CLUSTER_CONFIG_NAMESPACES=${ARGOCD_CLUSTER_CONFIG_NAMESPACES:-"openshift-gitops"}
@@ -44,14 +44,16 @@ WATCH_NAMESPACE=${WATCH_NAMESPACE:-""}
 # Print help message
 function print_help() {
   echo "Usage: $0 [--install|-i] [--uninstall|-u] [--help|-h]"
-  echo "  --install, -i		Install the openshift-gitops-operator manifests"
-  echo "  --uninstall, -u	Uninstall the openshift-gitops-operator manifests"
-  echo "  --help, -h      	Print this help message"
+  echo "  --install, -i    Install the openshift-gitops-operator manifests"
+  echo "  --uninstall, -u  Uninstall the openshift-gitops-operator manifests"
+  echo "  --migrate, -m    Migrates from OLM to non OLM manifests based installation"
+  echo "  --help, -h       Print this help message"
 
   echo
   echo "Example usage:"
   echo "	$0 --install"
   echo "	$0 --uninstall"
+  echo "	$0 --migrate"
 }
 
 
@@ -60,24 +62,42 @@ function check_pod_status_ready() {
   # Wait for the deployment rollout to complete before trying to list the pods
   # to ensure that only pods corresponding to the new version is considered.
   ${KUBECTL} rollout status deploy -n ${NAMESPACE_PREFIX}system --timeout=5m
-  for binary in "$@"; do
-    pod_name=$(${KUBECTL} get pods --no-headers --field-selector="status.phase!=Succeeded" -o custom-columns=":metadata.name" -n ${NAMESPACE_PREFIX}system | grep "$binary");
-    if [ ! -z "$pod_name" ]; then
-      echo "[DEBUG] Pod name : $pod_name";
-      ${KUBECTL} wait pod --for=condition=Ready $pod_name -n ${NAMESPACE_PREFIX}system --timeout=150s;
-      if [ $? -ne 0 ]; then
-        echo "[INFO] Pod '$pod_name' failed to become Ready in desired time. Logs from the pod:"
-        ${KUBECTL} logs $pod_name -n ${NAMESPACE_PREFIX}system --all-containers;
-        echo "[ERROR] Install/Upgrade failed. Performing rollback to $PREV_IMAGE";      
-        rollback
-      fi
-    fi
-  done
+  if [ $? -ne 0 ]; then
+    echo "[INFO] Deployments did not reach healthy state within 5m. Rolling back"
+  else
+    echo "[INFO] Deployments reached healthy state."
+    return 0
+  fi
+
+  pod_name=$(${KUBECTL} get pods --no-headers --field-selector="status.phase!=Succeeded" -o custom-columns=":metadata.name" -n ${NAMESPACE_PREFIX}system | grep "${1}");
+  if [ -z "$pod_name" ]; then
+    echo "[WARN] Ignoring empty pod name"
+    return 0
+  fi
+  echo "[DEBUG] Pod name : $pod_name";
+  ${KUBECTL} wait pod --for=condition=Ready $pod_name -n ${NAMESPACE_PREFIX}system --timeout=150s;
+  if [ $? -ne 0 ]; then
+    echo "[INFO] Pod '$pod_name' failed to become Ready in desired time. Logs from the pod:"
+    ${KUBECTL} logs $pod_name -n ${NAMESPACE_PREFIX}system --all-containers;
+    echo "[ERROR] Install/Upgrade failed. Performing rollback";
+    rollback
+    return 1
+  fi
+  return 0
+}
+
+# Handle rollback for different modes
+function rollback() {
+  if [ "$MODE" == "Migrate" ]; then
+      rollback_to_olm
+  else
+      rollback_to_previous_image
+  fi
 }
 
 # Rollback the deployment to use previous known good image
 # Applicable only for upgrade/downgrade operations.
-function rollback() {
+function rollback_to_previous_image() {
   if [ ! -z "${PREV_OPERATOR_IMG}" ]; then
     export OPERATOR_IMG=${PREV_OPERATOR_IMG}    
     prepare_kustomize_files
@@ -122,6 +142,16 @@ function install_kubectl() {
     wget https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/$(uname | tr '[:upper:]' '[:lower:]')/$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)/kubectl -O ${WORK_DIR}/kubectl
     KUBECTL=${WORK_DIR}/kubectl
     chmod +x ${WORK_DIR}/kubectl
+  fi
+}
+
+# installs the stable version of regctl binary if not found in PATH
+function install_regctl() {
+  if [[ -z "${REGCTL}" ]]; then
+    echo "[INFO] regctl binary not found in \$PATH, installing regctl-${REGCTL_VERSION} in ${WORK_DIR}"
+    wget https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-$(uname | tr '[:upper:]' '[:lower:]')-$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) -O ${WORK_DIR}/regctl
+    REGCTL=${WORK_DIR}/regctl
+    chmod +x ${WORK_DIR}/regctl
   fi
 }
 
@@ -236,9 +266,7 @@ spec:
 }
 
 function extract_component_images_from_bundle_image() {
-  container_id=$(${DOCKER} create --quiet --entrypoint sh "${BUNDLE_IMG}")
-  ${DOCKER} cp "$container_id:manifests/gitops-operator.clusterserviceversion.yaml" "${WORK_DIR}"
-  ${DOCKER} container rm "$container_id" >/dev/null 2>&1
+  ${REGCTL} image get-file "${BUNDLE_IMG}" manifests/gitops-operator.clusterserviceversion.yaml "${WORK_DIR}"/gitops-operator.clusterserviceversion.yaml
 
   CONTAINER_YAML=$(cat "${WORK_DIR}"/gitops-operator.clusterserviceversion.yaml | ${YQ} '.spec.install.spec | .deployments[0].spec.template.spec.containers[0]' > "${WORK_DIR}"/container.yaml)
 
@@ -271,6 +299,13 @@ function init_work_directory() {
 # This function just checks if the binary is found in the PATH and 
 # does not validate if the version of the binary matches the minimum required version.
 function check_and_install_prerequisites {
+  # Check if wget is available in PATH, if not exit immediately.
+  which wget
+  if [ $? -ne 0 ]; then
+    echo "Mandatory pre-requsite 'wget' missing"
+    exit 1
+  fi
+
   # install kustomize in the the work directory if its not available in the PATH
   KUSTOMIZE=$(which kustomize)
   install_kustomize
@@ -282,6 +317,27 @@ function check_and_install_prerequisites {
   # install yq in the the work directory if its not available in the PATH
   YQ=$(which yq)
   install_yq
+
+  if [ ${USE_BUNDLE_IMG} == "true" ];then
+    # install yq in the the work directory if its not available in the PATH
+    REGCTL=$(which regctl)
+    install_regctl
+    check_prerequisite regctl ${REGCTL}
+  fi
+
+  check_prerequisite kustomize ${KUSTOMIZE}
+  check_prerequisite kubectl ${KUBECTL}
+  check_prerequisite yq ${YQ}
+
+}
+
+# Check if the given prerequisite binary is found in path or the script
+# installed them in the path.
+function check_prerequisite() {
+  if [[ -z "${2}" || ! -x "${2}"  ]]; then
+    echo "Prerequisite '${1}' binary could not be installed"
+    exit 1
+  fi
 }
 
 # Checks if the openshift-gitops-operator is already installed in the system.
@@ -306,13 +362,7 @@ function prepare_kustomize_files() {
   # create the required yaml files for the kustomize based install.
   create_kustomization_init_file
   if [ ${USE_BUNDLE_IMG} == "true" ]; then
-    DOCKER=$(which ${DOCKER})
-    if [ ! -z "${DOCKER}" ]; then
-      extract_component_images_from_bundle_image
-    else
-      echo -n "[WARN] \'${DOCKER}\' binary not found in \$PATH,"
-      echo "falling back to default values or overrides provided using environment variables."
-    fi
+    extract_component_images_from_bundle_image
   fi
   create_image_overrides_patch_file
   create_security_context_patch_file
@@ -355,7 +405,6 @@ function print_info() {
     echo "Bundle image:"
     echo "-------------"
     echo "BUNDLE_IMG: ${BUNDLE_IMG}"
-    echo "DOCKER_TOOL: ${DOCKER}"
     echo ""
   fi
   echo "Operator image:"
@@ -394,6 +443,86 @@ function print_info() {
   echo "==========================================="
 }
 
+# migration from an OLM installation to a non OLM installation.
+function migrate_olm_installation() {
+  extract_custom_env_in_subscription
+  scale_down_olm_deploy
+
+  if [ -f ${WORK_DIR}/migrate_env.sh ];then
+    echo "Sourcing env variables used for customizing subscription"
+    source ${WORK_DIR}/migrate_env.sh
+  fi
+  apply_kustomize_manifests
+  # Check pod status if it becomes ready
+  check_pod_status_ready gitops-operator-controller-manager
+
+  if [ $? -eq 0 ]; then
+    # Non OLM installation is successful and its safe to remove the OLM specific
+    # objects.
+    remove_subscription
+    remove_installed_csv
+    wait_for_olm_removal
+  fi
+}
+
+# When migrating from OLM to non OLM installation, deployment created by the OLM operator
+# must be scaled down to avoid 2 conflicting operators operating on the same CR.
+function scale_down_olm_deploy() {
+  ${KUBECTL} scale deploy/gitops-operator-controller-manager -n openshift-operators --replicas=0
+}
+
+# If migration to non OLM installation fails, revert to OLM based installation
+# by scaling back the OLM created deployments from 0 to 1.
+# Note: Rollback is possible only if the corresponding Subscription and ClusterServiceVersion objects are available.
+function rollback_to_olm() {
+  ${KUBECTL} scale deploy/gitops-operator-controller-manager -n openshift-operators --replicas=1
+}
+
+# Deletes the subscription for openshift-gitops-operator
+function remove_subscription() {
+  #Delete the gitops subscription
+  ${KUBECTL} delete subscription openshift-gitops-operator -n openshift-operators
+}
+
+# Deletes the ClusterServiceVersion Object from the system
+function remove_installed_csv() {
+  # get installedCSV from subscription status
+  installedCSV=$(${YQ} '.status.installedCSV' ${WORK_DIR}/subscription.yaml)
+  if [ "${installedCSV}" == "null" ]; then
+    echo "[INFO] No installed CSV in Subscription"
+    return
+  fi
+  ${KUBECTL} delete clusterserviceversion ${installedCSV} -n openshift-operators
+}
+
+# Waits till the OLM removal is successful.
+function wait_for_olm_removal() {
+  # Wait till the operator deployment is completely removed.
+  ${KUBECTL} wait --for=delete deploy/gitops-operator-controller-manager -n openshift-operators --timeout=60s
+}
+
+# Extract the custom configuration set in the Subscription and
+# store the env settings in a file which can be sourced when running
+# the non-OLM installation.
+function extract_custom_env_in_subscription() {
+  # Get the GitOps subscription object as yaml
+  ${KUBECTL} get subscription openshift-gitops-operator -n openshift-operators -o yaml > ${WORK_DIR}/subscription.yaml
+  # check if config.env element is present
+  element=$(${YQ} '.spec.config.env' ${WORK_DIR}/subscription.yaml)
+  if [ "${element}" == "null" ]; then
+    echo "[INFO] No custom config present in Subscription"
+    return
+  fi
+
+  # for each custom env, convert it to key=value combination.
+  while IFS=$'\t' read -r name value _; do
+    echo "Setting $name=$value"
+    echo "export $name=$value" >> ${WORK_DIR}/migrate_env.sh
+  done < <(yq e '.[] | [.name, .value] | @tsv' ${WORK_DIR}/env_overrides.yaml)
+}
+
+
+
 # Code execution starts here
 function main() {
   if [ $# -eq 0 ]; then
@@ -416,7 +545,7 @@ function main() {
         check_and_install_prerequisites
         get_prev_operator_image
         prepare_kustomize_files
-	print_info
+        print_info
         echo "[INFO] Performing $MODE operation for openshift-gitops-operator..."
         apply_kustomize_manifests
         # Check pod status and rollback if necessary.
@@ -429,11 +558,23 @@ function main() {
         init_work_directory
         check_and_install_prerequisites
         prepare_kustomize_files
-	print_info
+        print_info
         # Remove the GitOpsService instance created for the default
         # ArgoCD instance created in openshift-gitops namespace.
         ${KUBECTL} delete gitopsservice/cluster
         delete_kustomize_manifests
+        exit 0
+        ;;
+    --migrate | -m)
+	MODE="Migrate"
+        echo "[INFO] Performing $MODE operation openshift-gitops-operator..."
+        init_work_directory
+        check_and_install_prerequisites
+        prepare_kustomize_files
+	      print_info
+        # Remove the GitOpsService instance created for the default
+        # ArgoCD instance created in openshift-gitops namespace.
+        migrate_olm_installation
         exit 0
         ;;
     -h | --help)


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement


**What does this PR do / why we need it**:
Improve the manifest based installation script (non-OLM installation) by removing the dependency on either `docker` or `podman` and instead using a lightweight binary `regctl` to extract the `ClusterServiceVersion` from within the bundle image. Since this binary gets automatically installed and uninstalled if not present on the host system, its easy for users to run the installation script without going through the overheads of setting up `docker` or `podman` on their host systems.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
