### PR TITLE
fix: Handle kam image reconciliation during upgrades [release 1.9]

### DIFF
--- a/controllers/kam.go
+++ b/controllers/kam.go
@@ -221,6 +221,10 @@ func (r *ReconcileGitopsService) reconcileCLIServer(cr *pipelinesv1alpha1.Gitops
 			existingDeployment.Spec.Template.Spec.Containers[0].Resources = deploymentObj.Spec.Template.Spec.Containers[0].Resources
 			changed = true
 		}
+		if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Containers[0].Image, deploymentObj.Spec.Template.Spec.Containers[0].Image) {
+			existingDeployment.Spec.Template.Spec.Containers[0].Image = deploymentObj.Spec.Template.Spec.Containers[0].Image
+			changed = true
+		}
 		if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.NodeSelector, deploymentObj.Spec.Template.Spec.NodeSelector) {
 			existingDeployment.Spec.Template.Spec.NodeSelector = deploymentObj.Spec.Template.Spec.NodeSelector
 			changed = true


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
Fixes #563 
Closes #563 

**How to test changes / Special notes to the reviewer**:

 1. Install GitOps Operator v1.8.0
 2. Verify KAM version
 3. Upgrade GitOps Operator to v1.9.0
 4. Verify KAM version

