### PR TITLE
Fixed log timestamp format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible
 	github.com/operator-framework/api v0.17.5
 	github.com/stretchr/testify v1.8.2
+	go.uber.org/zap v1.24.0
 	golang.org/x/mod v0.10.0
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.27.1
@@ -75,7 +76,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.9.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -83,6 +84,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.RFC3339TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement


**What does this PR do / why we need it**:
Our log timestamp is not human readable.

**Which issue(s) this PR fixes**:

Fixes #?
[GITOPS-2898: Operator logs should have human readable timestamps
](https://issues.redhat.com/browse/GITOPS-2898)
**How to test changes / Special notes to the reviewer**:
1. Have a k8s cluster running.
2. Go to gitops-operator/ directory and run `make install run`. Observe the timestamps in log are in RFC3339 format e.g. `2023-06-27T07:12:48-04:00`.
