### PR TITLE
fix: sentinal liveliness issue

### DIFF
--- a/build/redis/sentinel_liveness.sh.tpl
+++ b/build/redis/sentinel_liveness.sh.tpl
@@ -1,6 +1,5 @@
 response=$(
   redis-cli \
-    -a "${AUTH}" --no-auth-warning \
     -h localhost \
     -p 26379 \
 {{- if eq .UseTLS "true"}}


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
```
Readiness probe failed: AUTH failed: ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?
```
