### PR TITLE
fix: race condition in e2e test 1-057_validate_notifications

### DIFF
--- a/test/openshift/e2e/parallel/1-057_validate_notifications/05-verify-email.yaml
+++ b/test/openshift/e2e/parallel/1-057_validate_notifications/05-verify-email.yaml
@@ -3,17 +3,25 @@ kind: TestStep
 commands:
 - script: | 
     set -e
-    sleep 5
     smtp4dev_pod=$(kubectl get pod -l=app=smtp4dev -o NAME -n $NAMESPACE)
-    exit_code=$(kubectl -n $NAMESPACE exec --stdin "${smtp4dev_pod}" -- /bin/bash \
-    -c 'if [[ $(grep -rnw /tmp -e "Subject: Application my-app-3 has been created.") ]]; then
-    exit 0; else
-    exit 1;
-    fi')
 
-
-    if [[ $exit_code -eq 0 ]]; then
-        exit 0
-    else
+    while :
+    do      
+      if [[ $timer -eq 120 ]]; then
+        echo "timed out while waiting for email notification"
         exit 1
-    fi
+      fi
+
+      exit_code=$(kubectl -n $NAMESPACE exec --stdin "${smtp4dev_pod}" -- /bin/bash \
+      -c 'if [[ $(grep -rnw /tmp -e "Subject: Application my-app-3 has been created.") ]]; then
+      exit 0; else
+      exit 1;
+      fi')
+
+      if [[ $exit_code -eq 0 ]]; then
+        exit 0
+      fi
+      
+      timer=$((timer+5))
+      sleep 5
+    done


### PR DESCRIPTION
**What type of PR is this?**
> /kind failing-test

**What does this PR do / why we need it**:
Fixes race condition in e2e test 1-057_validate_notifications. 

**Fixes**
RH issue tracker :- https://issues.redhat.com/browse/GITOPS-5968
