### PR TITLE
Fix 'Unable to retrieve current OCP version: Malformed version' when running unit tests

### DIFF
--- a/controllers/argocd_metrics_controller.go
+++ b/controllers/argocd_metrics_controller.go
@@ -366,6 +366,7 @@ func (r *ArgoCDMetricsReconciler) reconcileOperatorMetricsServiceMonitor(reqLogg
 			reqLogger.Info(fmt.Sprintf("Unable to retrieve the operator's running namespace via '%s': you should only see this message when running within unit tests, otherwise it is an error.", operatorPodNamespacePath))
 			return nil
 		}
+		reqLogger.Error(err, "Error retrieving operator's running namespace")
 		return err
 	}
 

--- a/controllers/argocd_metrics_controller.go
+++ b/controllers/argocd_metrics_controller.go
@@ -362,7 +362,10 @@ func (r *ArgoCDMetricsReconciler) reconcileOperatorMetricsServiceMonitor(reqLogg
 
 	data, err := os.ReadFile(operatorPodNamespacePath)
 	if err != nil {
-		reqLogger.Error(err, "Error retrieving operator's running namespace")
+		if os.IsNotExist(err) {
+			reqLogger.Info(fmt.Sprintf("Unable to retrieve the operator's running namespace via '%s': you should only see this message when running within unit tests, otherwise it is an error.", operatorPodNamespacePath))
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION


**What type of PR is this?**
/kind failing-test

**What does this PR do / why we need it**:
- This PR fixes the following error, when running the unit tests locally:
```
2024/01/24 09:40:13 Unable to retrieve current OCP version: Malformed version:
FAIL 
coverage: 69.8% of statements
FAIL github.com/redhat-developer/gitops-operator/controllers 0.088s
ok github.com/redhat-developer/gitops-operator/controllers/argocd 0.022s coverage: 92.9% of statements
ok github.com/redhat-developer/gitops-operator/controllers/argocd/openshift 0.015s coverage: 69.6% of statements
? github.com/redhat-developer/gitops-operator/version [no test files]
ok github.com/redhat-developer/gitops-operator/controllers/util 0.012s coverage: 16.7% of statements
FAIL
make: *** [Makefile:113: test] Error 1
Error: Process completed with exit code 2.
```

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

