### PR TITLE
updated Argo CD 2.7.6 CRDs and argocd-operator

### DIFF
--- a/bundle/manifests/argoproj.io_applications.yaml
+++ b/bundle/manifests/argoproj.io_applications.yaml
@@ -1428,7 +1428,7 @@ spec:
                           as part of automated sync (default: false)'
                         type: boolean
                       selfHeal:
-                        description: 'SelfHeal specifies whether to revert resources
+                        description: 'SelfHeal specifes whether to revert resources
                           back to their desired state upon modification in the cluster
                           (default: false)'
                         type: boolean
@@ -1492,7 +1492,7 @@ spec:
                   conditions
                 items:
                   description: ApplicationCondition contains details about an application
-                    condition, which is usually an error or warning
+                    condition, which is usally an error or warning
                   properties:
                     lastTransitionTime:
                       description: LastTransitionTime is the time the condition was
@@ -2941,19 +2941,6 @@ spec:
                   syncResult:
                     description: SyncResult is the result of a Sync operation
                     properties:
-                      managedNamespaceMetadata:
-                        description: ManagedNamespaceMetadata contains the current
-                          sync state of managed namespace metadata
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
                       resources:
                         description: Resources contains a list of sync result items
                           for each individual resource in a sync operation

--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -259,7 +259,7 @@ spec:
     Audit trails of rollouts to the clusters\n* Monitoring and logging integration
     with OpenShift\n* Automated GitOps bootstrapping using Tekton and Argo CD with
     [GitOps Application Manager CLI](https://github.com/redhat-developer/kam)\n\n##
-    Components\n* Argo CD 2.7.2\n* GitOps Application Manager CLI ([download](https://github.com/redhat-developer/kam/releases))\n\n##
+    Components\n* Argo CD 2.7.6\n* GitOps Application Manager CLI ([download](https://github.com/redhat-developer/kam/releases))\n\n##
     How to Install \nAfter installing the OpenShift GitOps operator, an instance  of
     Argo CD is installed in the `openshift-gitops` namespace which has sufficent privileges
     for managing cluster configurations. You can create additional Argo CD instances

--- a/config/crd/bases/argoproj.io_applications.yaml
+++ b/config/crd/bases/argoproj.io_applications.yaml
@@ -1427,7 +1427,7 @@ spec:
                           as part of automated sync (default: false)'
                         type: boolean
                       selfHeal:
-                        description: 'SelfHeal specifies whether to revert resources
+                        description: 'SelfHeal specifes whether to revert resources
                           back to their desired state upon modification in the cluster
                           (default: false)'
                         type: boolean
@@ -1491,7 +1491,7 @@ spec:
                   conditions
                 items:
                   description: ApplicationCondition contains details about an application
-                    condition, which is usually an error or warning
+                    condition, which is usally an error or warning
                   properties:
                     lastTransitionTime:
                       description: LastTransitionTime is the time the condition was
@@ -2940,19 +2940,6 @@ spec:
                   syncResult:
                     description: SyncResult is the result of a Sync operation
                     properties:
-                      managedNamespaceMetadata:
-                        description: ManagedNamespaceMetadata contains the current
-                          sync state of managed namespace metadata
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
                       resources:
                         description: Resources contains a list of sync result items
                           for each individual resource in a sync operation

--- a/config/manifests/patches/description.yaml
+++ b/config/manifests/patches/description.yaml
@@ -13,7 +13,7 @@
     Audit trails of rollouts to the clusters\n* Monitoring and logging integration
     with OpenShift\n* Automated GitOps bootstrapping using Tekton and Argo CD with
     [GitOps Application Manager CLI](https://github.com/redhat-developer/kam)\n\n##
-    Components\n* Argo CD 2.7.2\n* GitOps Application Manager CLI ([download](https://github.com/redhat-developer/kam/releases))\n\n##
+    Components\n* Argo CD 2.7.6\n* GitOps Application Manager CLI ([download](https://github.com/redhat-developer/kam/releases))\n\n##
     How to Install \nAfter installing the OpenShift GitOps operator, an instance  of
     Argo CD is installed in the `openshift-gitops` namespace which has sufficent privileges
     for managing cluster configurations. You can create additional Argo CD instances

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/argoproj-labs/argo-rollouts-manager v0.0.2-0.20230515023837-0632f3e856d5
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20230703172554-566de5160d52
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20230707151228-cbc97a02a8ce
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.2-0.20230515023837-0632f3e856d5 h1:SlFbeNb42H7DUGzE9B/uYYjlQjNSR4y+eaWiTqN3PGs=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.2-0.20230515023837-0632f3e856d5/go.mod h1:AiEjAr6e/DCDiicjoC7W7LaZdO28sfgoBhjbGryzEZ8=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20230703172554-566de5160d52 h1:DRnECV/XUunMA2P94HzjT6OSHve+KJE/k+wHFmfG8Og=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20230703172554-566de5160d52/go.mod h1:5gJtEVwehEm9qt4Wi76Dyyi6Y36XHLkNNJ1EKrthZTg=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20230707151228-cbc97a02a8ce h1:GuZLI2a4qTQVT4ZPKX4fPQgtAWiiOUaQ0Hqpnri6RLM=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20230707151228-cbc97a02a8ce/go.mod h1:5gJtEVwehEm9qt4Wi76Dyyi6Y36XHLkNNJ1EKrthZTg=
 github.com/argoproj/argo-cd/v2 v2.7.6 h1:AKRQm0fLGgBmKQILrpc/2PZM2WYlfCP5tquU6DqDudU=
 github.com/argoproj/argo-cd/v2 v2.7.6/go.mod h1:uRU//iTjnzlCs+hKOKo5Na2OZGNTlklnu/g9Wi4enh4=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/test/openshift/e2e/sequential/1-031_validate_toolchain/01-check.yaml
+++ b/test/openshift/e2e/sequential/1-031_validate_toolchain/01-check.yaml
@@ -6,7 +6,7 @@ commands:
     set -o pipefail
 
     # These variables need to be maintained according to the component matrix: https://spaces.redhat.com/display/GITOPS/GitOps+Component+Matrix
-    expected_kustomizeVersion='kustomize/v5.0.1'
+    expected_kustomizeVersion='v5.0.1'
     expected_helmVersion='v3.10.0'
     expected_argocdVersion='v2.6.1'
     expected_dexVersion='v2.35.1'
@@ -34,9 +34,7 @@ commands:
     )
 
     kustomizeVersion=$(oc -n openshift-gitops exec $gitops_server_pod \
-      -- kustomize version | \
-      awk -F':' '{ print $2 }' | \
-      awk '{ print $1 }'
+      -- kustomize version
     )
     helmVersion=$(oc -n openshift-gitops exec $gitops_server_pod \
       -- helm version | \

--- a/test/openshift/e2e/sequential/1-031_validate_toolchain/01-check.yaml
+++ b/test/openshift/e2e/sequential/1-031_validate_toolchain/01-check.yaml
@@ -6,7 +6,7 @@ commands:
     set -o pipefail
 
     # These variables need to be maintained according to the component matrix: https://spaces.redhat.com/display/GITOPS/GitOps+Component+Matrix
-    expected_kustomizeVersion='kustomize/v4.5.7'
+    expected_kustomizeVersion='kustomize/v5.0.1'
     expected_helmVersion='v3.10.0'
     expected_argocdVersion='v2.6.1'
     expected_dexVersion='v2.35.1'


### PR DESCRIPTION
**What type of PR is this?**
 /kind enhancement

**What does this PR do / why we need it**:
Argocd-operator was [updated with the latest CRDs](https://github.com/argoproj-labs/argocd-operator/pull/944) from [Argo CD 2.7.6](https://github.com/argoproj/argo-cd/tree/v2.7.6/manifests/crds), this PR pulls in those changes and updates CRDs to match. 

**Have you updated the necessary documentation?**
NA

I know that the changes to CRDs include adding in typos but that's what's in upstream... :upside_down_face: 
