### PR TITLE
Add OpenShift Rollouts Route Plugin E2E tests to GitOps Operator tests

### DIFF
--- a/scripts/run-rollouts-e2e-tests.sh
+++ b/scripts/run-rollouts-e2e-tests.sh
@@ -4,7 +4,7 @@
 # - Runs the (cluster-scoped) E2E tests of the Argo Rollouts operator
 # - Runs the upstream E2E tests from the argo-rollouts repo
 
-set -e
+set -ex
 
 ROLLOUTS_TMP_DIR=$(mktemp -d)
 
@@ -17,6 +17,10 @@ cd "$ROLLOUTS_TMP_DIR/argo-rollouts-manager"
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in go.mod of gitops-operator (which will usually be the most recent argo-rollouts-manager commit)
 TARGET_ROLLOUT_MANAGER_COMMIT=192dd2c3b5dd026e2c59c5765e98ca2f70ca01f9
+
+# This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
+# - It should always point to the same argo-rollouts-manager commit that is referenced in the version of argo-rollouts-manager that is in go.mod
+TARGET_OPENSHIFT_ROUTE_ROLLOUT_PLUGIN_COMMIT=8b4125a7f9ecffb0247df91a4c890f88c0c523b7
 
 git checkout $TARGET_ROLLOUT_MANAGER_COMMIT
 
@@ -35,3 +39,31 @@ cd "$ROLLOUTS_TMP_DIR/argo-rollouts-manager"
 
 SKIP_RUN_STEP=true hack/run-upstream-argo-rollouts-e2e-tests.sh
 
+# 3) Run rollouts-plugin-trafficrouter-openshift E2E tests
+
+kubectl delete ns argo-rollouts || true
+
+kubectl wait --timeout=5m --for=delete namespace/argo-rollouts
+
+kubectl create ns argo-rollouts
+kubectl config set-context --current --namespace=argo-rollouts
+
+cat << EOF > "$ROLLOUTS_TMP_DIR/rollout-manager.yaml"
+apiVersion: argoproj.io/v1alpha1
+kind: RolloutManager
+metadata:
+  name: argo-rollout
+  namespace: argo-rollouts
+spec: {}
+EOF
+
+kubectl apply -f "$ROLLOUTS_TMP_DIR/rollout-manager.yaml"
+
+cd "$ROLLOUTS_TMP_DIR"
+git clone https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-openshift
+
+cd "$ROLLOUTS_TMP_DIR/rollouts-plugin-trafficrouter-openshift"
+
+git checkout $TARGET_OPENSHIFT_ROUTE_ROLLOUT_PLUGIN_COMMIT
+
+make test-e2e


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
- This adds runs the E2E tests from https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-openshift on gitops-operator

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

