### PR TITLE
Make the route API mandatory for the operator to successfully boot up

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,6 +128,15 @@ func main() {
 		setupLog.Info("unable to inspect cluster")
 	}
 
+	if err := argocd.InspectCluster(); err != nil {
+		setupLog.Info("unable to inspect cluster")
+	}
+
+	if !argocd.IsRouteAPIAvailable() {
+		setupLog.Info("route API not available")
+		os.Exit(1)
+	}
+
 	disableHTTP2 := func(c *tls.Config) {
 		if enableHTTP2 {
 			return

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+
 	"os"
 	"reflect"
 	"strings"
@@ -57,6 +58,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/argoproj-labs/argocd-operator/controllers/argocd"
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 
 	pipelinesv1alpha1 "github.com/redhat-developer/gitops-operator/api/v1alpha1"
 	"github.com/redhat-developer/gitops-operator/common"
@@ -128,11 +130,7 @@ func main() {
 		setupLog.Info("unable to inspect cluster")
 	}
 
-	if err := argocd.InspectCluster(); err != nil {
-		setupLog.Info("unable to inspect cluster")
-	}
-
-	if !argocd.IsRouteAPIAvailable() {
+	if routeAvailable, err := argoutil.VerifyAPI(routev1.GroupName, routev1.GroupVersion.Version); !routeAvailable || err != nil {
 		setupLog.Info("route API not available")
 		os.Exit(1)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug



**What does this PR do / why we need it**:
Given a ROSA cluster with OpenShift GitOps installed, When ROSA hibernates and later resumes, the route API is not available immediately. But the operator pod is restarted and this causes the operator to be initialized without the Route API handling logic. Current workaround requires the operator pod to be restarted once the route api is available to fix the issue.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
https://issues.redhat.com/browse/GITOPS-4358

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
