### PR TITLE
Upgrade v1.14 to Argo Rollouts manager v0.0.4.1: df262fe66d25638de47ee98130dcebe016c8fae5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.21.0
 
 require (
-	github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241004094712-aea86d7ae590
+	github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241019174305-df262fe66d25
 	github.com/argoproj-labs/argocd-operator v0.12.1-0.20241009134657-7cd9755474eb
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241004094712-aea86d7ae590 h1:UJWMptB+Vi1KwRmzkdr0aGkyOE4YP2VDg59Lt9S3AEI=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241004094712-aea86d7ae590/go.mod h1:seR9B+tx6AbGaya+JA61HDBFciKx7FM7t/1IMhOwXlM=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241019174305-df262fe66d25 h1:Q3Xe/zfMlZ7AqW8FT2l4cGmKfsdhC99V3bulDhD7Pqo=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241019174305-df262fe66d25/go.mod h1:seR9B+tx6AbGaya+JA61HDBFciKx7FM7t/1IMhOwXlM=
 github.com/argoproj-labs/argocd-operator v0.12.1-0.20241009134657-7cd9755474eb h1:AklnEY7Ykr3iFjQsSR8T3r68clGUAghb7wT50kSeeM0=
 github.com/argoproj-labs/argocd-operator v0.12.1-0.20241009134657-7cd9755474eb/go.mod h1:aTGUCLiLqtLHdfXzhHcvxvqVVWrE58aIADtuY6rjhsQ=
 github.com/argoproj/argo-cd/v2 v2.12.4 h1:mlKcLvCX6F8Gz5/q2v6ImsYbSLMTTCeKYYTwGZV5vx4=


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
- Upgrade to latest version of Argo Rollouts v0.0.4.1 to address issues identified when switching from cluster/namespace-scoped Rollouts installs

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
