### PR TITLE
Minor fixes to update-rollouts-manager script

### DIFF
--- a/hack/upgrade-rollouts-manager/README.md
+++ b/hack/upgrade-rollouts-manager/README.md
@@ -12,7 +12,6 @@ The Go code and script in this directory will automatically open a pull request 
 ### Prerequisites
 - GitHub CLI (_gh_) installed and on PATH
 - Go installed and on PATH
-- Operator-sdk installed and on PATH
 - You must have your own fork of the [argo-rollouts-manager](https://github.com/argoproj-labs/argo-rollouts-manager) repository in GitHub(e.g. `jgwest/argo-rollouts-manager`)
 - Your local SSH key registered (e.g. `~/.ssh/id_rsa.pub`) with GitHub to allow git clone via SSH
 

--- a/hack/upgrade-rollouts-manager/main.go
+++ b/hack/upgrade-rollouts-manager/main.go
@@ -47,7 +47,7 @@ func main() {
 	}
 	commitIds := strings.Split(stdout, "\n")
 	if len(commitIds) == 0 {
-		exitWithError(fmt.Errorf("unable to retrive commit ids"))
+		exitWithError(fmt.Errorf("unable to retrieve commit ids"))
 	}
 
 	mostRecentCommitID := commitIds[0]
@@ -133,7 +133,7 @@ func createNewCommitAndBranch(latestRolloutsManagerCommitId string, newBranchNam
 		{"git", "stash"},
 		{"git", "fetch", "parent"},
 		{"git", "checkout", "master"},
-		{"git", "rebase", "parent/master"},
+		{"git", "reset", "--hard", "parent/master"},
 		{"git", "checkout", "-b", newBranchName},
 	}
 
@@ -257,7 +257,7 @@ func regenerateE2ETestScript(commitID string, pathToGitRepo string) error {
 
 	for _, line := range strings.Split(string(fileBytes), "\n") {
 
-		if strings.Contains(line, envName) {
+		if strings.HasPrefix(line, envName+"=") {
 
 			res += envName + "=" + commitID + "\n"
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind enhancement

**What does this PR do / why we need it**:

Minor tweaks to improve the script which is used to upgrade the rollouts-manager dependency in gitops-operator repo


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.
