### PR TITLE
fix: operator controller manager cannot list networkpolicies [1.11]

### DIFF
--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -729,6 +729,18 @@ spec:
           - ingresses
           verbs:
           - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          - networkpolicies
+          verbs:
+          - create
           - delete
           - get
           - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -434,6 +434,18 @@ rules:
   - ingresses
   verbs:
   - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs:
+  - create
   - delete
   - get
   - list

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -155,7 +155,7 @@ type ReconcileGitopsService struct {
 
 //+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;delete;patch;update
 //+kubebuilder:rbac:groups=batch,resources=cronjobs;jobs,verbs=get;list;watch;create;delete;patch;update
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;delete;patch;update
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses;networkpolicies,verbs=get;list;watch;create;delete;patch;update
 
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=operatorgroups;subscriptions;clusterserviceversions,verbs=create;get;list;watch
 


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
fix: operator controller manager cannot list networkpolicies
```
E0522 18:24:17.392760       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.28.3/tools/cache/reflector.go:229: Failed to watch *v1.NetworkPolicy: failed to list *v1.NetworkPolicy: networkpolicies.networking.k8s.io is forbidden: User "system:serviceaccount:openshift-operators:openshift-gitops-operator-controller-manager" cannot list resource "networkpolicies" in API group "networking.k8s.io" at the cluster scope
```

**Have you updated the necessary documentation?**
NA

**How to test changes / Special notes to the reviewer**:
- Create the operator bundle and run it using OLM.
