### PR TITLE
fix: Remove resource limits for manager container

### DIFF
--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -164,7 +164,7 @@ metadata:
     capabilities: Deep Insights
     console.openshift.io/plugins: '["gitops-plugin"]'
     containerImage: quay.io/redhat-developer/gitops-operator
-    createdAt: "2024-08-20T17:38:59Z"
+    createdAt: "2024-10-04T04:12:36Z"
     description: Enables teams to adopt GitOps principles for managing cluster configurations
       and application delivery across hybrid multi-cluster Kubernetes environments.
     features.operators.openshift.io/disconnected: "true"
@@ -1017,13 +1017,7 @@ spec:
                     port: 8081
                   initialDelaySeconds: 5
                   periodSeconds: 10
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 768Mi
-                  requests:
-                    cpu: 10m
-                    memory: 256Mi
+                resources: {}
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,13 +52,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        resources:
-          limits:
-            cpu: 500m
-            memory: 768Mi
-          requests:
-            cpu: 10m
-            memory: 256Mi
+        resources: {}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
During the operator-sdk upgrade, we set resource limits for the manager container. However, these limits are causing issues for users, particularly on clusters with a large number of secrets and configmaps, as the operator requires significantly more memory to function, leading to OOM kills. We are currently exploring ways to reduce memory consumption, however, this involves significant effort. Therefore, this PR removes the limits to minimize the impact.

**Which issue(s) this PR fixes**:

Fixes [GITOPS-5665](https://issues.redhat.com/browse/GITOPS-5665)

**How to test changes / Special notes to the reviewer**:

I have tested this change using the reproducer from JIRA. The operator was functioning properly, consuming over 2GB of memory without any OOM kills.
