### PR TITLE
Fix intermittent failures of E2E tests 1-045 and 1-069

### DIFF
--- a/test/openshift/e2e/parallel/1-045_validate_repo_exec_timeout/04-check-workload-env.yaml
+++ b/test/openshift/e2e/parallel/1-045_validate_repo_exec_timeout/04-check-workload-env.yaml
@@ -1,11 +1,29 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-- script: sleep 10
-- script: |
-    timeout=$(oc get -n $NAMESPACE deployment argocd-repo-server -o json \
-      | jq -r '.spec.template.spec.containers[0].env[]|select(.name=="ARGOCD_EXEC_TIMEOUT").value')
-    if test "$timeout" != "300s"; then
-      echo "Assertion failed. Timeout should be 300s, is '$timeout'"
+  - script: |
+      function check_timeout() {
+        timeout=$(oc get -n $NAMESPACE deployment argocd-repo-server -o json \
+          | jq -r '.spec.template.spec.containers[0].env[]|select(.name=="ARGOCD_EXEC_TIMEOUT").value')
+        if test "$timeout" != "300s"; then
+          echo "Waiting for timeout to be 300s, is '$timeout'"
+          return 1
+        fi
+        return 0
+      }
+
+      echo -n "Waiting until timeout has expected value"
+      for i in {1..150}; do # timeout after 5 minutes
+
+        if check_timeout; then
+          # success
+          echo ".spec.template.spec.containers[0].env had expected env var"
+          exit 0
+        else
+          echo "Still waiting for 'spec.template.spec.containers[0].env' to have expected env var"
+        fi
+        sleep 2
+      done
+
+      echo ".spec.template.spec.containers[0].env never had expected env var"
       exit 1
-    fi

--- a/test/openshift/e2e/parallel/1-069_validate_redis_secure_comm_autotls_ha/03-check_secret.yaml
+++ b/test/openshift/e2e/parallel/1-069_validate_redis_secure_comm_autotls_ha/03-check_secret.yaml
@@ -2,17 +2,37 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
 - script: |
-    set -e
-    secret_type="$(oc get secrets argocd-operator-redis-tls -n $NAMESPACE --template '{{.type}}')"
-    secret_len="$(oc get secrets argocd-operator-redis-tls -n $NAMESPACE --template '{{len .data}}')"
-    expected_secret_type="kubernetes.io/tls"
-    expected_secret_len=2
+    function check_secret() {
+      secret_type="$(oc get secrets argocd-operator-redis-tls -n $NAMESPACE --template '{{.type}}')"
+      secret_len="$(oc get secrets argocd-operator-redis-tls -n $NAMESPACE --template '{{len .data}}')"
+      expected_secret_type="kubernetes.io/tls"
+      expected_secret_len=2
 
-    if test ${secret_type} != ${expected_secret_type}; then
-      echo "argocd-operator-redis-tls secret type is ${secret_type} and should be ${expected_secret_type}"
-      exit 1
-    fi
-    if test ${secret_len} != ${expected_secret_len}; then
-      echo "argocd-operator-redis-tls secret length is ${secret_len} and should be ${expected_secret_len}"
-      exit 1
-    fi
+      if test ${secret_type} != ${expected_secret_type}; then
+        echo "argocd-operator-redis-tls secret type is ${secret_type} and should be ${expected_secret_type}"
+        return 1
+      fi
+      if test ${secret_len} != ${expected_secret_len}; then
+        echo "argocd-operator-redis-tls secret length is ${secret_len} and should be ${expected_secret_len}"
+        return 1
+      fi
+
+      return 0    
+    }
+
+    echo -n "Waiting until secret has expected type and .data length"
+    for i in {1..150}; do # timeout after 5 minutes
+
+      if check_secret; then
+        # success
+        echo "Secret has expected length and type."
+        exit 0
+      else
+        echo "Still waiting for Secret to have expected length and type."
+      fi
+      sleep 2
+    done
+
+    echo "Secret never had expected length and type"
+    exit 1
+    


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What does this PR do / why we need it**:
- Fixes intermittent failures of E2E tests 1-045 and 1-069
- These tests should not just assume that the value will be updated instantly; they should instead wait for the value to be updated, and fail if it hasn't after some period of time.