### PR TITLE
Fixed the default ArgoCD role for default instance openshift-gitops

### DIFF
--- a/controllers/argocd/argocd.go
+++ b/controllers/argocd/argocd.go
@@ -28,6 +28,9 @@ import (
 var (
 	defaultAdminPolicy = "g, system:cluster-admins, role:admin\ng, cluster-admins, role:admin\n"
 	defaultScope       = "[groups]"
+
+	//The policy.default property in the argocd-rbac-cm ConfigMap.
+	defaultArgoCDRole = ""
 )
 
 // resource exclusions for the ArgoCD CR.
@@ -169,8 +172,9 @@ func getArgoServerSpec() argoapp.ArgoCDServerSpec {
 
 func getDefaultRBAC() argoapp.ArgoCDRBACSpec {
 	return argoapp.ArgoCDRBACSpec{
-		Policy: &defaultAdminPolicy,
-		Scopes: &defaultScope,
+		Policy:        &defaultAdminPolicy,
+		Scopes:        &defaultScope,
+		DefaultPolicy: &defaultArgoCDRole,
 	}
 }
 

--- a/controllers/argocd/argocd_test.go
+++ b/controllers/argocd/argocd_test.go
@@ -135,10 +135,11 @@ func TestDexConfiguration(t *testing.T) {
 	// Verify the default RBAC
 	testAdminPolicy := "g, system:cluster-admins, role:admin\ng, cluster-admins, role:admin\n"
 	testDefaultScope := "[groups]"
-
+	testDefaultArgoCDRole := ""
 	testRBAC := argoapp.ArgoCDRBACSpec{
-		Policy: &testAdminPolicy,
-		Scopes: &testDefaultScope,
+		Policy:        &testAdminPolicy,
+		Scopes:        &testDefaultScope,
+		DefaultPolicy: &testDefaultArgoCDRole,
 	}
 	assert.DeepEqual(t, testArgoCD.Spec.RBAC, testRBAC)
 }

--- a/docs/OpenShift GitOps Usage Guide.md
+++ b/docs/OpenShift GitOps Usage Guide.md
@@ -275,9 +275,20 @@ As an option, You can configure an htpasswd Identity Provider using this [link](
 
 ### **Configure Argo CD RBAC**
 
-By default, any user logged into Argo CD using RHSSO will be a read-only user.
+
+For versions upto and not including v1.10, any user logged into Argo CD using RHSSO will be a read-only user by default.
 
 `policy.default: role:readonly`
+
+For versions starting v1.10 and above,
+
+- any user logged into the default Argo CD instance `openshift-gitops` in namespace `openshift-gitops` will have no access by default.
+
+`policy.default: ''`
+
+- any user logged into user managed custom Argo CD instance will have `read-only` access by default.
+
+`policy.default: 'role:readonly'`
 
 
 This behavior can be modified by updating the *argocd-rbac-cm*  configmap data section.

--- a/test/openshift/e2e/sequential/1-086_validate_default_argocd_role/01-assert.yaml
+++ b/test/openshift/e2e/sequential/1-086_validate_default_argocd_role/01-assert.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+spec:
+  server:
+    route:
+      enabled: true
+status:
+  phase: Available
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: openshift-gitops
+    app.kubernetes.io/name: argocd-rbac-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-rbac-cm
+  namespace: openshift-gitops
+data:
+  policy.csv: |
+    g, system:cluster-admins, role:admin
+    g, cluster-admins, role:admin
+  policy.default: ""
+  scopes: '[groups]'
+---

--- a/test/openshift/e2e/sequential/1-086_validate_default_argocd_role/02-assert.yaml
+++ b/test/openshift/e2e/sequential/1-086_validate_default_argocd_role/02-assert.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
   name: argocd-default-policy
-  namespace: test-1-076-custom
+  namespace: test-1-086-custom
 spec:
   server:
     route:
@@ -14,7 +14,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
   name: argocd-default-policy-empty
-  namespace: test-1-076-custom2
+  namespace: test-1-086-custom2
 spec:
   server:
     route:
@@ -26,7 +26,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
   name: argocd-default-policy-admin
-  namespace: test-1-076-custom3
+  namespace: test-1-086-custom3
 spec:
   server:
     route:
@@ -42,7 +42,7 @@ metadata:
     app.kubernetes.io/name: argocd-rbac-cm
     app.kubernetes.io/part-of: argocd
   name: argocd-rbac-cm
-  namespace: test-1-076-custom
+  namespace: test-1-086-custom
 data:
   policy.csv: ""
   policy.default: role:readonly
@@ -56,7 +56,7 @@ metadata:
     app.kubernetes.io/name: argocd-rbac-cm
     app.kubernetes.io/part-of: argocd
   name: argocd-rbac-cm
-  namespace: test-1-076-custom2
+  namespace: test-1-086-custom2
 data:
   policy.csv: ""
   policy.default: ''
@@ -70,7 +70,7 @@ metadata:
     app.kubernetes.io/name: argocd-rbac-cm
     app.kubernetes.io/part-of: argocd
   name: argocd-rbac-cm
-  namespace: test-1-076-custom3
+  namespace: test-1-086-custom3
 data:
   policy.csv: ""
   policy.default: 'role:admin'

--- a/test/openshift/e2e/sequential/1-086_validate_default_argocd_role/02-assert.yaml
+++ b/test/openshift/e2e/sequential/1-086_validate_default_argocd_role/02-assert.yaml
@@ -1,0 +1,78 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: argocd-default-policy
+  namespace: test-1-076-custom
+spec:
+  server:
+    route:
+      enabled: true
+status:
+  phase: Available
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: argocd-default-policy-empty
+  namespace: test-1-076-custom2
+spec:
+  server:
+    route:
+      enabled: true
+status:
+  phase: Available
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: argocd-default-policy-admin
+  namespace: test-1-076-custom3
+spec:
+  server:
+    route:
+      enabled: true
+status:
+  phase: Available
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: argocd-default-policy
+    app.kubernetes.io/name: argocd-rbac-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-rbac-cm
+  namespace: test-1-076-custom
+data:
+  policy.csv: ""
+  policy.default: role:readonly
+  scopes: '[groups]'
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: argocd-default-policy-empty
+    app.kubernetes.io/name: argocd-rbac-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-rbac-cm
+  namespace: test-1-076-custom2
+data:
+  policy.csv: ""
+  policy.default: ''
+  scopes: '[groups]'
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: argocd-default-policy-admin
+    app.kubernetes.io/name: argocd-rbac-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-rbac-cm
+  namespace: test-1-076-custom3
+data:
+  policy.csv: ""
+  policy.default: 'role:admin'
+  scopes: '[groups]'
+---

--- a/test/openshift/e2e/sequential/1-086_validate_default_argocd_role/02-install.yaml
+++ b/test/openshift/e2e/sequential/1-086_validate_default_argocd_role/02-install.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-1-076-custom
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-1-076-custom2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-1-076-custom3
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: argocd-default-policy
+  namespace: test-1-076-custom
+spec:
+  sso:
+    verifyTLS: true
+  server:
+    route:
+      enabled: true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: argocd-default-policy-empty
+  namespace: test-1-076-custom2
+spec:
+  rbac:
+    defaultPolicy: ''
+  sso:
+    verifyTLS: true
+  server:
+    route:
+      enabled: true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: argocd-default-policy-admin
+  namespace: test-1-076-custom3
+spec:
+  rbac:
+    defaultPolicy: 'role:admin'
+  sso:
+    verifyTLS: true
+  server:
+    route:
+      enabled: true

--- a/test/openshift/e2e/sequential/1-086_validate_default_argocd_role/02-install.yaml
+++ b/test/openshift/e2e/sequential/1-086_validate_default_argocd_role/02-install.yaml
@@ -1,23 +1,23 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: test-1-076-custom
+  name: test-1-086-custom
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: test-1-076-custom2
+  name: test-1-086-custom2
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: test-1-076-custom3
+  name: test-1-086-custom3
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
   name: argocd-default-policy
-  namespace: test-1-076-custom
+  namespace: test-1-086-custom
 spec:
   sso:
     verifyTLS: true
@@ -29,7 +29,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
   name: argocd-default-policy-empty
-  namespace: test-1-076-custom2
+  namespace: test-1-086-custom2
 spec:
   rbac:
     defaultPolicy: ''
@@ -43,7 +43,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
   name: argocd-default-policy-admin
-  namespace: test-1-076-custom3
+  namespace: test-1-086-custom3
 spec:
   rbac:
     defaultPolicy: 'role:admin'


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`
/kind enhancement
> /kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
This PR is to make the default ArgoCD instance with name `openshift-gitops` in namespace `openshift-gitops` to have restricted default permissions. With default `readonly` permission, any non-admin user will be able to view the Application and other manifest resource managed by ArgoCD which can contain sensitive information. By setting the default permission to `''` this read only access can be avoided.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [x] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
