### PR TITLE
chore: Update argocd-operator to 1.10.1-rc to address CVEs

### DIFF
--- a/bundle/manifests/argoproj.io_applicationsets.yaml
+++ b/bundle/manifests/argoproj.io_applicationsets.yaml
@@ -2371,8 +2371,6 @@ spec:
                           - metadata
                           - spec
                           type: object
-                      required:
-                      - elements
                       type: object
                     matrix:
                       properties:
@@ -4715,8 +4713,6 @@ spec:
                                     - metadata
                                     - spec
                                     type: object
-                                required:
-                                - elements
                                 type: object
                               matrix:
                                 x-kubernetes-preserve-unknown-fields: true
@@ -9742,8 +9738,6 @@ spec:
                                     - metadata
                                     - spec
                                     type: object
-                                required:
-                                - elements
                                 type: object
                               matrix:
                                 x-kubernetes-preserve-unknown-fields: true

--- a/config/crd/bases/argoproj.io_applicationsets.yaml
+++ b/config/crd/bases/argoproj.io_applicationsets.yaml
@@ -2370,8 +2370,6 @@ spec:
                           - metadata
                           - spec
                           type: object
-                      required:
-                      - elements
                       type: object
                     matrix:
                       properties:
@@ -4714,8 +4712,6 @@ spec:
                                     - metadata
                                     - spec
                                     type: object
-                                required:
-                                - elements
                                 type: object
                               matrix:
                                 x-kubernetes-preserve-unknown-fields: true
@@ -9741,8 +9737,6 @@ spec:
                                     - metadata
                                     - spec
                                     type: object
-                                required:
-                                - elements
                                 type: object
                               matrix:
                                 x-kubernetes-preserve-unknown-fields: true

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/argoproj-labs/argo-rollouts-manager v0.0.2-0.20230515023837-0632f3e856d5
-	github.com/argoproj-labs/argocd-operator v0.10.1-0.20240305111621-c242083c769c
+	github.com/argoproj-labs/argocd-operator v0.10.1-rc1
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.4.1
 	github.com/google/go-cmp v0.6.0
@@ -26,7 +26,7 @@ require (
 )
 
 require (
-	github.com/argoproj/argo-cd/v2 v2.10.1 // indirect
+	github.com/argoproj/argo-cd/v2 v2.10.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -639,10 +639,10 @@ github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.2-0.20230515023837-0632f3e856d5 h1:SlFbeNb42H7DUGzE9B/uYYjlQjNSR4y+eaWiTqN3PGs=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.2-0.20230515023837-0632f3e856d5/go.mod h1:AiEjAr6e/DCDiicjoC7W7LaZdO28sfgoBhjbGryzEZ8=
-github.com/argoproj-labs/argocd-operator v0.10.1-0.20240305111621-c242083c769c h1:rKME1hb+gB5RfNFcK49OXxsuAOdqsqW+FhAvLzYIi7w=
-github.com/argoproj-labs/argocd-operator v0.10.1-0.20240305111621-c242083c769c/go.mod h1:4TThdvK88j46P6ybACEhHHqJstdnF+CFHkmlS068dqk=
-github.com/argoproj/argo-cd/v2 v2.10.1 h1:VD06GPeoq14Bo7IfiW+EKim3T1C9xaMElVrEtw+zll0=
-github.com/argoproj/argo-cd/v2 v2.10.1/go.mod h1:SK1uGZ9xWVzxuyg079MaO6+hz/Oz9wSDkGyT0gEkYSs=
+github.com/argoproj-labs/argocd-operator v0.10.1-rc1 h1:EIKNIeTEEl5fnlp1xccmwx/DeMZd0W2dZlG6mUp3S9U=
+github.com/argoproj-labs/argocd-operator v0.10.1-rc1/go.mod h1:zgUWRBTiJ8NTktr31Dvm60dh16MLIzkC/CAUTlTxj64=
+github.com/argoproj/argo-cd/v2 v2.10.5 h1:2YSZPjNY3KyE1kme2U54uAAicEn/4zyQ3aAkqkyW8UA=
+github.com/argoproj/argo-cd/v2 v2.10.5/go.mod h1:nujAuswdQvB6yWI8HubQjfUiLdiIlKlG0ihx2Ht1D28=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/test/openshift/e2e/parallel/1-031_validate_toolchain/01-check.yaml
+++ b/test/openshift/e2e/parallel/1-031_validate_toolchain/01-check.yaml
@@ -7,8 +7,8 @@ commands:
 
       # These variables need to be maintained according to the component matrix: https://spaces.redhat.com/display/GITOPS/GitOps+Component+Matrix
       expected_kustomizeVersion='v5.2.1'
-      expected_helmVersion='v3.13.2'
-      expected_argocdVersion='v2.9.2'
+      expected_helmVersion='v3.14.0'
+      expected_argocdVersion='v2.10.5+335875d'
       
       if CI="prow"; then
       # when running against openshift-ci


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

Update argocd-operator to https://github.com/argoproj-labs/argocd-operator/tree/v0.10.1-rc1 
