### PR TITLE
Script to auto-upgrade argo-rollouts-manager to latest

### DIFF
--- a/hack/upgrade-rollouts-manager/.gitignore
+++ b/hack/upgrade-rollouts-manager/.gitignore
@@ -1,0 +1,2 @@
+settings.env
+argo-rollouts-manager

--- a/hack/upgrade-rollouts-manager/README.md
+++ b/hack/upgrade-rollouts-manager/README.md
@@ -1,0 +1,33 @@
+# Update gitops-operator to latest release of argo-rollouts-manager
+
+The Go code and script in this directory will automatically open a pull request to update the gitops-operator to the latest commit of argo-rollouts-manager:
+- Update `go.mod` to point to latest module version
+- Update CRDs to latest
+- Regenerate manifests and bundles
+- (Currently disabled): Update target Rollouts version in `hack/run-upstream-argo-rollouts-e2e-tests.sh`
+- Open Pull Request using 'gh' CLI
+
+## Instructions
+
+### Prerequisites
+- GitHub CLI (_gh_) installed and on PATH
+- Go installed and on PATH
+- Operator-sdk installed and on PATH
+- You must have your own fork of the [argo-rollouts-manager](https://github.com/argoproj-labs/argo-rollouts-manager) repository in GitHub(e.g. `jgwest/argo-rollouts-manager`)
+- Your local SSH key registered (e.g. `~/.ssh/id_rsa.pub`) with GitHub to allow git clone via SSH
+
+### Configure and run the tool
+
+```bash
+
+# Set required Environment Variables
+export GITHUB_FORK_USERNAME="(your username here)"
+export GH_TOKEN="(a GitHub personal access token that can clone/push/open PRs against argo-rollouts-manager repo)"
+
+# or, you can set these values in the settings.env file:
+#   cp settings_template.env settings.env
+# Then set env vars in settings.env (which is excluded in the .gitignore)
+
+./init-repo.sh
+./go-run.sh
+```

--- a/hack/upgrade-rollouts-manager/go-run.sh
+++ b/hack/upgrade-rollouts-manager/go-run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd $SCRIPT_DIR
+
+# Read Github Token and Username from settings.env, if it exists
+vars_file="$SCRIPT_DIR/settings.env"
+if [[ -f "$vars_file" ]]; then
+    source "$vars_file"
+fi
+
+# Run the upgrade code
+go run .

--- a/hack/upgrade-rollouts-manager/go.mod
+++ b/hack/upgrade-rollouts-manager/go.mod
@@ -1,0 +1,7 @@
+module github.com/redhat-developepr/gitops-operator/upgrade-rollouts-manager
+
+go 1.20
+
+require github.com/google/go-github/v58 v58.0.0
+
+require github.com/google/go-querystring v1.1.0 // indirect

--- a/hack/upgrade-rollouts-manager/go.sum
+++ b/hack/upgrade-rollouts-manager/go.sum
@@ -1,0 +1,10 @@
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-github/v58 v58.0.0 h1:Una7GGERlF/37XfkPwpzYJe0Vp4dt2k1kCjlxwjIvzw=
+github.com/google/go-github/v58 v58.0.0/go.mod h1:k4hxDKEfoWpSqFlc8LTpGd9fu2KrV1YAa6Hi6FmDNY4=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/hack/upgrade-rollouts-manager/init-repo.sh
+++ b/hack/upgrade-rollouts-manager/init-repo.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd $SCRIPT_DIR
+
+# Read Github Token and Username from settings.env, if it exists
+vars_file="$SCRIPT_DIR/settings.env"
+if [[ -f "$vars_file" ]]; then
+    source "$vars_file"
+fi
+
+# Clone fork of gitops-operator repo
+
+rm -rf "$SCRIPT_DIR/gitops-operator" || true
+
+git clone "git@github.com:$GITHUB_FORK_USERNAME/gitops-operator"
+cd gitops-operator
+
+# Add a remote back to the original repo
+
+git remote add parent "git@github.com:redhat-developer/gitops-operator"
+git fetch parent
+

--- a/hack/upgrade-rollouts-manager/main.go
+++ b/hack/upgrade-rollouts-manager/main.go
@@ -1,0 +1,370 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+
+	"os/exec"
+
+	"github.com/google/go-github/v58/github"
+)
+
+// These can be set while debugging
+const (
+	// if readOnly is true:
+	// - PRs will not be opened
+	// - Git commits will not be pushed to fork
+	// This is roughly equivalent to a dry run
+	readOnly = false // default to false
+
+	PRTitlePrefix = "Update to latest commit of argo-rollouts-manager "
+)
+
+func main() {
+
+	pathToGitOpsOperatorGitRepo := "gitops-operator"
+
+	// Checkout argo-rollouts-manager repo into a temporary directory
+	pathToRolloutsManagerGitRepo, err := checkoutRolloutsManagerRepoIntoTempDir()
+	if err != nil {
+		exitWithError(err)
+		return
+	}
+
+	// Get latest commit ID from argo-rollouts-manager
+	stdout, _, err := runCommandWithWorkDir(pathToRolloutsManagerGitRepo, "git", "log", "--format=%H")
+	if err != nil {
+		exitWithError(err)
+		return
+	}
+	commitIds := strings.Split(stdout, "\n")
+	if len(commitIds) == 0 {
+		exitWithError(fmt.Errorf("unable to retrive commit ids"))
+	}
+
+	mostRecentCommitID := commitIds[0]
+
+	newBranchName := "upgrade-rollouts-manager"
+
+	// Create, commit, and push a new branch
+	if repoAlreadyUpToDate, err := createNewCommitAndBranch(mostRecentCommitID, newBranchName, pathToRolloutsManagerGitRepo, pathToGitOpsOperatorGitRepo); err != nil {
+
+		if repoAlreadyUpToDate {
+			fmt.Println("* Exiting as target repository is already up to date.")
+			return
+		}
+
+		exitWithError(err)
+		return
+	}
+
+	if !readOnly {
+
+		var existingPRID *int
+
+		{
+
+			gitHubToken := os.Getenv("GH_TOKEN")
+			if gitHubToken == "" {
+				exitWithError(fmt.Errorf("missing GH_TOKEN"))
+				return
+			}
+
+			client := github.NewClient(nil).WithAuthToken(gitHubToken)
+
+			// 1) Check for existing version update PRs on the repo
+
+			prList, _, err := client.PullRequests.List(context.Background(), "redhat-developer", "gitops-operator", &github.PullRequestListOptions{})
+			if err != nil {
+				exitWithError(err)
+				return
+			}
+			for _, pr := range prList {
+				if strings.HasPrefix(*pr.Title, PRTitlePrefix) {
+					existingPRID = (*pr).Number
+				}
+			}
+		}
+
+		PRTitle := PRTitlePrefix + "'" + mostRecentCommitID + "'"
+
+		bodyText := `
+
+Update to most recent 'argo-rollouts-manager' commit: https://github.com/argoproj-labs/argo-rollouts-manager/commit/` + mostRecentCommitID
+
+		if existingPRID != nil {
+			//  Update PR title/body if it already exists
+			if stdout, stderr, err := runCommandWithWorkDir(pathToGitOpsOperatorGitRepo, "gh", "pr", "edit", strconv.Itoa(*existingPRID),
+				"-R", "redhat-developer/gitops-operator",
+				"--title", PRTitle, "--body", bodyText); err != nil {
+				fmt.Println(stdout, stderr)
+				exitWithError(err)
+				return
+			}
+
+		} else {
+			//  Create PR if it doesn't exist
+			if stdout, stderr, err := runCommandWithWorkDir(pathToGitOpsOperatorGitRepo, "gh", "pr", "create",
+				"-R", "redhat-developer/gitops-operator",
+				"--title", PRTitle, "--body", bodyText); err != nil {
+				fmt.Println(stdout, stderr)
+				exitWithError(err)
+				return
+			}
+
+		}
+
+	}
+
+}
+
+// return true if the argo-rollouts-manager repo is already up to date
+func createNewCommitAndBranch(latestRolloutsManagerCommitId string, newBranchName, pathToArgoRolloutsManagerRepo string, pathToGitOpsOperatorGitRepo string) (bool, error) {
+
+	commands := [][]string{
+		{"git", "stash"},
+		{"git", "fetch", "parent"},
+		{"git", "checkout", "master"},
+		{"git", "rebase", "parent/master"},
+		{"git", "checkout", "-b", newBranchName},
+	}
+
+	if err := runCommandListWithWorkDir(pathToGitOpsOperatorGitRepo, commands); err != nil {
+		return false, err
+	}
+
+	if goModGitCommit, err := extractCurrentRolloutsManagerGitCommitFromGoMod(pathToGitOpsOperatorGitRepo); err != nil {
+		return false, fmt.Errorf("unable to extract current target version from repo")
+
+	} else if strings.Contains(latestRolloutsManagerCommitId, goModGitCommit) {
+		return false, fmt.Errorf("gitops-operator is already on the target git commit")
+	}
+
+	if err := regenerateGoMod(latestRolloutsManagerCommitId, pathToGitOpsOperatorGitRepo); err != nil {
+		return false, err
+	}
+
+	// TODO: Uncomment this once we have argo-rollouts test integration with gitops-oeprator
+	// if err := regenerateE2ETestScript(latestRolloutsManagerCommitId, pathToGitOpsOperatorGitRepo); err != nil {
+	// 	return false, err
+	// }
+
+	if err := copyCRDsFromRolloutsManagerRepo(pathToArgoRolloutsManagerRepo, pathToGitOpsOperatorGitRepo); err != nil {
+		return false, fmt.Errorf("unable to copy rollouts CRDs: %w", err)
+	}
+
+	commands = [][]string{
+		{"go", "mod", "tidy"},
+		{"make", "generate", "manifests"},
+		{"make", "bundle"},
+		{"make", "fmt"},
+		{"git", "add", "--all"},
+		{"git", "commit", "-s", "-m", PRTitlePrefix + "'" + latestRolloutsManagerCommitId + "'"},
+	}
+	if err := runCommandListWithWorkDir(pathToGitOpsOperatorGitRepo, commands); err != nil {
+		return false, err
+	}
+
+	if !readOnly {
+		commands = [][]string{
+			{"git", "push", "-f", "--set-upstream", "origin", newBranchName},
+		}
+		if err := runCommandListWithWorkDir(pathToGitOpsOperatorGitRepo, commands); err != nil {
+			return false, err
+		}
+	}
+
+	return false, nil
+
+}
+
+func copyCRDsFromRolloutsManagerRepo(pathToRolloutsManagerGitRepo string, pathToGitRepo string) error {
+	rolloutManagerCRDPath := filepath.Join(pathToRolloutsManagerGitRepo, "config", "crd", "bases")
+
+	crdYamlDirEntries, err := os.ReadDir(rolloutManagerCRDPath)
+	if err != nil {
+		return err
+	}
+
+	var crdYAMLs []string
+	for _, crdYamlDirEntry := range crdYamlDirEntries {
+
+		if !crdYamlDirEntry.IsDir() {
+			crdYAMLs = append(crdYAMLs, crdYamlDirEntry.Name())
+		}
+	}
+
+	sort.Strings(crdYAMLs)
+
+	// NOTE: If this line fails, check if any new CRDs have been added to Rollouts, and/or if they have changed the filenames.
+	// - If so, this will require verifying the changes, then updating this list
+	if !reflect.DeepEqual(crdYAMLs, []string{
+		"analysis-run-crd.yaml",
+		"analysis-template-crd.yaml",
+		"argoproj.io_rolloutmanagers.yaml",
+		"cluster-analysis-template-crd.yaml",
+		"experiment-crd.yaml",
+		"rollout-crd.yaml"}) {
+		return fmt.Errorf("unexpected CRDs found: %v", crdYAMLs)
+	}
+
+	destinationPath := filepath.Join(pathToGitRepo, "config/crd/bases")
+	for _, crdYAML := range crdYAMLs {
+
+		destFile, err := os.Create(filepath.Join(destinationPath, crdYAML))
+		if err != nil {
+			return fmt.Errorf("unable to create file for '%s': %w", crdYAML, err)
+		}
+		defer destFile.Close()
+
+		srcFile, err := os.Open(filepath.Join(rolloutManagerCRDPath, crdYAML))
+		if err != nil {
+			return fmt.Errorf("unable to open source file for '%s': %w", crdYAML, err)
+		}
+		defer srcFile.Close()
+
+		_, err = io.Copy(destFile, srcFile)
+		if err != nil {
+			return fmt.Errorf("unable to copy file for '%s': %w", crdYAML, err)
+		}
+
+	}
+
+	return nil
+}
+
+func regenerateE2ETestScript(commitID string, pathToGitRepo string) error {
+
+	envName := "TARGET_ROLLOUT_MANAGER_COMMIT"
+	// Format of string to modify:
+	// TARGET_ROLLOUT_MANAGER_COMMIT=(commit id)
+
+	path := filepath.Join(pathToGitRepo, "scripts/openshiftci-presubmit-all-tests.sh")
+
+	fileBytes, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var res string
+
+	for _, line := range strings.Split(string(fileBytes), "\n") {
+
+		if strings.Contains(line, envName) {
+
+			res += envName + "=" + commitID + "\n"
+
+		} else {
+			res += line + "\n"
+		}
+
+	}
+
+	if err := os.WriteFile(path, []byte(res), 0600); err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func checkoutRolloutsManagerRepoIntoTempDir() (string, error) {
+
+	tmpDir, err := os.MkdirTemp("", "argo-rollouts-manager-src")
+	if err != nil {
+		return "", err
+	}
+
+	if _, _, err := runCommandWithWorkDir(tmpDir, "git", "clone", "https://github.com/argoproj-labs/argo-rollouts-manager"); err != nil {
+		return "", err
+	}
+
+	newWorkDir := filepath.Join(tmpDir, "argo-rollouts-manager")
+
+	return newWorkDir, nil
+}
+
+// extractCurrentRolloutsManagerGitCommitFromGoMod read the contents of the argo-rollouts-manager repo and determine which argo-rollouts version is being targeted.
+func extractCurrentRolloutsManagerGitCommitFromGoMod(pathToGitOpsOperatorGitRepo string) (string, error) {
+
+	// Style of text string to parse:
+	// github.com/argoproj-labs/argo-rollouts-manager v0.0.2-0.20240221054348-027faa92ffdb
+
+	path := filepath.Join(pathToGitOpsOperatorGitRepo, "go.mod")
+
+	fileBytes, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	for _, line := range strings.Split(string(fileBytes), "\n") {
+		if strings.Contains(line, "github.com/argoproj-labs/argo-rollouts-manager v") {
+
+			indexOfLastHyphen := strings.LastIndex(line, "-")
+			if indexOfLastHyphen != -1 {
+				return strings.TrimSpace(line[indexOfLastHyphen+1:]), nil
+			}
+
+		}
+	}
+
+	return "", fmt.Errorf("no version found in gitops-operator go.mod")
+}
+
+func regenerateGoMod(commitId string, pathToGitRepo string) error {
+
+	if err := runCommandListWithWorkDir(pathToGitRepo, [][]string{
+		{"go", "get", "github.com/argoproj-labs/argo-rollouts-manager@" + commitId},
+		{"go", "mod", "tidy"}}); err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func runCommandListWithWorkDir(workingDir string, commands [][]string) error {
+
+	for _, command := range commands {
+
+		_, _, err := runCommandWithWorkDir(workingDir, command...)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runCommandWithWorkDir(workingDir string, cmdList ...string) (string, string, error) {
+
+	fmt.Println(cmdList)
+
+	cmd := exec.Command(cmdList[0], cmdList[1:]...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Dir = workingDir
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	stdoutStr := stdout.String()
+	stderrStr := stderr.String()
+
+	fmt.Println(stdoutStr, stderrStr)
+
+	return stdoutStr, stderrStr, err
+
+}
+
+func exitWithError(err error) {
+	fmt.Println("ERROR:", err)
+	os.Exit(1)
+}

--- a/hack/upgrade-rollouts-manager/settings_template.env
+++ b/hack/upgrade-rollouts-manager/settings_template.env
@@ -1,0 +1,2 @@
+export GITHUB_FORK_USERNAME="(your username here)"
+export GH_TOKEN="(a GitHub personal access token that can clone/push/open PRs against argo-rollouts-manager repo)"


### PR DESCRIPTION
**What type of PR is this?**
A script which automatically upgrades to the latest commit of argo-rollouts-manager (Argo Rollouts operator).

When you run the script, it creates a PR like this: https://github.com/redhat-developer/gitops-operator/pull/700

See README.md within the PR for details.

/kind enhancement

**Have you updated the necessary documentation?**

* [X] Documentation update is required by this PR.
* [X] Documentation has been updated.

**Which issue(s) this PR fixes**: 

Fixes #? N/A
