### PR TITLE
Fix bug where ArgoCD removes nodePlacement stanza from configuration

### DIFF
--- a/controllers/argocd_metrics_controller_test.go
+++ b/controllers/argocd_metrics_controller_test.go
@@ -29,7 +29,6 @@ import (
 	is "gotest.tools/assert/cmp"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -349,7 +348,7 @@ func TestReconciler_add_dashboard(t *testing.T) {
 
 	// Need to create one configmap to test update existing versus create
 	cm := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "gitops-overview",
 			Namespace: dashboardNamespace,
 		},

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -472,9 +472,12 @@ func (r *ReconcileGitopsService) reconcileDefaultArgoCDInstance(instance *pipeli
 			changed = true
 		}
 
-		if !reflect.DeepEqual(existingArgoCD.Spec.NodePlacement, defaultArgoCDInstance.Spec.NodePlacement) {
-			existingArgoCD.Spec.NodePlacement = defaultArgoCDInstance.Spec.NodePlacement
-			changed = true
+		// if user is patching nodePlacement through GitopsService CR, then existingArgoCD NodePlacement is updated.
+		if defaultArgoCDInstance.Spec.NodePlacement != nil {
+			if !reflect.DeepEqual(existingArgoCD.Spec.NodePlacement, defaultArgoCDInstance.Spec.NodePlacement) {
+				existingArgoCD.Spec.NodePlacement = defaultArgoCDInstance.Spec.NodePlacement
+				changed = true
+			}
 		}
 
 		if changed {

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -423,7 +423,6 @@ func (r *ReconcileGitopsService) reconcileDefaultArgoCDInstance(instance *pipeli
 		}
 	} else {
 		changed := false
-
 		if existingArgoCD.Spec.ApplicationSet != nil {
 			if existingArgoCD.Spec.ApplicationSet.Resources == nil {
 				existingArgoCD.Spec.ApplicationSet.Resources = defaultArgoCDInstance.Spec.ApplicationSet.Resources
@@ -478,6 +477,10 @@ func (r *ReconcileGitopsService) reconcileDefaultArgoCDInstance(instance *pipeli
 				existingArgoCD.Spec.NodePlacement = defaultArgoCDInstance.Spec.NodePlacement
 				changed = true
 			}
+			// Handle the case where NodePlacement should be removed
+		} else if existingArgoCD.Spec.NodePlacement != nil {
+			existingArgoCD.Spec.NodePlacement = defaultArgoCDInstance.Spec.NodePlacement
+			changed = true
 		}
 
 		if changed {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

JIRA - https://issues.redhat.com/browse/GITOPS-4185

We were not able to patch the NodePlacement directly through ArgoCD CR, if we do,  it removes the nodePlacement from ArgoCD CR while reconciling because of this https://github.com/redhat-developer/gitops-operator/blob/master/controllers/gitopsservice_controller.go#L475 here `defaultArgoCDInstance.Spec.NodePlacement` is nil as it not getting updated anywhere else in code, `defaultArgoCDInstance.Spec.NodePlacement` is only getting updated if we update it through  GitOpsService CR or else it  update `existingArgoCD.Spec.NodePlacement` as nil because of the reason I have mentioned above  , but if a user wants to add custom nodePlacement he/she should patch nodePlacement through GitOpsService CR and it is working as expected  I see no bug in code and  code is valid https://github.com/redhat-developer/gitops-operator/blob/01251d23020555e3a28d4a69e30718e9d5f0eb4d/controllers/gitopsservice_controller.go#L392

I have updated the code here - https://github.com/redhat-developer/gitops-operator/blob/01251d23020555e3a28d4a69e30718e9d5f0eb4d/controllers/gitopsservice_controller.go#L475
which is checking for nil , the logic mentioned in the PR states that , it will check for `defaultArgoCDInstance.Spec.NodePlacement` not equal to nil (it means nodePlacePlacement is updated through GitOps service CR and the values got updated [here](https://github.com/redhat-developer/gitops-operator/blob/01251d23020555e3a28d4a69e30718e9d5f0eb4d/controllers/gitopsservice_controller.go#L392) in if condition) else it will not enter the if condition to check if `defaultArgoCDInstance.Spec.NodePlacement` is nil (it means  nodePlacePlacement is updated through ArgoCD by user and it should not replace the existingArgoCD with nil value, that is the changes made by user will not get reverted back as mentioned in the bug when it reconciles)

This is what I have came up with for the bug mentioned above, please do let me know your suggestions, thank you

