### PR TITLE
update argocd-operator version for release 1.14.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.0
 
 require (
 	github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241019174305-df262fe66d25
-	github.com/argoproj-labs/argocd-operator v0.12.1-0.20241009134657-7cd9755474eb
+	github.com/argoproj-labs/argocd-operator v0.12.1-0.20241022070936-f3c2fc4b2302
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.6.0
@@ -27,7 +27,7 @@ require (
 )
 
 require (
-	github.com/argoproj/argo-cd/v2 v2.12.4 // indirect
+	github.com/argoproj/argo-cd/v2 v2.12.6 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cert-manager/cert-manager v1.14.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -622,10 +622,10 @@ github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241019174305-df262fe66d25 h1:Q3Xe/zfMlZ7AqW8FT2l4cGmKfsdhC99V3bulDhD7Pqo=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241019174305-df262fe66d25/go.mod h1:seR9B+tx6AbGaya+JA61HDBFciKx7FM7t/1IMhOwXlM=
-github.com/argoproj-labs/argocd-operator v0.12.1-0.20241009134657-7cd9755474eb h1:AklnEY7Ykr3iFjQsSR8T3r68clGUAghb7wT50kSeeM0=
-github.com/argoproj-labs/argocd-operator v0.12.1-0.20241009134657-7cd9755474eb/go.mod h1:aTGUCLiLqtLHdfXzhHcvxvqVVWrE58aIADtuY6rjhsQ=
-github.com/argoproj/argo-cd/v2 v2.12.4 h1:mlKcLvCX6F8Gz5/q2v6ImsYbSLMTTCeKYYTwGZV5vx4=
-github.com/argoproj/argo-cd/v2 v2.12.4/go.mod h1:2fh6q4NX/cylbH6Ktx/KjJsX7sOBwF3jbGnO0IZyNOc=
+github.com/argoproj-labs/argocd-operator v0.12.1-0.20241022070936-f3c2fc4b2302 h1:XCJ081tKWf3lPrlhCKF3iD7p/2SODT2Ah34EkOeEAHs=
+github.com/argoproj-labs/argocd-operator v0.12.1-0.20241022070936-f3c2fc4b2302/go.mod h1:Wc7grUq8ZFE7AVFXKBRGrSdADDetjafndCVaXxn68lY=
+github.com/argoproj/argo-cd/v2 v2.12.6 h1:5EEdZbsyK1trxcm4AcCt5WNgGOAmXMdZSjEfe35IV7U=
+github.com/argoproj/argo-cd/v2 v2.12.6/go.mod h1:BS64uTH/mG3dEpulAI4oIyJiluuYdAbGlisR/s9FrEM=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.3.0/go.mod h1:zXjbSimjXTd7vOpY8B0/2LpvNvDoXBuplAD+gJD3GYs=

--- a/test/openshift/e2e/parallel/1-031_validate_toolchain/01-check.yaml
+++ b/test/openshift/e2e/parallel/1-031_validate_toolchain/01-check.yaml
@@ -8,7 +8,7 @@ commands:
       # These variables need to be maintained according to the component matrix: https://spaces.redhat.com/display/GITOPS/GitOps+Component+Matrix
       expected_kustomizeVersion='v5.4.2'
       expected_helmVersion='v3.15.2'
-      expected_argocdVersion='v2.12.4+27d1e64'
+      expected_argocdVersion='v2.12.6+4dab5bd'
       
       if CI="prow"; then
       # when running against openshift-ci


### PR DESCRIPTION
**What type of PR is this?**

 /kind cleanup


**What does this PR do / why we need it**:
This PR updates argocd and argocd-operator version