### PR TITLE
fix: enable infra label to console-plugin deployment

### DIFF
--- a/controllers/consoleplugin.go
+++ b/controllers/consoleplugin.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"reflect"
 
+	argocommon "github.com/argoproj-labs/argocd-operator/common"
+	argocdutil "github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 	consolev1 "github.com/openshift/api/console/v1"
 	pipelinesv1alpha1 "github.com/redhat-developer/gitops-operator/api/v1alpha1"
 	"github.com/redhat-developer/gitops-operator/controllers/util"
@@ -241,16 +243,30 @@ func pluginConfigMap() *corev1.ConfigMap {
 	}
 }
 
-func (r *ReconcileGitopsService) reconcileDeployment(instance *pipelinesv1alpha1.GitopsService, request reconcile.Request) (reconcile.Result, error) {
+func (r *ReconcileGitopsService) reconcileDeployment(cr *pipelinesv1alpha1.GitopsService, request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := logs.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	newPluginDeployment := pluginDeployment()
 
-	if err := controllerutil.SetControllerReference(instance, newPluginDeployment, r.Scheme); err != nil {
+	if err := controllerutil.SetControllerReference(cr, newPluginDeployment, r.Scheme); err != nil {
 		return reconcile.Result{}, err
+	}
+
+	newPluginDeployment.Spec.Template.Spec.NodeSelector = argocommon.DefaultNodeSelector()
+
+	if cr.Spec.RunOnInfra {
+		newPluginDeployment.Spec.Template.Spec.NodeSelector[common.InfraNodeLabelSelector] = ""
+	}
+	if len(cr.Spec.NodeSelector) > 0 {
+		newPluginDeployment.Spec.Template.Spec.NodeSelector = argocdutil.AppendStringMap(newPluginDeployment.Spec.Template.Spec.NodeSelector, cr.Spec.NodeSelector)
+	}
+
+	if len(cr.Spec.Tolerations) > 0 {
+		newPluginDeployment.Spec.Template.Spec.Tolerations = cr.Spec.Tolerations
 	}
 
 	// Check if this Deployment already exists
 	existingPluginDeployment := &appsv1.Deployment{}
+
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: newPluginDeployment.Name, Namespace: newPluginDeployment.Namespace}, existingPluginDeployment)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -272,7 +288,9 @@ func (r *ReconcileGitopsService) reconcileDeployment(instance *pipelinesv1alpha1
 			!reflect.DeepEqual(existingSpecTemplate.Spec.Containers, newSpecTemplate.Spec.Containers) ||
 			!reflect.DeepEqual(existingSpecTemplate.Spec.Volumes, newSpecTemplate.Spec.Volumes) ||
 			!reflect.DeepEqual(existingSpecTemplate.Spec.RestartPolicy, newSpecTemplate.Spec.RestartPolicy) ||
-			!reflect.DeepEqual(existingSpecTemplate.Spec.DNSPolicy, newSpecTemplate.Spec.DNSPolicy)
+			!reflect.DeepEqual(existingSpecTemplate.Spec.DNSPolicy, newSpecTemplate.Spec.DNSPolicy) ||
+			!reflect.DeepEqual(existingPluginDeployment.Spec.Template.Spec.NodeSelector, newPluginDeployment.Spec.Template.Spec.NodeSelector) ||
+			!reflect.DeepEqual(existingPluginDeployment.Spec.Template.Spec.Tolerations, newPluginDeployment.Spec.Template.Spec.Tolerations)
 
 		if changed {
 			reqLogger.Info("Reconciling plugin deployment", "Namespace", existingPluginDeployment.Namespace, "Name", existingPluginDeployment.Name)
@@ -284,6 +302,8 @@ func (r *ReconcileGitopsService) reconcileDeployment(instance *pipelinesv1alpha1
 			existingSpecTemplate.Spec.Volumes = newSpecTemplate.Spec.Volumes
 			existingSpecTemplate.Spec.RestartPolicy = newSpecTemplate.Spec.RestartPolicy
 			existingSpecTemplate.Spec.DNSPolicy = newSpecTemplate.Spec.DNSPolicy
+			existingPluginDeployment.Spec.Template.Spec.NodeSelector = newPluginDeployment.Spec.Template.Spec.NodeSelector
+			existingPluginDeployment.Spec.Template.Spec.Tolerations = newPluginDeployment.Spec.Template.Spec.Tolerations
 			return reconcile.Result{}, r.Client.Update(context.TODO(), newPluginDeployment)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug

**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
Enable `runOnInfra: true` in GitOpsService CR
And verify that the console-plugin pods has the correct nodeSelector label added to it.
