### PR TITLE
chore: Add environment variable to change operator logging level

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,8 +94,27 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", enableHTTP2, "If HTTP/2 should be enabled for the metrics and webhook servers.")
 
+	//Configure log level
+	logLevelStr := strings.ToLower(os.Getenv("LOG_LEVEL"))
+	logLevel := zapcore.InfoLevel
+	switch logLevelStr {
+	case "debug":
+		logLevel = zapcore.DebugLevel
+	case "info":
+		logLevel = zapcore.InfoLevel
+	case "warn":
+		logLevel = zapcore.WarnLevel
+	case "error":
+		logLevel = zapcore.ErrorLevel
+	case "panic":
+		logLevel = zapcore.PanicLevel
+	case "fatal":
+		logLevel = zapcore.FatalLevel
+	}
+
 	opts := zap.Options{
 		Development: true,
+		Level:       logLevel,
 		TimeEncoder: zapcore.RFC3339TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:
This PR adds env variable `LOG_LEVEL` to control logs level of the operator.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes [GITOPS-4016](https://issues.redhat.com/browse/GITOPS-4016)

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
cherry-picked the changes from : https://github.com/argoproj-labs/argocd-operator/pull/1224

1. Run the following command from PR branch,
```shell
LOG_LEVEL=error make install run
```