### PR TITLE
Fix typo in YAML for 1-020_validate_redis_ha_nonha

### DIFF
--- a/test/openshift/e2e/sequential/1-020_validate_redis_ha_nonha/04-disable-ha.yaml
+++ b/test/openshift/e2e/sequential/1-020_validate_redis_ha_nonha/04-disable-ha.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: openshift-gitops
 spec:
   ha:
-   enabled: false
+    enabled: false


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
- Fix typo in YAML for 1-020_validate_redis_ha_nonha
- I somewhat suspect this is causing tests after it that depend on `openshift-gitops` namespace to break (e.g. `1-041_validate_argocd_sync_alert`)
