### PR TITLE
Fix race condition in e2e test 1-052_validate_rolebinding_number

### DIFF
--- a/test/openshift/e2e/parallel/1-052_validate_rolebinding_number/02-check_rolebindings.yaml
+++ b/test/openshift/e2e/parallel/1-052_validate_rolebinding_number/02-check_rolebindings.yaml
@@ -9,14 +9,40 @@ commands:
       "openshift-gitops-argocd-application-controller"
       "openshift-gitops-argocd-server"
     )
-    current_rb=( $(oc get rolebindings -n "${NAMESPACE}" | awk '/gitops/ {print $1}') )
 
-    # Check that the required RoleBindings exist:
-    for rb in "${expected_rb[@]}"
-    do
-      oc get rolebinding "${rb}" -n "${NAMESPACE}" > /dev/null
+    # Check that eventually the current role bindings equal the expected role
+    # bindings. Timeout after 60 seconds
+    timer=0
+    current_rb=( $(oc get rolebindings -n "${NAMESPACE}" | awk '/gitops/ {print $1}' | sort) )
+    while [[ "${current_rb[@]}" != "${expected_rb[@]}" ]]; do
+      if [[ $timer -eq 60 ]]; then
+        echo "timed out waiting for current role bindings to equal expected role bindings"
+        echo "current role bindings: ${current_rb[*]}"
+        echo "expected role bindings: ${expected_rb[*]}"
+        exit 1
+      fi
+
+      timer=$((timer+5))
+      sleep 5
+      current_rb=( $(oc get rolebindings -n "${NAMESPACE}" | awk '/gitops/ {print $1}' | sort) )
     done
 
-    # Check that there are only two RoleBindings
-    echo "Current RoleBindings: ${current_rb[*]}"
-    [[ "${#current_rb[@]}" == "2" ]]
+    # Check that the expected role bindings continue to exist for at least the
+    # next 20 seconds
+    timer=0
+    while [ true ]; do
+      if [[ $timer -eq 20 ]]; then
+        break
+      fi
+
+      current_rb=( $(oc get rolebindings -n "${NAMESPACE}" | awk '/gitops/ {print $1}' | sort) )
+      if [[ "${current_rb[@]}" != "${expected_rb[@]}" ]]; then
+        echo "current role bindings have changed, now not equal to expected role bindings"
+        echo "current role bindings: ${current_rb[*]}"
+        echo "expected role bindings: ${expected_rb[*]}"
+        exit 1
+      fi
+
+      timer=$((timer+5))
+      sleep 5
+    done


### PR DESCRIPTION
**What type of PR is this?**

> /kind failing-test

**What does this PR do / why we need it**:

Fixes race condition in e2e test 1-052_validate_rolebinding_number. As per Jonathan's request:

- '02-check_rolebindings.yaml' should loop wait, rather than only running once then failing:
  - first it should loop, waiting for the expected number of rolebindings exist (e.g. similar to an 'Eventually' in ginkgo)
  - then it should loop, waiting that the expected number of rolebindings continue to exists for 20 seconds (similar to 'Consistently' in ginkgo)
