### PR TITLE
chore: Bump go to 1.22

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.21
+  tag: golang-1.22

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-developer/gitops-operator
 
-go 1.21.0
+go 1.22
 
 require (
 	github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241023053239-85db81b64541

--- a/openshift-ci/build-root/Dockerfile
+++ b/openshift-ci/build-root/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-4.16
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.16
 
 ARG KUBECTL_KUTTL_VERSION=0.12.1
 ARG OPERATOR_SDK_VERSION=1.35.0

--- a/test/openshift/e2e/ignore-tests/parallel/1-066_validate_redis_secure_comm_no_autotls_no_ha/02-generate_cert.yaml
+++ b/test/openshift/e2e/ignore-tests/parallel/1-066_validate_redis_secure_comm_no_autotls_no_ha/02-generate_cert.yaml
@@ -17,5 +17,4 @@ commands:
      -out ${PWD}/redis.crt \
      -newkey rsa:4096 \
      -nodes \
-     -sha256 \
      -days 10

--- a/test/openshift/e2e/ignore-tests/parallel/1-067_validate_redis_secure_comm_no_autotls_ha/02-generate_cert.yaml
+++ b/test/openshift/e2e/ignore-tests/parallel/1-067_validate_redis_secure_comm_no_autotls_ha/02-generate_cert.yaml
@@ -17,5 +17,4 @@ commands:
     -out ${PWD}/redis-ha.crt \
     -newkey rsa:4096 \
     -nodes \
-    -sha256 \
     -days 10

--- a/test/openshift/e2e/parallel/1-066_validate_redis_secure_comm_no_autotls_no_ha/02-generate_cert.yaml
+++ b/test/openshift/e2e/parallel/1-066_validate_redis_secure_comm_no_autotls_no_ha/02-generate_cert.yaml
@@ -17,5 +17,4 @@ commands:
      -out ${PWD}/redis.crt \
      -newkey rsa:4096 \
      -nodes \
-     -sha256 \
      -days 10

--- a/test/openshift/e2e/parallel/1-067_validate_redis_secure_comm_no_autotls_ha/02-generate_cert.yaml
+++ b/test/openshift/e2e/parallel/1-067_validate_redis_secure_comm_no_autotls_ha/02-generate_cert.yaml
@@ -17,5 +17,4 @@ commands:
     -out ${PWD}/redis-ha.crt \
     -newkey rsa:4096 \
     -nodes \
-    -sha256 \
     -days 10


### PR DESCRIPTION
**What does this PR do / why we need it**:
Bump golang to 1.22
