### PR TITLE
feat: Add tls cert mount for appset controller

### DIFF
--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -6655,6 +6655,11 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  scmRootCAConfigMap:
+                    description: SCMRootCAConfigMap is the name of the config map
+                      that stores the Gitlab SCM Provider's TLS certificate which
+                      will be mounted on the ApplicationSet Controller (optional).
+                    type: string
                   version:
                     description: Version is the Argo CD ApplicationSet image tag.
                       (optional)

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -6646,6 +6646,11 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  scmRootCAConfigMap:
+                    description: SCMRootCAConfigMap is the name of the config map
+                      that stores the Gitlab SCM Provider's TLS certificate which
+                      will be mounted on the ApplicationSet Controller (optional).
+                    type: string
                   version:
                     description: Version is the Argo CD ApplicationSet image tag.
                       (optional)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/argoproj-labs/argo-rollouts-manager v0.0.2-0.20230515023837-0632f3e856d5
-	github.com/argoproj-labs/argocd-operator v0.0.16-0.20230904085417-8ddbce30cba6
+	github.com/argoproj-labs/argocd-operator v0.0.16-0.20230911190332-91bf13127dd7
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.5.9
@@ -34,7 +34,7 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/argoproj/argo-cd/v2 v2.8.2 // indirect
+	github.com/argoproj/argo-cd/v2 v2.8.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,10 +111,10 @@ github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.2-0.20230515023837-0632f3e856d5 h1:SlFbeNb42H7DUGzE9B/uYYjlQjNSR4y+eaWiTqN3PGs=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.2-0.20230515023837-0632f3e856d5/go.mod h1:AiEjAr6e/DCDiicjoC7W7LaZdO28sfgoBhjbGryzEZ8=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20230904085417-8ddbce30cba6 h1:RJwXuv6+tHdaUN7g/qpjvZ/h4RvVW61MPuhXjhfzDVk=
-github.com/argoproj-labs/argocd-operator v0.0.16-0.20230904085417-8ddbce30cba6/go.mod h1:x9w45Z8sXVhMYmcZox2l4NKoLVRxkIB11gnbxFdQ6bE=
-github.com/argoproj/argo-cd/v2 v2.8.2 h1:NfFX2l5+YZXB2OTH4syVybX3/6kx+Q7bZkCgW0Hy7ZU=
-github.com/argoproj/argo-cd/v2 v2.8.2/go.mod h1:Pkw7r6HKh5k/5Ynl4MvwCG79ktYBk+7PbJxCjXSlT30=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20230911190332-91bf13127dd7 h1:PGjfIAc6S7ZILt6PXQMHWpTwePyf7gLHCzcSxkUv3NE=
+github.com/argoproj-labs/argocd-operator v0.0.16-0.20230911190332-91bf13127dd7/go.mod h1:Jspd6aN7606tw5EhwGAh30g+YHH19t0yLeXOkF+Drm0=
+github.com/argoproj/argo-cd/v2 v2.8.3 h1:ybJ7eNoP7/u5Vqncais6WeVRBEGmZmriAIwLEKmWHIA=
+github.com/argoproj/argo-cd/v2 v2.8.3/go.mod h1:Pkw7r6HKh5k/5Ynl4MvwCG79ktYBk+7PbJxCjXSlT30=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/test/openshift/e2e/parallel/1-104_validate_applicationset_tls_scm_volume_mount/01-assert.yaml
+++ b/test/openshift/e2e/parallel/1-104_validate_applicationset_tls_scm_volume_mount/01-assert.yaml
@@ -1,0 +1,75 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd
+  namespace: test-1-104-appsets-scm-tls-mount
+spec:
+  applicationSet:
+    scmRootCAConfigMap: test-1-104-appsets-scm-tls-cm
+status:
+  phase: Available
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-applicationset-controller
+  namespace: test-1-104-appsets-scm-tls-mount
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/managed-by: argocd
+    app.kubernetes.io/name: argocd-applicationset-controller
+    app.kubernetes.io/part-of: argocd-applicationset
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-applicationset-controller
+  template:
+    spec:
+      containers:
+        - command:
+          - entrypoint.sh
+          - argocd-applicationset-controller
+          - --argocd-repo-server
+          - argocd-repo-server.test-1-104-appsets-scm-tls-mount.svc.cluster.local:8081
+          - --loglevel
+          - info
+          - --scm-root-ca-path
+          - /app/tls/scm/cert
+          volumeMounts:
+          - mountPath: /app/config/ssh
+            name: ssh-known-hosts
+          - mountPath: /app/config/tls
+            name: tls-certs
+          - mountPath: /app/config/gpg/source
+            name: gpg-keys
+          - mountPath: /app/config/gpg/keys
+            name: gpg-keyring
+          - mountPath: /tmp
+            name: tmp
+          - mountPath: /app/tls/scm/cert
+            name: appset-gitlab-scm-tls-cert
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: argocd-ssh-known-hosts-cm
+        name: ssh-known-hosts
+      - configMap:
+          defaultMode: 420
+          name: argocd-tls-certs-cm
+        name: tls-certs
+      - configMap:
+          defaultMode: 420
+          name: argocd-gpg-keys-cm
+        name: gpg-keys
+      - emptyDir: {}
+        name: gpg-keyring
+      - emptyDir: {}
+        name: tmp
+      - configMap:
+          defaultMode: 420
+          name: argocd-appset-gitlab-scm-tls-certs-cm
+        name: appset-gitlab-scm-tls-cert

--- a/test/openshift/e2e/parallel/1-104_validate_applicationset_tls_scm_volume_mount/01-install.yaml
+++ b/test/openshift/e2e/parallel/1-104_validate_applicationset_tls_scm_volume_mount/01-install.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-1-104-appsets-scm-tls-mount
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-1-104-appsets-scm-tls-cm
+  namespace: test-1-104-appsets-scm-tls-mount
+data:
+  cert: |
+    -----BEGIN CERTIFICATE-----
+    AIIEBCCA7+gAwIBAgIUQdTcSHY2Sxd3Tq/v1eIEZPCNbOowDQYJKoZIhvcNAQEL
+    BQAwezELMAkGA1UEBhMCREUxFTATBgNVBAgMDExvd2VyIFNheG9ueTEQMA4GA1UE
+    BwwHSGFub3ZlcjEVMBMGA1UECgwMVGVzdGluZyBDb3JwMRIwEAYDVQQLDAlUZXN0
+    c3VpdGUxGDAWBrNVBAMMD2Jhci5leGFtcGxlLmNvbTAeFw0xOTA3MDgxMzU2MTda
+    Fw0yMDA3MDcxMzU2MTdaMHsxCzAJBgNVBAYTAkRFMRUwEwYDVQQIDAxMb3dlciBT
+    YXhvbnkxEDAOBgNVBAcMB0hhbm92ZXIxFTATBgNVBAoMDFRlc3RpbmcgQ29ycDES
+    MBAGA1UECwwJVGVzdHN1aXRlMRgwFgYDVQQDDA9iYXIuZXhhbXBsZS5jb20wggIi
+    MA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCv4mHMdVUcafmaSHVpUM0zZWp5
+    NFXfboxA4inuOkE8kZlbGSe7wiG9WqLirdr39Ts+WSAFA6oANvbzlu3JrEQ2CHPc
+    CNQm6diPREFwcDPFCe/eMawbwkQAPVSHPts0UoRxnpZox5pn69ghncBR+jtvx+/u
+    P6HdwW0qqTvfJnfAF1hBJ4oIk2AXiip5kkIznsAh9W6WRy6nTVCeetmIepDOGe0G
+    ZJIRn/OfSz7NzKylfDCat2z3EAutyeT/5oXZoWOmGg/8T7pn/pR588GoYYKRQnp+
+    YilqCPFX+az09EqqK/iHXnkdZ/Z2fCuU+9M/Zhrnlwlygl3RuVBI6xhm/ZsXtL2E
+    Gxa61lNy6pyx5+hSxHEFEJshXLtioRd702VdLKxEOuYSXKeJDs1x9o6cJ75S6hko
+    Ml1L4zCU+xEsMcvb1iQ2n7PZdacqhkFRUVVVmJ56th8aYyX7KNX6M9CD+kMpNm6J
+    kKC1li/Iy+RI138bAvaFplajMF551kt44dSvIoJIbTr1LigudzWPqk31QaZXV/4u
+    kD1n4p/XMc9HYU/was/CmQBFqmIZedTLTtK7clkuFN6wbwzdo1wmUNgnySQuMacO
+    gxhHxxzRWxd24uLyk9Px+9U3BfVPaRLiOPaPoC58lyVOykjSgfpgbus7JS69fCq7
+    bEH4Jatp/10zkco+UQIDAQABo1MwUTAdBgNVHQ4EFgQUjXH6PHi92y4C4hQpey86
+    r6+x1ewwHwYDVR0jBBgwFoAUjXH6PHi92y4C4hQpey86r6+x1ewwDwYDVR0TAQH/
+    BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAgEAFE4SdKsX9UsLy+Z0xuHSxhTd0jfn
+    Iih5mtzb8CDNO5oTw4z0aMeAvpsUvjJ/XjgxnkiRACXh7K9hsG2r+ageRWGevyvx
+    CaRXFbherV1kTnZw4Y9/pgZTYVWs9jlqFOppz5sStkfjsDQ5lmPJGDii/StENAz2
+    XmtiPOgfG9Upb0GAJBCuKnrU9bIcT4L20gd2F4Y14ccyjlf8UiUi192IX6yM9OjT
+    +TuXwZgqnTOq6piVgr+FTSa24qSvaXb5z/mJDLlk23npecTouLg83TNSn3R6fYQr
+    d/Y9eXuUJ8U7/qTh2Ulz071AO9KzPOmleYPTx4Xty4xAtWi1QE5NHW9/Ajlv5OtO
+    OnMNWIs7ssDJBsB7VFC8hcwf79jz7kC0xmQqDfw51Xhhk04kla+v+HZcFW2AO9so
+    6ZdVHHQnIbJa7yQJKZ+hK49IOoBR6JgdB5kymoplLLiuqZSYTcwSBZ72FYTm3iAr
+    jzvt1hxpxVDmXvRnkhRrIRhK4QgJL0jRmirBjDY+PYYd7bdRIjN7WNZLFsgplnS8
+    9w6CwG32pRlm0c8kkiQ7FXA6BYCqOsDI8f1VGQv331OpR2Ck+FTv+L7DAmg6l37W
+    AIIEBCCA7+gAwIBAgIUQdTcSHY2Sxd3Tq/v1eIEZPCNbOowDQYJKoZIhvcNAQEL
+    XWyb96wrUlv+E8I=
+    -----END CERTIFICATE-----
+
+---
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd
+  namespace: test-1-104-appsets-scm-tls-mount
+spec:
+  applicationSet:
+    scmRootCAConfigMap: test-1-104-appsets-scm-tls-cm


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
https://github.com/argoproj-labs/argocd-operator/pull/985 introduced support for custom tls cert mount into application set controller. This PR bring this change into gitops-operator.

Changes
- Update ArgoCD CRD to include new `spec.applicationSet.scmRootCaPath` field.
- Update argocd-operator commit ref in go.mod.
- Add kuttl test.

**Which issue(s) this PR fixes**:

Fixes [GITOPS-3107](https://issues.redhat.com/browse/GITOPS-3107)

**How to test changes / Special notes to the reviewer**:
Test instructions same as https://github.com/argoproj-labs/argocd-operator/pull/985
