### PR TITLE
fix: subscription environment is immutable

### DIFF
--- a/docs/OpenShift GitOps Usage Guide.md
+++ b/docs/OpenShift GitOps Usage Guide.md
@@ -413,7 +413,7 @@ Make sure to click **Save**. You should now have a new tab called **Credentials*
 
 ## **Setting environment variables**
 
-Updating the following environment variables in the existing Subscription Object for the GitOps Operator will allow you (as an admin) to change certain properties in your cluster:
+Setting the following environment variables when creating a Subscription Object for the GitOps Operator will allow you (as an admin) to change certain properties in your cluster:
 
 <table>
   <tr>


### PR DESCRIPTION
**What type of PR is this?**

> /kind documentation

**What does this PR do / why we need it**:

```
$ oc explain sub.spec.config.env
KIND:     Subscription
VERSION:  operators.coreos.com/v1alpha1

RESOURCE: env <[]Object>

DESCRIPTION:
     Env is a list of environment variables to set in the container. Cannot be
     updated.
...
```

**Have you updated the necessary documentation?**

Yes.

**Which issue(s) this PR fixes**:

None.

**Test acceptance criteria**:

NA?

**How to test changes / Special notes to the reviewer**:

No test needed?