### PR TITLE
fix: add apiservicedefinitions for rollouts API [1.10]

### DIFF
--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -157,15 +157,15 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: An AnalysisRun is an instantiation of an AnalysisTemplate.
-        AnalysisRuns are like Jobs in that they eventually complete.
+    - description: An AnalysisRun is an instantiation of an AnalysisTemplate. AnalysisRuns
+        are like Jobs in that they eventually complete.
       displayName: AnalysisRun
       kind: AnalysisRun
       name: analysisruns.argoproj.io
       version: v1alpha1
-    - description: An AnalysisTemplate is a template spec which defines how to
-        perform a canary analysis, such as the metrics, its frequency,
-        and the values which are considered successful or failed.
+    - description: An AnalysisTemplate is a template spec which defines how to perform
+        a canary analysis, such as the metrics, its frequency, and the values which
+        are considered successful or failed.
       displayName: AnalysisTemplate
       kind: AnalysisTemplate
       name: analysistemplates.argoproj.io
@@ -186,6 +186,9 @@ spec:
       displayName: AppProject
       kind: AppProject
       name: appprojects.argoproj.io
+      version: v1alpha1
+    - kind: ArgoCD
+      name: argocds.argoproj.io
       version: v1alpha1
     - description: Argo CD is the representation of an Argo CD deployment.
       displayName: Argo CD
@@ -238,14 +241,16 @@ spec:
         name: ""
         version: v1
       version: v1beta1
-    - description: A ClusterAnalysisTemplate is like an AnalysisTemplate,but it is not limited to its namespace.
-        It can be used by any Rollout throughout the cluster.
+    - description: A ClusterAnalysisTemplate is like an AnalysisTemplate,but it is
+        not limited to its namespace. It can be used by any Rollout throughout the
+        cluster.
       displayName: ClusterAnalysisTemplate
       kind: ClusterAnalysisTemplate
       name: clusteranalysistemplates.argoproj.io
       version: v1alpha1
-    - description: An Experiment is limited run of one or more ReplicaSets for the purposes of analysis.
-        Experiments typically run for a pre-determined duration, but can also run indefinitely until stopped.
+    - description: An Experiment is limited run of one or more ReplicaSets for the
+        purposes of analysis. Experiments typically run for a pre-determined duration,
+        but can also run indefinitely until stopped.
       displayName: Experiment
       kind: Experiment
       name: experiments.argoproj.io
@@ -259,6 +264,9 @@ spec:
       displayName: RolloutManager
       kind: RolloutManager
       name: rolloutmanagers.argoproj.io
+      version: v1alpha1
+    - kind: Rollout
+      name: rollouts.argoproj.io
       version: v1alpha1
   description: "Red Hat OpenShift GitOps is a declarative continuous delivery platform
     based on [Argo CD](https://argoproj.github.io/argo-cd/). It enables teams to adopt
@@ -535,6 +543,18 @@ spec:
           - argoproj.io
           resources:
           - rollouts
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - argoproj.io
+          resources:
+          - rollouts
           - rollouts/finalizers
           - rollouts/scale
           - rollouts/status
@@ -547,6 +567,20 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - argoproj.io
+          resources:
+          - rollouts/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - argoproj.io
+          resources:
+          - rollouts/status
+          verbs:
+          - get
+          - patch
+          - update
         - apiGroups:
           - autoscaling
           resources:

--- a/config/manifests/bases/gitops-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/gitops-operator.clusterserviceversion.yaml
@@ -25,15 +25,15 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: An AnalysisRun is an instantiation of an AnalysisTemplate.
-        AnalysisRuns are like Jobs in that they eventually complete.
+    - description: An AnalysisRun is an instantiation of an AnalysisTemplate. AnalysisRuns
+        are like Jobs in that they eventually complete.
       displayName: AnalysisRun
       kind: AnalysisRun
       name: analysisruns.argoproj.io
       version: v1alpha1
-    - description: An AnalysisTemplate is a template spec which defines how to
-        perform a canary analysis, such as the metrics, its frequency,
-        and the values which are considered successful or failed.
+    - description: An AnalysisTemplate is a template spec which defines how to perform
+        a canary analysis, such as the metrics, its frequency, and the values which
+        are considered successful or failed.
       displayName: AnalysisTemplate
       kind: AnalysisTemplate
       name: analysistemplates.argoproj.io
@@ -106,27 +106,29 @@ spec:
         name: ""
         version: v1
       version: v1beta1
-    - description: A ClusterAnalysisTemplate is like an AnalysisTemplate,but it is not limited to its namespace.
-        It can be used by any Rollout throughout the cluster.
+    - description: A ClusterAnalysisTemplate is like an AnalysisTemplate,but it is
+        not limited to its namespace. It can be used by any Rollout throughout the
+        cluster.
       displayName: ClusterAnalysisTemplate
       kind: ClusterAnalysisTemplate
       name: clusteranalysistemplates.argoproj.io
       version: v1alpha1
-    - description: An Experiment is limited run of one or more ReplicaSets for the purposes of analysis.
-        Experiments typically run for a pre-determined duration, but can also run indefinitely until stopped.
+    - description: An Experiment is limited run of one or more ReplicaSets for the
+        purposes of analysis. Experiments typically run for a pre-determined duration,
+        but can also run indefinitely until stopped.
       displayName: Experiment
       kind: Experiment
       name: experiments.argoproj.io
-      version: v1alpha1
-    - description: GitopsService is the Schema for the gitopsservices API
-      displayName: Gitops Service
-      kind: GitopsService
-      name: gitopsservices.pipelines.openshift.io
       version: v1alpha1
     - description: A controller for managing Argo Rollouts
       displayName: RolloutManager
       kind: RolloutManager
       name: rolloutmanagers.argoproj.io
+      version: v1alpha1
+    - description: GitopsService is the Schema for the gitopsservices API
+      displayName: Gitops Service
+      kind: GitopsService
+      name: gitopsservices.pipelines.openshift.io
       version: v1alpha1
   displayName: Red Hat OpenShift GitOps
   install:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -248,6 +248,18 @@ rules:
   - argoproj.io
   resources:
   - rollouts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
   - rollouts/finalizers
   - rollouts/scale
   - rollouts/status
@@ -260,6 +272,20 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - autoscaling
   resources:

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -164,6 +164,11 @@ type ReconcileGitopsService struct {
 //+kubebuilder:rbac:groups=argoproj.io,resources=rolloutmanagers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=argoproj.io,resources=rolloutmanagers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=argoproj.io,resources=rolloutmanagers/finalizers,verbs=update
+
+//+kubebuilder:rbac:groups=argoproj.io,resources=rollouts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=argoproj.io,resources=rollouts/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=argoproj.io,resources=rollouts/finalizers,verbs=update
+
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps;endpoints;events;pods;namespaces;secrets;serviceaccounts;services;services/finalizers,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
- Adds the missing apiservicedefinitions for Argo Rollouts in the CSV.

**Have you updated the necessary documentation?**
NA