### PR TITLE
feat: Update non-olm-install script to setup conversion webhook

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-# - auth_proxy_service.yaml
+- auth_proxy_service.yaml
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 # - auth_proxy_client_clusterrole.yaml

--- a/hack/non-olm-install/README.md
+++ b/hack/non-olm-install/README.md
@@ -85,6 +85,7 @@ The following environment variables can be set to configure various options for 
 | **DISABLE_DEFAULT_ARGOCD_INSTANCE** | When set to `true`, this will disable the default 'ready-to-use' installation of Argo CD in the `openshift-gitops` namespace. |false |
 | **SERVER_CLUSTER_ROLE** |This environment variable enables administrators to configure a common cluster role to use across all of the managed namespaces in the role bindings the operator creates for the Argo CD server. | None |
 | **WATCH_NAMESPACE** | namespaces in which Argo applications can be created | None |
+| **ENABLE_CONVERSION_WEBHOOK** | This environment variable enables conversion webhook to convert v1alpha1 ArgoCD resources to v1beta1 | true |
 ### Running the script
 
 #### Usage

--- a/hack/non-olm-install/install-gitops-operator.sh
+++ b/hack/non-olm-install/install-gitops-operator.sh
@@ -398,6 +398,7 @@ function delete_kustomize_manifests() {
     echo "[INFO] (Attempt ${retry_count}) Executing kustomize build command"
     retry_count=$((retry_count+1))
     ${KUSTOMIZE} build ${WORK_DIR} > ${WORK_DIR}/kustomize-build-output.yaml && break
+    ${YQ} -i 'del( .metadata.creationTimestamp | select(. == "null") )' ${WORK_DIR}/kustomize-build-output.yaml
   done
   echo "[INFO] Deleting k8s resources from kustomize manifests"
   ${KUBECTL} delete -f ${WORK_DIR}/kustomize-build-output.yaml

--- a/hack/non-olm-install/install-gitops-operator.sh
+++ b/hack/non-olm-install/install-gitops-operator.sh
@@ -103,7 +103,7 @@ function rollback_to_previous_image() {
   if [ ! -z "${PREV_OPERATOR_IMG}" ]; then
     export OPERATOR_IMG=${PREV_OPERATOR_IMG}    
     prepare_kustomize_files
-    ${KUSTOMIZE} build ${WORK_DIR} | ${KUBECTL} apply -f -
+    ${KUSTOMIZE} build ${WORK_DIR} | ${KUBECTL} apply --server-side=true -f -
     echo "[INFO] Operator update operation was unsuccessful!!";
   else
     echo "[INFO] Installing image for the first time. Nothing to rollback. Quitting..";
@@ -179,6 +179,7 @@ resources:
   - https://github.com/redhat-developer/gitops-operator/config/rbac?ref=$GIT_REVISION&timeout=90s
   - https://github.com/redhat-developer/gitops-operator/config/manager?ref=$GIT_REVISION&timeout=90s
   - https://github.com/redhat-developer/gitops-operator/config/prometheus?ref=$GIT_REVISION&timeout=90s
+  - https://github.com/redhat-developer/gitops-operator/config/webhook?ref=$GIT_REVISION&timeout=90s
 patches:
   - path: https://raw.githubusercontent.com/redhat-developer/gitops-operator/master/config/default/manager_auth_proxy_patch.yaml 
   - path: https://raw.githubusercontent.com/redhat-developer/gitops-operator/master/config/default/manager_webhook_patch.yaml

--- a/hack/non-olm-install/install-gitops-operator.sh
+++ b/hack/non-olm-install/install-gitops-operator.sh
@@ -398,8 +398,8 @@ function delete_kustomize_manifests() {
     echo "[INFO] (Attempt ${retry_count}) Executing kustomize build command"
     retry_count=$((retry_count+1))
     ${KUSTOMIZE} build ${WORK_DIR} > ${WORK_DIR}/kustomize-build-output.yaml && break
-    ${YQ} -i 'del( .metadata.creationTimestamp | select(. == "null") )' ${WORK_DIR}/kustomize-build-output.yaml
   done
+  ${YQ} -i 'del( .metadata.creationTimestamp | select(. == "null") )' ${WORK_DIR}/kustomize-build-output.yaml
   echo "[INFO] Deleting k8s resources from kustomize manifests"
   ${KUBECTL} delete -f ${WORK_DIR}/kustomize-build-output.yaml
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
This PR updates non-olm operator install script to setup conversion webhook for automatic migration of ArgoCD v1alpha1 CRs to v1beta1. The webhook is enabled by default and is controlled by `ENABLE_CONVERSION_WEBHOOK` env var. 
For non-olm install, webhook cert management is off-loaded to Openshift Service CA operator. The required annotations for this are already added in configs so no special handling is required in the script. 

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Related [GITOPS-3040](https://issues.redhat.com/browse/GITOPS-3040)

**How to test changes / Special notes to the reviewer**:
- Installation
   ```bash
    ./hack/non-olm-install/install-gitops-operator.sh -i
   ```
- Manual testing
   Same as https://github.com/argoproj-labs/argocd-operator/pull/964.
- Automated testing
   ```bash
   kubectl kuttl test ./test/openshift/e2e/parallel/ --config ./test/openshift/e2e/parallel/kuttl-test.yaml --test 1-103_argocd_alpha_to_beta_conversion
   ```