### PR TITLE
Rollouts E2E test script should point to v0.0.4.1 branch

### DIFF
--- a/scripts/run-rollouts-e2e-tests.sh
+++ b/scripts/run-rollouts-e2e-tests.sh
@@ -16,7 +16,7 @@ cd "$ROLLOUTS_TMP_DIR/argo-rollouts-manager"
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in go.mod of gitops-operator (which will usually be the most recent argo-rollouts-manager commit)
-TARGET_ROLLOUT_MANAGER_COMMIT=aea86d7ae5902e2ee8d0e652a2770484d9fa09df
+TARGET_ROLLOUT_MANAGER_COMMIT=df262fe66d25638de47ee98130dcebe016c8fae5
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in the version of argo-rollouts-manager that is in go.mod


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:
- Rollouts E2E test script should point to v0.0.4.1 branch

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

N/A

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
