### PR TITLE
Fix Rollouts plugin location URL format

### DIFF
--- a/main.go
+++ b/main.go
@@ -280,7 +280,7 @@ func getArgoRolloutsOpenshiftRouteTrafficManagerPath() string {
 
 	argoRolloutsImage := os.Getenv("ARGO_ROLLOUTS_IMAGE")
 	if argoRolloutsImage != "" && strings.HasPrefix(argoRolloutsImage, "registry.redhat.io/openshift-gitops") {
-		openShiftRoutePluginLocation = "/plugins/rollouts-trafficrouter-openshift/openshift-route-plugin"
+		openShiftRoutePluginLocation = "file:/plugins/rollouts-trafficrouter-openshift/openshift-route-plugin"
 		return openShiftRoutePluginLocation
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:

h3. *Description of problem:*

When using pre-release builds, when you  creat ean Argo Rollouts (install by creating a RolloutManager CR) the Rollouts Pod that is created will fail to start.

If you look at the Pods logs for the Rollout controller, you will see the following error:
```
[jgw@localhost-lan rollouts-plugin-trafficrouter-openshift]$ k logs pod/argo-rollouts-7bcddf67cf-hl8ph
time="2024-06-10T12:46:22Z" level=info msg="Argo Rollouts starting" version=vstable+737ca89
time="2024-06-10T12:46:22Z" level=info msg="Creating event broadcaster"
time="2024-06-10T12:46:22Z" level=info msg="Setting up event handlers"
time="2024-06-10T12:46:22Z" level=info msg="Setting up experiments event handlers"
time="2024-06-10T12:46:22Z" level=info msg="Setting up analysis event handlers"
time="2024-06-10T12:46:22Z" level=fatal msg="Failed to download plugins: plugin location must be of http(s) or file scheme"
```

The fix is a one line change to gitops-operator. The ConfigMap that is generated SHOUD contain this:
```
  trafficRouterPlugins: |
    - name: argoproj-labs/openshift
      location: file:/plugins/rollouts-trafficrouter-openshift/openshift-route-plugin
      sha256: ""
```

