### PR TITLE
Update to latest commit of argo-rollouts-manager '52fd4a22e49e9bb0a3947262cce75931b63b209b'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.21.0
 
 require (
-	github.com/argoproj-labs/argo-rollouts-manager v0.0.4-0.20240807084148-a96aa79b5464
+	github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241003091439-52fd4a22e49e
 	github.com/argoproj-labs/argocd-operator v0.12.0-rc3
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.4-0.20240807084148-a96aa79b5464 h1:LTMoDmQoIjqhe+pulFiG7l80pnjjZX6WiivURO2uXsQ=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.4-0.20240807084148-a96aa79b5464/go.mod h1:seR9B+tx6AbGaya+JA61HDBFciKx7FM7t/1IMhOwXlM=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241003091439-52fd4a22e49e h1:qp6+6Ii2yF3vlIOuLZPrcgmb11fBh+xLR6bNPZpFNiw=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241003091439-52fd4a22e49e/go.mod h1:seR9B+tx6AbGaya+JA61HDBFciKx7FM7t/1IMhOwXlM=
 github.com/argoproj-labs/argocd-operator v0.12.0-rc3 h1:UqHQFeaZKWY8IqsAgLU3CwjRymcYCsJ01Wysqf7nDiY=
 github.com/argoproj-labs/argocd-operator v0.12.0-rc3/go.mod h1:+yvFAnSJZL8iOTWI3cTQ9qwXfh40lLyOI4ghDFqM8S0=
 github.com/argoproj/argo-cd/v2 v2.12.3 h1:Bi4QahHTnKl3esU5MplQP1wraGhaTpvgAV4GsMqc3Zc=

--- a/scripts/run-rollouts-e2e-tests.sh
+++ b/scripts/run-rollouts-e2e-tests.sh
@@ -16,7 +16,7 @@ cd "$ROLLOUTS_TMP_DIR/argo-rollouts-manager"
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in go.mod of gitops-operator (which will usually be the most recent argo-rollouts-manager commit)
-TARGET_ROLLOUT_MANAGER_COMMIT=a96aa79b546433ee2d68f48d424baaabed0cb2ac
+TARGET_ROLLOUT_MANAGER_COMMIT=52fd4a22e49e9bb0a3947262cce75931b63b209b
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in the version of argo-rollouts-manager that is in go.mod
@@ -67,4 +67,5 @@ cd "$ROLLOUTS_TMP_DIR/rollouts-plugin-trafficrouter-openshift"
 git checkout $TARGET_OPENSHIFT_ROUTE_ROLLOUT_PLUGIN_COMMIT
 
 make test-e2e
+
 

--- a/test/openshift/e2e/sequential/1-100_validate_rollouts_resources_creation/01-assert.yaml
+++ b/test/openshift/e2e/sequential/1-100_validate_rollouts_resources_creation/01-assert.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: argo-rollouts
+  namespace: openshift-gitops
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -33,11 +34,13 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: argo-rollouts-notification-secret
+  namespace: openshift-gitops
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: argo-rollouts
+  namespace: openshift-gitops  
 status:
   readyReplicas: 1
 ---
@@ -45,3 +48,4 @@ apiVersion: v1
 kind: Service
 metadata:
   name: argo-rollouts-metrics
+  namespace: openshift-gitops  

--- a/test/openshift/e2e/sequential/1-100_validate_rollouts_resources_creation/01-install-rolloutmanager.yaml
+++ b/test/openshift/e2e/sequential/1-100_validate_rollouts_resources_creation/01-install-rolloutmanager.yaml
@@ -2,6 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: RolloutManager
 metadata:
   name: example-rollout-manager
+  namespace: openshift-gitops  
   labels:
     example: example-rollout-manager
 spec: {}

--- a/test/openshift/e2e/sequential/1-100_validate_rollouts_resources_creation/02-assert.yaml
+++ b/test/openshift/e2e/sequential/1-100_validate_rollouts_resources_creation/02-assert.yaml
@@ -3,5 +3,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: RolloutManager
 metadata:
   name: example-rollout-manager
+  namespace: openshift-gitops  
 status:
   phase: Available

--- a/test/openshift/e2e/sequential/1-101_validate_rollout_policyrules/01-install-rollloutmanager.yaml
+++ b/test/openshift/e2e/sequential/1-101_validate_rollout_policyrules/01-install-rollloutmanager.yaml
@@ -2,6 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: RolloutManager
 metadata:
   name: example-rollout-manager
+  namespace: openshift-gitops  
   labels:
     example: example-rollout-manager
 spec: {}


### PR DESCRIPTION


Update to most recent 'argo-rollouts-manager' commit: https://github.com/argoproj-labs/argo-rollouts-manager/commit/52fd4a22e49e9bb0a3947262cce75931b63b209b