### PR TITLE
Updated default version to 1.9.2 and tools kustomize, regctl, yq

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-- auth_proxy_service.yaml
+#- auth_proxy_service.yaml
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
-- auth_proxy_client_clusterrole.yaml
+#- auth_proxy_client_clusterrole.yaml

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-#- auth_proxy_service.yaml
+# - auth_proxy_service.yaml
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
-#- auth_proxy_client_clusterrole.yaml
+# - auth_proxy_client_clusterrole.yaml

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-# - auth_proxy_service.yaml
+- auth_proxy_service.yaml
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
-# - auth_proxy_client_clusterrole.yaml
+- auth_proxy_client_clusterrole.yaml

--- a/hack/non-olm-install/install-gitops-operator.sh
+++ b/hack/non-olm-install/install-gitops-operator.sh
@@ -177,7 +177,7 @@ resources:
   - https://github.com/redhat-developer/gitops-operator/config/crd?ref=$GIT_REVISION&timeout=90s
   - https://github.com/redhat-developer/gitops-operator/config/rbac?ref=$GIT_REVISION&timeout=90s
   - https://github.com/redhat-developer/gitops-operator/config/manager?ref=$GIT_REVISION&timeout=90s
-  - https://raw.githubusercontent.com/redhat-developer/gitops-operator/master/config/rbac/auth_proxy_service.yaml
+  - https://github.com/redhat-developer/gitops-operator/config/prometheus?ref=$GIT_REVISION&timeout=90s
 patches:
   - path: https://raw.githubusercontent.com/redhat-developer/gitops-operator/master/config/default/manager_auth_proxy_patch.yaml 
   - path: env-overrides.yaml

--- a/hack/non-olm-install/install-gitops-operator.sh
+++ b/hack/non-olm-install/install-gitops-operator.sh
@@ -177,6 +177,7 @@ resources:
   - https://github.com/redhat-developer/gitops-operator/config/crd?ref=$GIT_REVISION&timeout=90s
   - https://github.com/redhat-developer/gitops-operator/config/rbac?ref=$GIT_REVISION&timeout=90s
   - https://github.com/redhat-developer/gitops-operator/config/manager?ref=$GIT_REVISION&timeout=90s
+  - https://raw.githubusercontent.com/redhat-developer/gitops-operator/master/config/rbac/auth_proxy_service.yaml
 patches:
   - path: https://raw.githubusercontent.com/redhat-developer/gitops-operator/master/config/default/manager_auth_proxy_patch.yaml 
   - path: env-overrides.yaml

--- a/hack/non-olm-install/install-gitops-operator.sh
+++ b/hack/non-olm-install/install-gitops-operator.sh
@@ -380,7 +380,7 @@ function apply_kustomize_manifests() {
     ${KUSTOMIZE} build ${WORK_DIR} > ${WORK_DIR}/kustomize-build-output.yaml || continue
     ${YQ} -i 'del( .metadata.creationTimestamp | select(. == "null") )' ${WORK_DIR}/kustomize-build-output.yaml
     echo "[INFO] (Attempt ${attempt}) Creating k8s resources from kustomize manifests"
-    ${KUBECTL} apply -f ${WORK_DIR}/kustomize-build-output.yaml && break
+    ${KUBECTL} apply --server-side=true -f ${WORK_DIR}/kustomize-build-output.yaml && break
   done
 }
 

--- a/hack/non-olm-install/install-gitops-operator.sh
+++ b/hack/non-olm-install/install-gitops-operator.sh
@@ -176,7 +176,7 @@ namespace: ${NAMESPACE}
 namePrefix: ${NAME_PREFIX}
 resources:
   - https://github.com/redhat-developer/gitops-operator/config/crd?ref=$GIT_REVISION&timeout=90s
-  - https://github.com/anandf/gitops-operator/config/rbac?ref=fix_non_olm_installation&timeout=90s
+  - https://github.com/redhat-developer/gitops-operator/config/rbac?ref=$GIT_REVISION&timeout=90s
   - https://github.com/redhat-developer/gitops-operator/config/manager?ref=$GIT_REVISION&timeout=90s
   - https://github.com/redhat-developer/gitops-operator/config/prometheus?ref=$GIT_REVISION&timeout=90s
 patches:

--- a/hack/non-olm-install/install-gitops-operator.sh
+++ b/hack/non-olm-install/install-gitops-operator.sh
@@ -41,6 +41,7 @@ CONTROLLER_CLUSTER_ROLE=${CONTROLLER_CLUSTER_ROLE:-""}
 DISABLE_DEFAULT_ARGOCD_INSTANCE=${DISABLE_DEFAULT_ARGOCD_INSTANCE:-"false"}
 SERVER_CLUSTER_ROLE=${SERVER_CLUSTER_ROLE:-""}
 WATCH_NAMESPACE=${WATCH_NAMESPACE:-""}
+ENABLE_CONVERSION_WEBHOOK=${ENABLE_CONVERSION_WEBHOOK:-"true"}
 
 # Print help message
 function print_help() {
@@ -180,6 +181,7 @@ resources:
   - https://github.com/redhat-developer/gitops-operator/config/prometheus?ref=$GIT_REVISION&timeout=90s
 patches:
   - path: https://raw.githubusercontent.com/redhat-developer/gitops-operator/master/config/default/manager_auth_proxy_patch.yaml 
+  - path: https://raw.githubusercontent.com/redhat-developer/gitops-operator/master/config/default/manager_webhook_patch.yaml
   - path: env-overrides.yaml
   - path: security-context.yaml" > ${WORK_DIR}/kustomization.yaml
 }
@@ -228,7 +230,9 @@ spec:
         - name: SERVER_CLUSTER_ROLE
           value: \"${SERVER_CLUSTER_ROLE}\"
         - name: WATCH_NAMESPACE
-          value: \"${WATCH_NAMESPACE}\"" > ${WORK_DIR}/env-overrides.yaml
+          value: \"${WATCH_NAMESPACE}\"
+        - name: ENABLE_CONVERSION_WEBHOOK
+          value: \"${ENABLE_CONVERSION_WEBHOOK}\"" > ${WORK_DIR}/env-overrides.yaml
 }
 
 # Create a security context for the containers that are present in the deployment.
@@ -442,6 +446,9 @@ function print_info() {
   fi
   if [ ! -z "${WATCH_NAMESPACE}" ]; then
     echo "WATCH_NAMESPACE: ${WATCH_NAMESPACE}"
+  fi
+  if [ ! -z "${ENABLE_CONVERSION_WEBHOOK}" ]; then
+    echo "ENABLE_CONVERSION_WEBHOOK: ${ENABLE_CONVERSION_WEBHOOK}"
   fi
   echo "==========================================="
 }

--- a/hack/non-olm-install/install-gitops-operator.sh
+++ b/hack/non-olm-install/install-gitops-operator.sh
@@ -7,7 +7,7 @@ MAX_RETRIES=3
 
 # gitops-operator version tagged images
 OPERATOR_REGISTRY=${OPERATOR_REGISTRY:-"registry.redhat.io"}
-GITOPS_OPERATOR_VER=${GITOPS_OPERATOR_VER:-"v1.9.0-29"}
+GITOPS_OPERATOR_VER=${GITOPS_OPERATOR_VER:-"v1.9.2-2"}
 OPERATOR_REGISTRY_ORG=${OPERATOR_REGISTRY_ORG:-"openshift-gitops-1"}
 IMAGE_PREFIX=${IMAGE_PREFIX:-""}  
 OPERATOR_IMG=${OPERATOR_IMG:-"${OPERATOR_REGISTRY}/${OPERATOR_REGISTRY_ORG}/${IMAGE_PREFIX}gitops-rhel8-operator:${GITOPS_OPERATOR_VER}"}
@@ -30,10 +30,10 @@ ARGOCD_REDIS_IMAGE=${ARGOCD_REDIS_IMAGE:-"registry.redhat.io/rhel8/redis-6:1-110
 ARGOCD_REDIS_HA_PROXY_IMAGE=${ARGOCD_REDIS_HA_PROXY_IMAGE:-"registry.redhat.io/openshift4/ose-haproxy-router:v4.12.0-202302280915.p0.g3065f65.assembly.stream"}
 
 # Tool Versions
-KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-"v4.5.7"}
+KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-"v5.1.1"}
 KUBECTL_VERSION=${KUBECTL_VERSION:-"v1.26.0"}
-YQ_VERSION=${YQ_VERSION:-"v4.31.2"}
-REGCTL_VERSION=${REGCTL_VERSION:-"v0.4.8"}
+YQ_VERSION=${YQ_VERSION:-"v4.35.1"}
+REGCTL_VERSION=${REGCTL_VERSION:-"v0.5.1"}
 
 # Operator configurations
 ARGOCD_CLUSTER_CONFIG_NAMESPACES=${ARGOCD_CLUSTER_CONFIG_NAMESPACES:-"openshift-gitops"}
@@ -378,6 +378,7 @@ function apply_kustomize_manifests() {
     retry_count=$((retry_count+1))
     echo "[INFO] (Attempt ${attempt}) Executing kustomize build command"
     ${KUSTOMIZE} build ${WORK_DIR} > ${WORK_DIR}/kustomize-build-output.yaml || continue
+    ${YQ} -i 'del( .metadata.creationTimestamp | select(. == "null") )' ${WORK_DIR}/kustomize-build-output.yaml
     echo "[INFO] (Attempt ${attempt}) Creating k8s resources from kustomize manifests"
     ${KUBECTL} apply -f ${WORK_DIR}/kustomize-build-output.yaml && break
   done

--- a/hack/non-olm-install/install-gitops-operator.sh
+++ b/hack/non-olm-install/install-gitops-operator.sh
@@ -175,7 +175,7 @@ namespace: ${NAMESPACE}
 namePrefix: ${NAME_PREFIX}
 resources:
   - https://github.com/redhat-developer/gitops-operator/config/crd?ref=$GIT_REVISION&timeout=90s
-  - https://github.com/redhat-developer/gitops-operator/config/rbac?ref=$GIT_REVISION&timeout=90s
+  - https://github.com/anandf/gitops-operator/config/rbac?ref=fix_non_olm_installation&timeout=90s
   - https://github.com/redhat-developer/gitops-operator/config/manager?ref=$GIT_REVISION&timeout=90s
   - https://github.com/redhat-developer/gitops-operator/config/prometheus?ref=$GIT_REVISION&timeout=90s
 patches:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What does this PR do / why we need it**:
Non OLM installation fails as the latest version of CRD manifests creates resources with `creationTimestamp="null"` this causes the builds to fail with error 
```
error: unable to decode "/tmp/gitops-operator-install-dxw9u9c/kustomize-build-output.yaml": parsing time "null" as "2006-01-02T15:04:05Z07:00": cannot parse "null" as "2006"
```
Also, updated the default version and dependent tool versions - yq, kustomize and regctl
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
