### PR TITLE
Run argo-rollouts-manager/plugin E2E tests as part of gitops-operator E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,9 @@ e2e-tests-sequential:
 
 .PHONY: e2e-tests-parallel ## Runs kuttl e2e parallel tests, (Defaults to 5 runs at a time)
 e2e-tests-parallel:
-	CI=prow make e2e-tests-parallel-ginkgo
+    "scripts/run-rollouts-e2e-tests.sh"
+
+	# CI=prow make e2e-tests-parallel-ginkgo
 	# @echo "Running GitOps Operator parallel E2E tests..."
 	# . ./scripts/run-kuttl-tests.sh  parallel
 

--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -29,3 +29,10 @@ cd ../..
 # Run e2e test
 make test-e2e
 
+# Run Rollouts E2E tests
+cd "$SCRIPT_DIR"
+
+# Get path containing the current script, usually (repo path)/scripts
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+"$SCRIPT_DIR/run-rollouts-e2e-tests.sh"


### PR DESCRIPTION
**What type of PR is this?**
- Experimenting with running upstream argo-rollouts-manager E2E tests on downstream gitops-operator
- Since gitops-operator vendors in argo-rollouts-manager, the same tests should _theoretically_ pass in both places
 
/kind enhancement

**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
