### PR TITLE
Fixed CRDs owned by GitOps Operator in the clusterserviceversion manifest file for v1.11

### DIFF
--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -157,10 +157,17 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - kind: AnalysisRun
+    - description: An AnalysisRun is an instantiation of an AnalysisTemplate.
+        AnalysisRuns are like Jobs in that they eventually complete.
+      displayName: AnalysisRun
+      kind: AnalysisRun
       name: analysisruns.argoproj.io
       version: v1alpha1
-    - kind: AnalysisTemplate
+    - description: An AnalysisTemplate is a template spec which defines how to
+        perform a canary analysis, such as the metrics, its frequency,
+        and the values which are considered successful or failed.
+      displayName: AnalysisTemplate
+      kind: AnalysisTemplate
       name: analysistemplates.argoproj.io
       version: v1alpha1
     - description: An Application is a group of Kubernetes resources as defined by
@@ -171,6 +178,7 @@ spec:
       version: v1alpha1
     - description: ApplicationSet is the representation of an ApplicationSet controller
         deployment.
+      displayName: ApplicationSet
       kind: ApplicationSet
       name: applicationsets.argoproj.io
       version: v1alpha1
@@ -186,7 +194,7 @@ spec:
       resources:
       - kind: ArgoCD
         name: ""
-        version: v1alpha1
+        version: v1beta1
       - kind: ConfigMap
         name: ""
         version: v1
@@ -229,14 +237,17 @@ spec:
       - kind: StatefulSet
         name: ""
         version: v1
-      version: v1alpha1
-    - kind: ArgoCD
-      name: argocds.argoproj.io
       version: v1beta1
-    - kind: ClusterAnalysisTemplate
+    - description: A ClusterAnalysisTemplate is like an AnalysisTemplate,but it is not limited to its namespace.
+        It can be used by any Rollout throughout the cluster.
+      displayName: ClusterAnalysisTemplate
+      kind: ClusterAnalysisTemplate
       name: clusteranalysistemplates.argoproj.io
       version: v1alpha1
-    - kind: Experiment
+    - description: An Experiment is limited run of one or more ReplicaSets for the purposes of analysis.
+        Experiments typically run for a pre-determined duration, but can also run indefinitely until stopped.
+      displayName: Experiment
+      kind: Experiment
       name: experiments.argoproj.io
       version: v1alpha1
     - description: GitopsService is the Schema for the gitopsservices API
@@ -244,12 +255,12 @@ spec:
       kind: GitopsService
       name: gitopsservices.pipelines.openshift.io
       version: v1alpha1
-    - kind: RolloutManager
+    - description: A controller for managing Argo Rollouts
+      displayName: RolloutManager
+      kind: RolloutManager
       name: rolloutmanagers.argoproj.io
       version: v1alpha1
-    - kind: Rollout
-      name: rollouts.argoproj.io
-      version: v1alpha1
+
   description: "Red Hat OpenShift GitOps is a declarative continuous delivery platform
     based on [Argo CD](https://argoproj.github.io/argo-cd/). It enables teams to adopt
     GitOps principles for managing cluster configurations and automating secure and

--- a/config/manifests/bases/gitops-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/gitops-operator.clusterserviceversion.yaml
@@ -25,11 +25,30 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: An AnalysisRun is an instantiation of an AnalysisTemplate.
+        AnalysisRuns are like Jobs in that they eventually complete.
+      displayName: AnalysisRun
+      kind: AnalysisRun
+      name: analysisruns.argoproj.io
+      version: v1alpha1
+    - description: An AnalysisTemplate is a template spec which defines how to
+        perform a canary analysis, such as the metrics, its frequency,
+        and the values which are considered successful or failed.
+      displayName: AnalysisTemplate
+      kind: AnalysisTemplate
+      name: analysistemplates.argoproj.io
+      version: v1alpha1
     - description: An Application is a group of Kubernetes resources as defined by
         a manifest.
       displayName: Application
       kind: Application
       name: applications.argoproj.io
+      version: v1alpha1
+    - description: ApplicationSet is the representation of an ApplicationSet controller
+        deployment.
+      displayName: ApplicationSet
+      kind: ApplicationSet
+      name: applicationsets.argoproj.io
       version: v1alpha1
     - description: An AppProject is a logical grouping of Argo CD Applications.
       displayName: AppProject
@@ -43,7 +62,7 @@ spec:
       resources:
       - kind: ArgoCD
         name: ""
-        version: v1alpha1
+        version: v1beta1
       - kind: ConfigMap
         name: ""
         version: v1
@@ -86,16 +105,28 @@ spec:
       - kind: StatefulSet
         name: ""
         version: v1
+      version: v1beta1
+    - description: A ClusterAnalysisTemplate is like an AnalysisTemplate,but it is not limited to its namespace.
+        It can be used by any Rollout throughout the cluster.
+      displayName: ClusterAnalysisTemplate
+      kind: ClusterAnalysisTemplate
+      name: clusteranalysistemplates.argoproj.io
       version: v1alpha1
-    - description: ApplicationSet is the representation of an ApplicationSet controller
-        deployment.
-      kind: ApplicationSet
-      name: applicationsets.argoproj.io
+    - description: An Experiment is limited run of one or more ReplicaSets for the purposes of analysis.
+        Experiments typically run for a pre-determined duration, but can also run indefinitely until stopped.
+      displayName: Experiment
+      kind: Experiment
+      name: experiments.argoproj.io
       version: v1alpha1
     - description: GitopsService is the Schema for the gitopsservices API
       displayName: Gitops Service
       kind: GitopsService
       name: gitopsservices.pipelines.openshift.io
+      version: v1alpha1
+    - description: A controller for managing Argo Rollouts
+      displayName: RolloutManager
+      kind: RolloutManager
+      name: rolloutmanagers.argoproj.io
       version: v1alpha1
   displayName: Red Hat OpenShift GitOps
   install:


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug



**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-4513
Manual cherry-pick of https://github.com/redhat-developer/gitops-operator/pull/678

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
