### PR TITLE
Upgrade v1.13 to Argo Rollouts manager v0.0.3.1: e054d35fd0d9dad6b9ae26efa60f43cadc…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.21
 
 require (
-	github.com/argoproj-labs/argo-rollouts-manager v0.0.4-0.20241004113423-fc2d5cc721f9
+	github.com/argoproj-labs/argo-rollouts-manager v0.0.4-0.20241019175410-e054d35fd0d9
 	github.com/argoproj-labs/argocd-operator v0.11.1-0.20241010065622-764dd5d8fed9
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -637,8 +637,8 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.4-0.20241004113423-fc2d5cc721f9 h1:q1M17YEE3tX/NYEv802pSgYxz8ZQrSK8VKVc3xGQG5Q=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.4-0.20241004113423-fc2d5cc721f9/go.mod h1:seR9B+tx6AbGaya+JA61HDBFciKx7FM7t/1IMhOwXlM=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.4-0.20241019175410-e054d35fd0d9 h1:2yX5LMiwAbJAk2F0eZLOY4+2oA3P0RVlk3UZLqoCWh8=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.4-0.20241019175410-e054d35fd0d9/go.mod h1:seR9B+tx6AbGaya+JA61HDBFciKx7FM7t/1IMhOwXlM=
 github.com/argoproj-labs/argocd-operator v0.11.1-0.20241010065622-764dd5d8fed9 h1:oJWYeHLYmalJZ8M/2Xbxxe13H3NyneXry/LZ+RcVJ2Q=
 github.com/argoproj-labs/argocd-operator v0.11.1-0.20241010065622-764dd5d8fed9/go.mod h1:jqPwIfqquPrRahApcN7jfzEB/o185ZGfJwRhNEqd4hk=
 github.com/argoproj/argo-cd/v2 v2.11.9 h1:tk7jCH+HAqMLu4pWAndv6WGTocmuY1kVCGK1b8b2d1k=


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
- Upgrade to latest version of Argo Rollouts v0.0.3.1 to address issues identified when switching from cluster/namespace-scoped Rollouts installs


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
