### PR TITLE
Enable e2e tests

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -20,11 +20,13 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"testing"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
-	argoapi "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	argov1alpha1api "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	argocdprovisioner "github.com/argoproj-labs/argocd-operator/controllers/argocd"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	. "github.com/onsi/ginkgo"
@@ -87,6 +89,12 @@ const (
 	interval                            = time.Millisecond * 250
 )
 
+func TestAPIs(t *testing.T) {
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Suite")
+}
+
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
@@ -110,7 +118,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(routev1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
-	Expect(argoapi.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(argov1alpha1api.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(argov1beta1api.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(monitoringv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(operatorsv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(operatorsv1alpha1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
@@ -119,7 +128,6 @@ var _ = BeforeSuite(func() {
 	Expect(configv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(templatev1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(appsv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
-
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})

--- a/test/nondefaulte2e/suite_test.go
+++ b/test/nondefaulte2e/suite_test.go
@@ -21,11 +21,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"testing"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
-	argoapi "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	argov1alpha1api "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	argocdprovisioner "github.com/argoproj-labs/argocd-operator/controllers/argocd"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	. "github.com/onsi/ginkgo"
@@ -71,6 +73,11 @@ const (
 	interval           = time.Millisecond * 250
 )
 
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Suite")
+}
+
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
@@ -94,7 +101,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(routev1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
-	Expect(argoapi.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(monitoringv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(operatorsv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(operatorsv1alpha1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
@@ -103,7 +109,8 @@ var _ = BeforeSuite(func() {
 	Expect(configv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(templatev1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(appsv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
-
+	Expect(argov1alpha1api.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(argov1beta1api.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})


### PR DESCRIPTION
**What type of PR is this?**
 /kind code-refactoring

**What does this PR do / why we need it**:
Non-kuttl test execution was removed in a previous [PR ](https://github.com/redhat-developer/gitops-operator/pull/611/files)as the 'printer' package is no longer available in "sigs.k8s.io/controller-runtime/pkg/envtest/printer"

Which issue(s) this PR fixes:

Fixes #?
[GITOPS-4777](https://issues.redhat.com/browse/GITOPS-4777)

How to test changes / Special notes to the reviewer:
make test-e2e should now execute (without RunSpecsWithDefaultAndCustomReporters)
