### PR TITLE
Add dashboard for Rollouts

### DIFF
--- a/controllers/dashboards/gitops-rollouts.json
+++ b/controllers/dashboards/gitops-rollouts.json
@@ -18,90 +18,6 @@
             "panels": [
                 {
                     "cacheTimeout": null,
-                    "colorBackground": false,
-                    "colorValue": false,
-                    "colors": [
-                        "#299c46",
-                        "rgba(237, 129, 40, 0.89)",
-                        "#d44a3a"
-                    ],
-                    "datasource": "$datasource",
-                    "fieldConfig": {
-                        "defaults": {
-                            "custom": {}
-                        },
-                        "overrides": []
-                    },
-                    "fill": 1,
-                    "format": "dtdurations",
-                    "gauge": {
-                        "maxValue": 100,
-                        "minValue": 0,
-                        "show": false,
-                        "thresholdLabels": false,
-                        "thresholdMarkers": true
-                    },
-                    "id": 2,
-                    "interval": null,
-                    "links": [],
-                    "mappingType": 1,
-                    "mappingTypes": [
-                        {
-                            "name": "value to text",
-                            "value": 1
-                        },
-                        {
-                            "name": "range to text",
-                            "value": 2
-                        }
-                    ],
-                    "maxDataPoints": 100,
-                    "nullPointMode": "connected",
-                    "nullText": null,
-                    "postfix": "",
-                    "postfixFontSize": "50%",
-                    "prefix": "",
-                    "prefixFontSize": "50%",
-                    "rangeMaps": [
-                        {
-                            "from": "null",
-                            "text": "N/A",
-                            "to": "null"
-                        }
-                    ],
-                    "spaceLength": 10,
-                    "span": 2,
-                    "stack": false,
-                    "sparkline": {
-                        "fillColor": "rgba(31, 118, 189, 0.18)",
-                        "full": false,
-                        "lineColor": "rgb(31, 120, 193)",
-                        "show": false
-                    },
-                    "tableColumn": "",
-                    "targets": [
-                        {
-                            "expr": "time() - max(process_start_time_seconds{job=\"argo-rollouts-metrics\"})",
-                            "format": "time_series",
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        }
-                    ],
-                    "thresholds": "",
-                    "title": "Uptime (controller)",
-                    "type": "singlestat",
-                    "valueFontSize": "80%",
-                    "valueMaps": [
-                        {
-                            "op": "=",
-                            "text": "N/A",
-                            "value": "null"
-                        }
-                    ],
-                    "valueName": "current"
-                },
-                {
-                    "cacheTimeout": null,
                     "datasource": "$datasource",
                     "fieldConfig": {
                         "defaults": {
@@ -156,11 +72,11 @@
                         "textMode": "auto"
                     },
                     "spaceLength": 10,
-                    "span": 2,
+                    "span": 3,
                     "stack": false,
                     "targets": [
                         {
-                            "expr": "sum(rollout_info{job=\"argo-rollouts-metrics\"})",
+                            "expr": "sum(rollout_info{job=\"argo-rollouts-metrics\", namespace=~\"$namespace\"})",
                             "format": "time_series",
                             "intervalFactor": 1,
                             "refId": "A"
@@ -169,6 +85,196 @@
                     "timeFrom": null,
                     "timeShift": null,
                     "title": "Total Rollouts",
+                    "type": "singlestat"
+                },
+                {
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {},
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 5,
+                        "w": 4,
+                        "x": 4,
+                        "y": 6
+                    },
+                    "id": 37,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "text": {},
+                        "textMode": "auto"
+                    },
+                    "span": 3,
+                    "stack": false,
+                    "targets": [
+                        {
+                            "expr": "sum(rollout_info_replicas_desired{job=\"argo-rollouts-metrics\",namespace=~\"$namespace\"})",
+                            "instant": true,
+                            "interval": "",
+                            "legendFormat": "",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Replicas (desired)",
+                    "type": "singlestat"
+                },
+                {
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {},
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 5,
+                        "w": 4,
+                        "x": 8,
+                        "y": 6
+                    },
+                    "id": 35,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "text": {},
+                        "textMode": "auto"
+                    },
+                    "span": 3,
+                    "stack": false,
+                    "targets": [
+                        {
+                            "expr": "sum(rollout_info_replicas_available{job=\"argo-rollouts-metrics\",namespace=~\"$namespace\"})",
+                            "hide": false,
+                            "instant": true,
+                            "interval": "",
+                            "legendFormat": "",
+                            "refId": "A"
+                        }
+                    ],
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "Replica (available)",
+                    "type": "singlestat"
+                },
+                {
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {},
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 5,
+                        "w": 4,
+                        "x": 12,
+                        "y": 6
+                    },
+                    "id": 38,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "text": {},
+                        "textMode": "auto"
+                    },
+                    "span": 3,
+                    "stack": false,
+                    "targets": [
+                        {
+                            "expr": "sum(rollout_info_replicas_unavailable{job=\"argo-rollouts-metrics\",namespace=~\"$namespace\"})",
+                            "hide": false,
+                            "instant": true,
+                            "interval": "",
+                            "legendFormat": "",
+                            "refId": "A"
+                        }
+                    ],
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "Replica (unavailable)",
                     "type": "singlestat"
                 },
                 {
@@ -212,13 +318,14 @@
                     "renderer": "flot",
                     "seriesOverrides": [],
                     "spaceLength": 10,
-                    "span": 2,
+                    "span": 12,
                     "stack": false,
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(rollout_info{job=\"argo-rollouts-metrics\"}) by (strategy)",
+                            "expr": "sum(rollout_info{job=\"argo-rollouts-metrics\", namespace=~\"$namespace\"}) by (phase)",
                             "format": "time_series",
+                            "legendFormat": "{{phase}}",
                             "intervalFactor": 1,
                             "refId": "A"
                         }
@@ -227,7 +334,101 @@
                     "timeFrom": null,
                     "timeRegions": [],
                     "timeShift": null,
-                    "title": "Rollouts",
+                    "title": "Phase",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "cacheTimeout": null,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {}
+                        },
+                        "overrides": []
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "hiddenSeries": false,
+                    "id": 25,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "paceLength": 10,
+                    "percentage": false,
+                    "pluginVersion": "7.4.3",
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "span": 12,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "sum(rollout_info{job=\"argo-rollouts-metrics\", namespace=~\"$namespace\"}) by (strategy)",
+                            "format": "time_series",
+                            "legendFormat": "{{strategy}}",
+                            "intervalFactor": 1,
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "Strategy",
                     "tooltip": {
                         "shared": true,
                         "sort": 0,
@@ -273,565 +474,6 @@
             "title": "Controller Stats",
             "showTitle": true,
             "panels": [
-                {
-                    "cacheTimeout": null,
-                    "datasource": "$datasource",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "custom": {},
-                            "mappings": [
-                                {
-                                    "id": 0,
-                                    "op": "=",
-                                    "text": "",
-                                    "type": 1,
-                                    "value": ""
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "#d44a3a",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "rgba(237, 129, 40, 0.89)",
-                                        "value": 0
-                                    },
-                                    {
-                                        "color": "#629e51",
-                                        "value": 1
-                                    }
-                                ]
-                            },
-                            "unit": "none"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 3,
-                        "w": 4,
-                        "x": 0,
-                        "y": 5
-                    },
-                    "id": 18,
-                    "interval": null,
-                    "links": [],
-                    "maxDataPoints": 100,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "none",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "text": {},
-                        "textMode": "auto"
-                    },
-                    "span": 2,
-                    "stack": true,
-                    "targets": [
-                        {
-                            "expr": "sum(rollout_info{phase=\"Completed\",job=\"argo-rollouts-metrics\"} == 1)",
-                            "format": "time_series",
-                            "hide": false,
-                            "instant": true,
-                            "interval": "",
-                            "intervalFactor": 1,
-                            "legendFormat": "",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Stable",
-                    "type": "singlestat"
-                },
-                {
-                    "cacheTimeout": null,
-                    "datasource": "$datasource",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "custom": {},
-                            "mappings": [
-                                {
-                                    "id": 0,
-                                    "op": "=",
-                                    "text": "0",
-                                    "type": 1,
-                                    "value": "null"
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "#5794F2",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "#5794F2",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "#5794F2",
-                                        "value": 3
-                                    }
-                                ]
-                            },
-                            "unit": "none"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 3,
-                        "w": 4,
-                        "x": 4,
-                        "y": 5
-                    },
-                    "id": 21,
-                    "interval": null,
-                    "links": [],
-                    "maxDataPoints": 100,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "horizontal",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "text": {},
-                        "textMode": "auto"
-                    },
-                    "span": 2,
-                    "stack": true,
-                    "targets": [
-                        {
-                            "expr": "sum(rollout_info{phase=\"Progressing\",job=\"argo-rollouts-metrics\"})",
-                            "format": "time_series",
-                            "hide": false,
-                            "instant": true,
-                            "interval": "",
-                            "intervalFactor": 1,
-                            "legendFormat": "",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Progressing",
-                    "type": "singlestat"
-                },
-                {
-                    "cacheTimeout": null,
-                    "datasource": "$datasource",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "custom": {},
-                            "mappings": [
-                                {
-                                    "id": 0,
-                                    "op": "=",
-                                    "text": "0",
-                                    "type": 1,
-                                    "value": "null"
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "#5794F2",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "#5794F2",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "#5794F2",
-                                        "value": 3
-                                    }
-                                ]
-                            },
-                            "unit": "none"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 3,
-                        "w": 4,
-                        "x": 8,
-                        "y": 5
-                    },
-                    "id": 43,
-                    "interval": null,
-                    "links": [],
-                    "maxDataPoints": 100,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "none",
-                        "justifyMode": "auto",
-                        "orientation": "horizontal",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "text": {},
-                        "textMode": "auto"
-                    },
-                    "span": 2,
-                    "stack": true,
-                    "targets": [
-                        {
-                            "expr": "sum(rollout_info{phase=\"Paused\",job=\"argo-rollouts-metrics\"})",
-                            "format": "time_series",
-                            "hide": false,
-                            "instant": true,
-                            "interval": "",
-                            "intervalFactor": 1,
-                            "legendFormat": "",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Paused",
-                    "type": "singlestat"
-                },
-                {
-                    "cacheTimeout": null,
-                    "datasource": "$datasource",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "custom": {},
-                            "mappings": [
-                                {
-                                    "id": 0,
-                                    "op": "=",
-                                    "text": "0",
-                                    "type": 1,
-                                    "value": "null"
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "#F2495C",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "#F2495C",
-                                        "value": 0
-                                    },
-                                    {
-                                        "color": "#F2495C",
-                                        "value": 1
-                                    }
-                                ]
-                            },
-                            "unit": "none"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 3,
-                        "w": 4,
-                        "x": 12,
-                        "y": 5
-                    },
-                    "id": 30,
-                    "interval": null,
-                    "links": [],
-                    "maxDataPoints": 100,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "horizontal",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "text": {},
-                        "textMode": "auto"
-                    },
-                    "span": 2,
-                    "stack": true,
-                    "targets": [
-                        {
-                            "expr": "sum(rollout_info{job=\"argo-rollouts-metrics\",phase=\"Error\"} == 1)",
-                            "format": "time_series",
-                            "hide": false,
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Error",
-                    "type": "singlestat"
-                },
-                {
-                    "cacheTimeout": null,
-                    "datasource": "$datasource",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "custom": {},
-                            "mappings": [
-                                {
-                                    "id": 0,
-                                    "op": "=",
-                                    "text": "0",
-                                    "type": 1,
-                                    "value": "null"
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "#F2495C",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "#F2495C",
-                                        "value": 0
-                                    },
-                                    {
-                                        "color": "#F2495C",
-                                        "value": 1
-                                    }
-                                ]
-                            },
-                            "unit": "none"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 3,
-                        "w": 4,
-                        "x": 16,
-                        "y": 5
-                    },
-                    "id": 24,
-                    "interval": null,
-                    "links": [],
-                    "maxDataPoints": 100,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "none",
-                        "justifyMode": "auto",
-                        "orientation": "horizontal",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "text": {},
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "7.4.3",
-                    "targets": [
-                        {
-                            "expr": "sum(rollout_info{job=\"argo-rollouts-metrics\",phase=\"InvalidSpec\"} == 1)",
-                            "format": "time_series",
-                            "hide": false,
-                            "instant": true,
-                            "interval": "",
-                            "intervalFactor": 1,
-                            "legendFormat": "",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Invalid Spec",
-                    "type": "singlestat"
-                },
-                {
-                    "cacheTimeout": null,
-                    "datasource": "$datasource",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "custom": {},
-                            "mappings": [
-                                {
-                                    "id": 0,
-                                    "op": "=",
-                                    "text": "0",
-                                    "type": 1,
-                                    "value": "null"
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "#F2495C",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "#F2495C",
-                                        "value": 0
-                                    },
-                                    {
-                                        "color": "#F2495C",
-                                        "value": 1
-                                    }
-                                ]
-                            },
-                            "unit": "none"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 3,
-                        "w": 4,
-                        "x": 20,
-                        "y": 5
-                    },
-                    "id": 28,
-                    "interval": null,
-                    "links": [],
-                    "maxDataPoints": 100,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "none",
-                        "justifyMode": "auto",
-                        "orientation": "horizontal",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "text": {},
-                        "textMode": "auto"
-                    },
-                    "span": 2,
-                    "stack": true,
-                    "targets": [
-                        {
-                            "expr": "sum(rollout_info{job=\"argo-rollouts-metrics\",phase=\"Timeout\"} == 1)",
-                            "format": "time_series",
-                            "hide": false,
-                            "intervalFactor": 1,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Timeout",
-                    "type": "singlestat"
-                },
-                {
-                    "cacheTimeout": null,
-                    "datasource": "$datasource",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "custom": {},
-                            "mappings": [
-                                {
-                                    "id": 0,
-                                    "op": "=",
-                                    "text": "0",
-                                    "type": 1,
-                                    "value": "null"
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "#FF9830",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "green",
-                                        "value": 0
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 1
-                                    }
-                                ]
-                            },
-                            "unit": "none"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 3,
-                        "w": 4,
-                        "x": 0,
-                        "y": 8
-                    },
-                    "id": 23,
-                    "interval": null,
-                    "links": [],
-                    "maxDataPoints": 100,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "none",
-                        "justifyMode": "auto",
-                        "orientation": "horizontal",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "text": {},
-                        "textMode": "auto"
-                    },
-                    "span": 2,
-                    "stack": true,
-                    "targets": [
-                        {
-                            "expr": "sum(rollout_info{job=\"argo-rollouts-metrics\",phase=\"Abort\"} == 1)",
-                            "format": "time_series",
-                            "hide": false,
-                            "interval": "",
-                            "intervalFactor": 1,
-                            "legendFormat": "",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Aborted",
-                    "type": "singlestat"
-                },
                 {
                     "aliasColors": {},
                     "bars": false,
@@ -882,7 +524,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(increase(rollout_reconcile_count{job=\"argo-rollouts-metrics\"}[10m]))",
+                            "expr": "sum(increase(rollout_reconcile_count{job=\"argo-rollouts-metrics\", namespace=~\"$namespace\"}[10m]))",
                             "format": "time_series",
                             "intervalFactor": 1,
                             "refId": "A"
@@ -967,7 +609,7 @@
                     "reverseYBuckets": false,
                     "targets": [
                         {
-                            "expr": "sum(increase(rollout_reconcile_bucket[10m])) by (le)",
+                            "expr": "sum(increase(rollout_reconcile_bucket{namespace=~\"$namespace\"}[10m])) by (le)",
                             "format": "heatmap",
                             "intervalFactor": 1,
                             "legendFormat": "{{le}}",
@@ -981,7 +623,7 @@
                         "show": true,
                         "showHistogram": false
                     },
-                    "type": "heatmap",
+                    "type": "graph",
                     "xAxis": {
                         "show": true
                     },
@@ -1050,7 +692,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "go_memstats_heap_alloc_bytes{job=\"argo-rollouts-metrics\"}",
+                            "expr": "go_memstats_heap_alloc_bytes{job=\"argo-rollouts-metrics\", namespace=~\"$namespace\"}",
                             "format": "time_series",
                             "intervalFactor": 1,
                             "refId": "A"
@@ -1098,265 +740,6 @@
                     }
                 }
             ]
-        },
-        {
-            "collapse": false,
-            "editable": false,
-            "height": "250px",
-            "title": "Rollout Status",
-            "showTitle": true,
-            "panels": [
-                {
-                    "datasource": "$datasource",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "custom": {
-                                "align": "center",
-                                "filterable": false
-                            },
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 80
-                                    }
-                                ]
-                            }
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 5,
-                        "w": 4,
-                        "x": 0,
-                        "y": 6
-                    },
-                    "id": 42,
-                    "options": {
-                        "showHeader": false
-                    },
-                    "pluginVersion": "7.4.3",
-                    "targets": [
-                        {
-                            "expr": "rollout_info{job=\"argo-rollouts-metrics\",namespace=\"$namespace\",name=\"$rollout\"}",
-                            "format": "table",
-                            "instant": true,
-                            "interval": "",
-                            "legendFormat": "",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Phase",
-                    "transformations": [
-                        {
-                            "id": "filterFieldsByName",
-                            "options": {
-                                "include": {
-                                    "names": [
-                                        "phase"
-                                    ]
-                                }
-                            }
-                        }
-                    ],
-                    "type": "table"
-                },
-                {
-                    "datasource": "$datasource",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "custom": {},
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 80
-                                    }
-                                ]
-                            }
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 5,
-                        "w": 4,
-                        "x": 4,
-                        "y": 6
-                    },
-                    "id": 37,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "text": {},
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "7.4.3",
-                    "targets": [
-                        {
-                            "expr": "rollout_info_replicas_desired{job=\"argo-rollouts-metrics\",namespace=\"$namespace\",name=\"$rollout\"}",
-                            "instant": true,
-                            "interval": "",
-                            "legendFormat": "",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Replicas (desired)",
-                    "type": "singlestat"
-                },
-                {
-                    "datasource": "$datasource",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "custom": {},
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 80
-                                    }
-                                ]
-                            }
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 5,
-                        "w": 4,
-                        "x": 8,
-                        "y": 6
-                    },
-                    "id": 35,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "text": {},
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "7.4.3",
-                    "targets": [
-                        {
-                            "expr": "rollout_info_replicas_available{job=\"argo-rollouts-metrics\",namespace=\"$namespace\",name=\"$name\"}",
-                            "hide": false,
-                            "instant": true,
-                            "interval": "",
-                            "legendFormat": "",
-                            "refId": "A"
-                        }
-                    ],
-                    "timeFrom": null,
-                    "timeShift": null,
-                    "title": "Replica (available)",
-                    "type": "singlestat"
-                },
-                {
-                    "datasource": "$datasource",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "custom": {},
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 80
-                                    }
-                                ]
-                            }
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 5,
-                        "w": 4,
-                        "x": 12,
-                        "y": 6
-                    },
-                    "id": 38,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "text": {},
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "7.4.3",
-                    "targets": [
-                        {
-                            "expr": "rollout_info_replicas_unavailable{job=\"argo-rollouts-metrics\",namespace=\"$namespace\",name=\"$rollout\"}",
-                            "hide": false,
-                            "instant": true,
-                            "interval": "",
-                            "legendFormat": "",
-                            "refId": "A"
-                        }
-                    ],
-                    "timeFrom": null,
-                    "timeShift": null,
-                    "title": "Replica (unavailable)",
-                    "type": "singlestat"
-                }
-            ]
         }
     ],
     "schemaVersion": 27,
@@ -1401,33 +784,6 @@
                 "options": [],
                 "query": "label_values(rollout_info, namespace)",
                 "refresh": 0,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-            },
-            {
-                "allValue": ".+",
-                "current": {
-                    "selected": true,
-                    "text": "All",
-                    "value": "$__all"
-                },
-                "datasource": "$datasource",
-                "description": "rollout name",
-                "error": null,
-                "hide": 0,
-                "includeAll": false,
-                "label": "rollout",
-                "multi": false,
-                "name": "rollout",
-                "options": [],
-                "query": "label_values(rollout_info{namespace=~\"$namespace\"}, name)",
-                "refresh": 2,
                 "regex": "",
                 "skipUrlSync": false,
                 "sort": 1,

--- a/controllers/dashboards/gitops-rollouts.json
+++ b/controllers/dashboards/gitops-rollouts.json
@@ -1,0 +1,1451 @@
+{
+    "annotations": {
+        "list": []
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 8,
+    "iteration": 1626193355138,
+    "links": [],
+    "rows": [
+        {
+            "collapse": false,
+            "editable": true,
+            "height": "250px",
+            "title": "Rollouts",
+            "showTitle": true,
+            "panels": [
+                {
+                    "cacheTimeout": null,
+                    "colorBackground": false,
+                    "colorValue": false,
+                    "colors": [
+                        "#299c46",
+                        "rgba(237, 129, 40, 0.89)",
+                        "#d44a3a"
+                    ],
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {}
+                        },
+                        "overrides": []
+                    },
+                    "fill": 1,
+                    "format": "dtdurations",
+                    "gauge": {
+                        "maxValue": 100,
+                        "minValue": 0,
+                        "show": false,
+                        "thresholdLabels": false,
+                        "thresholdMarkers": true
+                    },
+                    "id": 2,
+                    "interval": null,
+                    "links": [],
+                    "mappingType": 1,
+                    "mappingTypes": [
+                        {
+                            "name": "value to text",
+                            "value": 1
+                        },
+                        {
+                            "name": "range to text",
+                            "value": 2
+                        }
+                    ],
+                    "maxDataPoints": 100,
+                    "nullPointMode": "connected",
+                    "nullText": null,
+                    "postfix": "",
+                    "postfixFontSize": "50%",
+                    "prefix": "",
+                    "prefixFontSize": "50%",
+                    "rangeMaps": [
+                        {
+                            "from": "null",
+                            "text": "N/A",
+                            "to": "null"
+                        }
+                    ],
+                    "spaceLength": 10,
+                    "span": 2,
+                    "stack": false,
+                    "sparkline": {
+                        "fillColor": "rgba(31, 118, 189, 0.18)",
+                        "full": false,
+                        "lineColor": "rgb(31, 120, 193)",
+                        "show": false
+                    },
+                    "tableColumn": "",
+                    "targets": [
+                        {
+                            "expr": "time() - max(process_start_time_seconds{job=\"argo-rollouts-metrics\"})",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": "",
+                    "title": "Uptime (controller)",
+                    "type": "singlestat",
+                    "valueFontSize": "80%",
+                    "valueMaps": [
+                        {
+                            "op": "=",
+                            "text": "N/A",
+                            "value": "null"
+                        }
+                    ],
+                    "valueName": "current"
+                },
+                {
+                    "cacheTimeout": null,
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {},
+                            "mappings": [
+                                {
+                                    "id": 0,
+                                    "op": "=",
+                                    "text": "N/A",
+                                    "type": 1,
+                                    "value": "null"
+                                }
+                            ],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "none"
+                        },
+                        "overrides": []
+                    },
+                    "fill": 1,
+                    "id": 14,
+                    "interval": null,
+                    "links": [],
+                    "maxDataPoints": 100,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "none",
+                        "justifyMode": "auto",
+                        "orientation": "horizontal",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "text": {},
+                        "textMode": "auto"
+                    },
+                    "spaceLength": 10,
+                    "span": 2,
+                    "stack": false,
+                    "targets": [
+                        {
+                            "expr": "sum(rollout_info{job=\"argo-rollouts-metrics\"})",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "refId": "A"
+                        }
+                    ],
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "Total Rollouts",
+                    "type": "singlestat"
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "cacheTimeout": null,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {}
+                        },
+                        "overrides": []
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "hiddenSeries": false,
+                    "id": 25,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "paceLength": 10,
+                    "percentage": false,
+                    "pluginVersion": "7.4.3",
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "span": 2,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "sum(rollout_info{job=\"argo-rollouts-metrics\"}) by (strategy)",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "Rollouts",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                }
+            ]
+        },
+        {
+            "collapse": false,
+            "editable": false,
+            "height": "250px",
+            "title": "Controller Stats",
+            "showTitle": true,
+            "panels": [
+                {
+                    "cacheTimeout": null,
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {},
+                            "mappings": [
+                                {
+                                    "id": 0,
+                                    "op": "=",
+                                    "text": "",
+                                    "type": 1,
+                                    "value": ""
+                                }
+                            ],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "#d44a3a",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "rgba(237, 129, 40, 0.89)",
+                                        "value": 0
+                                    },
+                                    {
+                                        "color": "#629e51",
+                                        "value": 1
+                                    }
+                                ]
+                            },
+                            "unit": "none"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 3,
+                        "w": 4,
+                        "x": 0,
+                        "y": 5
+                    },
+                    "id": 18,
+                    "interval": null,
+                    "links": [],
+                    "maxDataPoints": 100,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "none",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "text": {},
+                        "textMode": "auto"
+                    },
+                    "span": 2,
+                    "stack": true,
+                    "targets": [
+                        {
+                            "expr": "sum(rollout_info{phase=\"Completed\",job=\"argo-rollouts-metrics\"} == 1)",
+                            "format": "time_series",
+                            "hide": false,
+                            "instant": true,
+                            "interval": "",
+                            "intervalFactor": 1,
+                            "legendFormat": "",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Stable",
+                    "type": "singlestat"
+                },
+                {
+                    "cacheTimeout": null,
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {},
+                            "mappings": [
+                                {
+                                    "id": 0,
+                                    "op": "=",
+                                    "text": "0",
+                                    "type": 1,
+                                    "value": "null"
+                                }
+                            ],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "#5794F2",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "#5794F2",
+                                        "value": 1
+                                    },
+                                    {
+                                        "color": "#5794F2",
+                                        "value": 3
+                                    }
+                                ]
+                            },
+                            "unit": "none"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 3,
+                        "w": 4,
+                        "x": 4,
+                        "y": 5
+                    },
+                    "id": 21,
+                    "interval": null,
+                    "links": [],
+                    "maxDataPoints": 100,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "horizontal",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "text": {},
+                        "textMode": "auto"
+                    },
+                    "span": 2,
+                    "stack": true,
+                    "targets": [
+                        {
+                            "expr": "sum(rollout_info{phase=\"Progressing\",job=\"argo-rollouts-metrics\"})",
+                            "format": "time_series",
+                            "hide": false,
+                            "instant": true,
+                            "interval": "",
+                            "intervalFactor": 1,
+                            "legendFormat": "",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Progressing",
+                    "type": "singlestat"
+                },
+                {
+                    "cacheTimeout": null,
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {},
+                            "mappings": [
+                                {
+                                    "id": 0,
+                                    "op": "=",
+                                    "text": "0",
+                                    "type": 1,
+                                    "value": "null"
+                                }
+                            ],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "#5794F2",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "#5794F2",
+                                        "value": 1
+                                    },
+                                    {
+                                        "color": "#5794F2",
+                                        "value": 3
+                                    }
+                                ]
+                            },
+                            "unit": "none"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 3,
+                        "w": 4,
+                        "x": 8,
+                        "y": 5
+                    },
+                    "id": 43,
+                    "interval": null,
+                    "links": [],
+                    "maxDataPoints": 100,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "none",
+                        "justifyMode": "auto",
+                        "orientation": "horizontal",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "text": {},
+                        "textMode": "auto"
+                    },
+                    "span": 2,
+                    "stack": true,
+                    "targets": [
+                        {
+                            "expr": "sum(rollout_info{phase=\"Paused\",job=\"argo-rollouts-metrics\"})",
+                            "format": "time_series",
+                            "hide": false,
+                            "instant": true,
+                            "interval": "",
+                            "intervalFactor": 1,
+                            "legendFormat": "",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Paused",
+                    "type": "singlestat"
+                },
+                {
+                    "cacheTimeout": null,
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {},
+                            "mappings": [
+                                {
+                                    "id": 0,
+                                    "op": "=",
+                                    "text": "0",
+                                    "type": 1,
+                                    "value": "null"
+                                }
+                            ],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "#F2495C",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "#F2495C",
+                                        "value": 0
+                                    },
+                                    {
+                                        "color": "#F2495C",
+                                        "value": 1
+                                    }
+                                ]
+                            },
+                            "unit": "none"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 3,
+                        "w": 4,
+                        "x": 12,
+                        "y": 5
+                    },
+                    "id": 30,
+                    "interval": null,
+                    "links": [],
+                    "maxDataPoints": 100,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "horizontal",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "text": {},
+                        "textMode": "auto"
+                    },
+                    "span": 2,
+                    "stack": true,
+                    "targets": [
+                        {
+                            "expr": "sum(rollout_info{job=\"argo-rollouts-metrics\",phase=\"Error\"} == 1)",
+                            "format": "time_series",
+                            "hide": false,
+                            "intervalFactor": 1,
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Error",
+                    "type": "singlestat"
+                },
+                {
+                    "cacheTimeout": null,
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {},
+                            "mappings": [
+                                {
+                                    "id": 0,
+                                    "op": "=",
+                                    "text": "0",
+                                    "type": 1,
+                                    "value": "null"
+                                }
+                            ],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "#F2495C",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "#F2495C",
+                                        "value": 0
+                                    },
+                                    {
+                                        "color": "#F2495C",
+                                        "value": 1
+                                    }
+                                ]
+                            },
+                            "unit": "none"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 3,
+                        "w": 4,
+                        "x": 16,
+                        "y": 5
+                    },
+                    "id": 24,
+                    "interval": null,
+                    "links": [],
+                    "maxDataPoints": 100,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "none",
+                        "justifyMode": "auto",
+                        "orientation": "horizontal",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "text": {},
+                        "textMode": "auto"
+                    },
+                    "pluginVersion": "7.4.3",
+                    "targets": [
+                        {
+                            "expr": "sum(rollout_info{job=\"argo-rollouts-metrics\",phase=\"InvalidSpec\"} == 1)",
+                            "format": "time_series",
+                            "hide": false,
+                            "instant": true,
+                            "interval": "",
+                            "intervalFactor": 1,
+                            "legendFormat": "",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Invalid Spec",
+                    "type": "singlestat"
+                },
+                {
+                    "cacheTimeout": null,
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {},
+                            "mappings": [
+                                {
+                                    "id": 0,
+                                    "op": "=",
+                                    "text": "0",
+                                    "type": 1,
+                                    "value": "null"
+                                }
+                            ],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "#F2495C",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "#F2495C",
+                                        "value": 0
+                                    },
+                                    {
+                                        "color": "#F2495C",
+                                        "value": 1
+                                    }
+                                ]
+                            },
+                            "unit": "none"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 3,
+                        "w": 4,
+                        "x": 20,
+                        "y": 5
+                    },
+                    "id": 28,
+                    "interval": null,
+                    "links": [],
+                    "maxDataPoints": 100,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "none",
+                        "justifyMode": "auto",
+                        "orientation": "horizontal",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "text": {},
+                        "textMode": "auto"
+                    },
+                    "span": 2,
+                    "stack": true,
+                    "targets": [
+                        {
+                            "expr": "sum(rollout_info{job=\"argo-rollouts-metrics\",phase=\"Timeout\"} == 1)",
+                            "format": "time_series",
+                            "hide": false,
+                            "intervalFactor": 1,
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Timeout",
+                    "type": "singlestat"
+                },
+                {
+                    "cacheTimeout": null,
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {},
+                            "mappings": [
+                                {
+                                    "id": 0,
+                                    "op": "=",
+                                    "text": "0",
+                                    "type": 1,
+                                    "value": "null"
+                                }
+                            ],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "#FF9830",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "green",
+                                        "value": 0
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 1
+                                    }
+                                ]
+                            },
+                            "unit": "none"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 3,
+                        "w": 4,
+                        "x": 0,
+                        "y": 8
+                    },
+                    "id": 23,
+                    "interval": null,
+                    "links": [],
+                    "maxDataPoints": 100,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "none",
+                        "justifyMode": "auto",
+                        "orientation": "horizontal",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "text": {},
+                        "textMode": "auto"
+                    },
+                    "span": 2,
+                    "stack": true,
+                    "targets": [
+                        {
+                            "expr": "sum(rollout_info{job=\"argo-rollouts-metrics\",phase=\"Abort\"} == 1)",
+                            "format": "time_series",
+                            "hide": false,
+                            "interval": "",
+                            "intervalFactor": 1,
+                            "legendFormat": "",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Aborted",
+                    "type": "singlestat"
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {}
+                        },
+                        "overrides": []
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 8,
+                        "w": 24,
+                        "x": 0,
+                        "y": 11
+                    },
+                    "hiddenSeries": false,
+                    "id": 6,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "paceLength": 10,
+                    "percentage": false,
+                    "pluginVersion": "7.4.3",
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "sum(increase(rollout_reconcile_count{job=\"argo-rollouts-metrics\"}[10m]))",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "Reconcile Activity",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                },
+                {
+                    "cards": {
+                        "cardPadding": null,
+                        "cardRound": null
+                    },
+                    "color": {
+                        "cardColor": "#b4ff00",
+                        "colorScale": "sqrt",
+                        "colorScheme": "interpolateSpectral",
+                        "exponent": 0.5,
+                        "min": null,
+                        "mode": "spectrum"
+                    },
+                    "dataFormat": "tsbuckets",
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {}
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 24,
+                        "x": 0,
+                        "y": 19
+                    },
+                    "heatmap": {},
+                    "hideZeroBuckets": false,
+                    "highlightCards": true,
+                    "id": 8,
+                    "legend": {
+                        "show": false
+                    },
+                    "links": [],
+                    "reverseYBuckets": false,
+                    "targets": [
+                        {
+                            "expr": "sum(increase(rollout_reconcile_bucket[10m])) by (le)",
+                            "format": "heatmap",
+                            "intervalFactor": 1,
+                            "legendFormat": "{{le}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "Reconciliation Performance",
+                    "tooltip": {
+                        "show": true,
+                        "showHistogram": false
+                    },
+                    "type": "heatmap",
+                    "xAxis": {
+                        "show": true
+                    },
+                    "xBucketNumber": null,
+                    "xBucketSize": null,
+                    "yAxis": {
+                        "decimals": null,
+                        "format": "short",
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true,
+                        "splitFactor": null
+                    },
+                    "yBucketBound": "auto",
+                    "yBucketNumber": null,
+                    "yBucketSize": null
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {}
+                        },
+                        "overrides": []
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 6,
+                        "w": 24,
+                        "x": 0,
+                        "y": 27
+                    },
+                    "hiddenSeries": false,
+                    "id": 12,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "paceLength": 10,
+                    "percentage": false,
+                    "pluginVersion": "7.4.3",
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "go_memstats_heap_alloc_bytes{job=\"argo-rollouts-metrics\"}",
+                            "format": "time_series",
+                            "intervalFactor": 1,
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeFrom": null,
+                    "timeRegions": [],
+                    "timeShift": null,
+                    "title": "Memory Used",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false,
+                        "alignLevel": null
+                    }
+                }
+            ]
+        },
+        {
+            "collapse": false,
+            "editable": false,
+            "height": "250px",
+            "title": "Rollout Status",
+            "showTitle": true,
+            "panels": [
+                {
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {
+                                "align": "center",
+                                "filterable": false
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 5,
+                        "w": 4,
+                        "x": 0,
+                        "y": 6
+                    },
+                    "id": 42,
+                    "options": {
+                        "showHeader": false
+                    },
+                    "pluginVersion": "7.4.3",
+                    "targets": [
+                        {
+                            "expr": "rollout_info{job=\"argo-rollouts-metrics\",namespace=\"$namespace\",name=\"$rollout\"}",
+                            "format": "table",
+                            "instant": true,
+                            "interval": "",
+                            "legendFormat": "",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Phase",
+                    "transformations": [
+                        {
+                            "id": "filterFieldsByName",
+                            "options": {
+                                "include": {
+                                    "names": [
+                                        "phase"
+                                    ]
+                                }
+                            }
+                        }
+                    ],
+                    "type": "table"
+                },
+                {
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {},
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 5,
+                        "w": 4,
+                        "x": 4,
+                        "y": 6
+                    },
+                    "id": 37,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "text": {},
+                        "textMode": "auto"
+                    },
+                    "pluginVersion": "7.4.3",
+                    "targets": [
+                        {
+                            "expr": "rollout_info_replicas_desired{job=\"argo-rollouts-metrics\",namespace=\"$namespace\",name=\"$rollout\"}",
+                            "instant": true,
+                            "interval": "",
+                            "legendFormat": "",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Replicas (desired)",
+                    "type": "singlestat"
+                },
+                {
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {},
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 5,
+                        "w": 4,
+                        "x": 8,
+                        "y": 6
+                    },
+                    "id": 35,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "text": {},
+                        "textMode": "auto"
+                    },
+                    "pluginVersion": "7.4.3",
+                    "targets": [
+                        {
+                            "expr": "rollout_info_replicas_available{job=\"argo-rollouts-metrics\",namespace=\"$namespace\",name=\"$name\"}",
+                            "hide": false,
+                            "instant": true,
+                            "interval": "",
+                            "legendFormat": "",
+                            "refId": "A"
+                        }
+                    ],
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "Replica (available)",
+                    "type": "singlestat"
+                },
+                {
+                    "datasource": "$datasource",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {},
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 5,
+                        "w": 4,
+                        "x": 12,
+                        "y": 6
+                    },
+                    "id": 38,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "text": {},
+                        "textMode": "auto"
+                    },
+                    "pluginVersion": "7.4.3",
+                    "targets": [
+                        {
+                            "expr": "rollout_info_replicas_unavailable{job=\"argo-rollouts-metrics\",namespace=\"$namespace\",name=\"$rollout\"}",
+                            "hide": false,
+                            "instant": true,
+                            "interval": "",
+                            "legendFormat": "",
+                            "refId": "A"
+                        }
+                    ],
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "Replica (unavailable)",
+                    "type": "singlestat"
+                }
+            ]
+        }
+    ],
+    "schemaVersion": 27,
+    "tags": [
+        "GitOps"
+    ],
+    "style": "dark",
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "text": "default",
+                    "value": "default"
+                },
+                "hide": 0,
+                "label": "Data source",
+                "name": "datasource",
+                "options": [
+
+                ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+            },
+            {
+                "allValue": ".+",
+                "current": {
+                    "selected": true,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": "$datasource",
+                "definition": "label_values(rollout_info, namespace)",
+                "description": "namespace",
+                "error": null,
+                "hide": 0,
+                "includeAll": true,
+                "label": "namespace",
+                "multi": false,
+                "name": "namespace",
+                "options": [],
+                "query": "label_values(rollout_info, namespace)",
+                "refresh": 0,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": ".+",
+                "current": {
+                    "selected": true,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": "$datasource",
+                "description": "rollout name",
+                "error": null,
+                "hide": 0,
+                "includeAll": false,
+                "label": "rollout",
+                "multi": false,
+                "name": "rollout",
+                "options": [],
+                "query": "label_values(rollout_info{namespace=~\"$namespace\"}, name)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            }
+        ]
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "GitOps Rollouts",
+    "uid": "1aRz2fghq",
+    "version": 1
+}

--- a/controllers/dashboards/gitops-rollouts.json
+++ b/controllers/dashboards/gitops-rollouts.json
@@ -801,7 +801,7 @@
     },
     "timepicker": {},
     "timezone": "",
-    "title": "GitOps Rollouts",
+    "title": "GitOps / Rollouts",
     "uid": "1aRz2fghq",
     "version": 1
 }

--- a/docs/OpenShift GitOps Usage Guide.md
+++ b/docs/OpenShift GitOps Usage Guide.md
@@ -999,7 +999,7 @@ Refer [Working with Dex](#working-with-dex) section for more details.
 
 ## GitOps Monitoring Dashboards 
 
-As of GitOps Operator v1.10.0, the operator will deploy monitoring dashboards in the console Admin perspective. When navigating to *Observe* → *Monitoring* in the console, users should see three GitOps dashboards in the dropdown dashboard list: GitOps Overview, GitOps Components, and GitOps gRPC. These dashboards are based on the upstream Argo CD dashboards but have been modified to work with OpenShift console. 
+As of GitOps Operator will deploy monitoring dashboards in the console Admin perspective. When navigating to *Observe* → *Monitoring* in the console, users should see four GitOps dashboards in the dropdown dashboard list: GitOps Overview, GitOps Components, GitOps gRPC and Rollouts. These dashboards are based on the upstream Argo CD dashboards but have been modified to work with OpenShift console. 
 
 ![Dashboard Select Dropdown](assets/39.gitops_monitoring_dashboards_dropdown.png)
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
/kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

This PR adds a new dashboard to the OpenShift Console for Rollouts. It leverages the metrics provided by the operator deployed servicemonitor for Rollouts. This dashboard is based on the upstream Argo Rollouts dashboard but tuned and tweaked for the Console.

**Have you updated the necessary documentation?**

* [ *] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

No issue has been opened for this but can open one if needed.

**Test acceptance criteria**:

* [*] Unit Test
* [ ] E2E Test

This is covered by the existing dashboards unit tests.

**How to test changes / Special notes to the reviewer**:

Run the operator and validate that a Rollouts Dashboard appears in the OpenShift console. Assuming Rollouts are deployed on the various graphs will populate with metrics.
