### PR TITLE
Add GCP cherry pick bot

### DIFF
--- a/.github/cherry-pick-bot.yml
+++ b/.github/cherry-pick-bot.yml
@@ -1,0 +1,2 @@
+enabled: true
+preservePullRequestTitle: true


### PR DESCRIPTION

**What does this PR do / why we need it**:
This PR adds configuration for GCP cherry pick bot to streamline the process of back-porting PRs to release branches. This bot is already used in upstream argocd for cherry picking changes. 

**Bot Usage:**
Any PR which needs to be back-ported can be automated by commenting on the PR with
```
/cherry-pick target-branch-name
```
More details regarding bot can be found [here](https://github.com/googleapis/repo-automation-bots/tree/main/packages/cherry-pick-bot)

**Which issue(s) this PR fixes**:

[GITOPS-3286](https://issues.redhat.com/browse/GITOPS-3286)

**How to test changes / Special notes to the reviewer**:
**Please install the [GCP cherry pick bot ](https://github.com/apps/gcp-cherry-pick-bot) on `redhat-developer/gitops-operator` before merging the PR.**