### PR TITLE
Add script to run Rollouts tests against gitops-operator repo

### DIFF
--- a/hack/upgrade-rollouts-manager/main.go
+++ b/hack/upgrade-rollouts-manager/main.go
@@ -152,10 +152,9 @@ func createNewCommitAndBranch(latestRolloutsManagerCommitId string, newBranchNam
 		return false, err
 	}
 
-	// TODO: Uncomment this once we have argo-rollouts test integration with gitops-oeprator
-	// if err := regenerateE2ETestScript(latestRolloutsManagerCommitId, pathToGitOpsOperatorGitRepo); err != nil {
-	// 	return false, err
-	// }
+	if err := regenerateE2ETestScript(latestRolloutsManagerCommitId, pathToGitOpsOperatorGitRepo); err != nil {
+		return false, err
+	}
 
 	if err := copyCRDsFromRolloutsManagerRepo(pathToArgoRolloutsManagerRepo, pathToGitOpsOperatorGitRepo); err != nil {
 		return false, fmt.Errorf("unable to copy rollouts CRDs: %w", err)
@@ -247,7 +246,7 @@ func regenerateE2ETestScript(commitID string, pathToGitRepo string) error {
 	// Format of string to modify:
 	// TARGET_ROLLOUT_MANAGER_COMMIT=(commit id)
 
-	path := filepath.Join(pathToGitRepo, "scripts/openshiftci-presubmit-all-tests.sh")
+	path := filepath.Join(pathToGitRepo, "scripts/run-rollouts-e2e-tests.sh")
 
 	fileBytes, err := os.ReadFile(path)
 	if err != nil {

--- a/scripts/run-rollouts-e2e-tests.sh
+++ b/scripts/run-rollouts-e2e-tests.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# The goal of this script is to run the Argo Rollouts operator tests from the argo-rollouts-manager repo against gitops-operator:
+# - Runs the (cluster-scoped) E2E tests of the Argo Rollouts operator
+# - Runs the upstream E2E tests from the argo-rollouts repo
+
+ROLLOUTS_TMP_DIR=$(mktemp -d)
+
+cd $ROLLOUTS_TMP_DIR
+
+git clone https://github.com/argoproj-labs/argo-rollouts-manager
+
+cd "$ROLLOUTS_TMP_DIR/argo-rollouts-manager"
+
+# This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
+# - It should always point to the same argo-rollouts-manager commit that is referenced in go.mod of gitops-operator (which will usually be the most recent argo-rollouts-manager commit)
+TARGET_ROLLOUT_MANAGER_COMMIT=b3e573f0e6ea3a5ec3eeba70ebb5d90e58efcd68
+
+git checkout $TARGET_ROLLOUT_MANAGER_COMMIT
+
+# 1) Run E2E tests from argo-rollouts-manager repo
+
+make test-e2e
+
+# Clean up old namespaces created by test
+# NOTE: remove this once this is handled by 'make test-e2e' in argo-rollouts-manager repo
+kubectl delete rolloutmanagers --all -n test-rom-ns-1
+
+cd "$ROLLOUTS_TMP_DIR/argo-rollouts-manager"
+
+
+# 2) Run E2E tests from argoproj/argo-rollouts repo
+
+SKIP_RUN_STEP=true hack/run-upstream-argo-rollouts-e2e-tests.sh


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:

This PR adds a new shell script which can be run to verify the Argo Rollouts functionality within gitops-operator.
- It runs the (cluster-scoped) E2E tests of the Argo Rollouts operator
- It runs the upstream E2E tests from the argo-rollouts repo

This PR only adds the scripts to the repo, so they can be called manually. We can add integration to CI in a separate PR.


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.
