### PR TITLE
Change TLS termination to Reencrypt and Redirect on Insecure

### DIFF
--- a/controllers/kam.go
+++ b/controllers/kam.go
@@ -144,8 +144,8 @@ func newRouteForCLI() *routev1.Route {
 			TargetPort: intstr.IntOrString{IntVal: portTLS},
 		},
 		TLS: &routev1.TLSConfig{
-			Termination:                   routev1.TLSTerminationPassthrough,
-			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
+			Termination:                   routev1.TLSTerminationReencrypt,
+			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 		},
 	}
 

--- a/test/openshift/e2e/ignore-tests/sequential/1-001_validate_kam_service/01-assert.yaml
+++ b/test/openshift/e2e/ignore-tests/sequential/1-001_validate_kam_service/01-assert.yaml
@@ -24,8 +24,8 @@ spec:
   port:
     targetPort: 8443
   tls:
-    insecureEdgeTerminationPolicy: None
-    termination: passthrough
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
   to:
     kind: Service
     name: kam

--- a/test/openshift/e2e/sequential/1-001_validate_kam_service/01-assert.yaml
+++ b/test/openshift/e2e/sequential/1-001_validate_kam_service/01-assert.yaml
@@ -24,8 +24,8 @@ spec:
   port:
     targetPort: 8443
   tls:
-    insecureEdgeTerminationPolicy: None
-    termination: passthrough
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
   to:
     kind: Service
     name: kam


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What does this PR do / why we need it**:

When this operator is installed, the default route created is pass through so users get an invalid certificate warning since the gitops secret for tls is a generic.

Lots of corporate managed browsers do NOT let users bypass invalid certificates through accepting cert or typing "thisisunsafe" 

Default behavior for fresh install should be a working route using the apps* route.


**Have you updated the necessary documentation?**

No documentation necessary, without this PR, we should have a documentation bug. So if this isn't approved, we should update our docs on how to either update the certificate or update the CRD to use reencrypt.

**Which issue(s) this PR fixes**:

Fixes # GITOPS-3839

**Test acceptance criteria**:

* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:

Install operator, configure gitops CRD and open default link to ArgoCD - should no longer get SSL warning or blocked browser warning.
