### PR TITLE
Add additional debugging to test command execution

### DIFF
--- a/test/e2e/argocd_metrics_test.go
+++ b/test/e2e/argocd_metrics_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e
 
 import (
+	"bytes"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -30,6 +31,28 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+func runCommandWithOutput(cmdList ...string) (string, string, error) {
+
+	// Output the commands to be run, so that if the test fails we can determine why
+	fmt.Println(cmdList)
+
+	cmd := exec.Command(cmdList[0], cmdList[1:]...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	stdoutStr := stdout.String()
+	stderrStr := stderr.String()
+
+	// Output the stdout/sterr text, so that if the test fails we can determine why
+	fmt.Println(stdoutStr, stderrStr)
+
+	return stdoutStr, stderrStr, err
+
+}
+
 var _ = Describe("Argo CD metrics controller", func() {
 	Context("Check if monitoring resources are created", func() {
 		It("Role is created", func() {
@@ -37,8 +60,7 @@ var _ = Describe("Argo CD metrics controller", func() {
 			ocPath, err := exec.LookPath("oc")
 			Expect(err).NotTo(HaveOccurred())
 
-			cmd := exec.Command(ocPath, "apply", "-f", buildYAML)
-			err = cmd.Run()
+			_, _, err = runCommandWithOutput(ocPath, "apply", "-f", buildYAML)
 			Expect(err).NotTo(HaveOccurred())
 			// Alert delay
 			time.Sleep(60 * time.Second)

--- a/test/e2e/gitopsservice_test.go
+++ b/test/e2e/gitopsservice_test.go
@@ -129,8 +129,7 @@ var _ = Describe("GitOpsServiceController", func() {
 			ocPath, err := exec.LookPath("oc")
 			Expect(err).NotTo(HaveOccurred())
 
-			cmd := exec.Command(ocPath, "apply", "-f", imageYAML)
-			err = cmd.Run()
+			_, _, err = runCommandWithOutput(ocPath, "apply", "-f", imageYAML)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -191,8 +190,7 @@ var _ = Describe("GitOpsServiceController", func() {
 			nonDefaultAppCR := filepath.Join("..", "appcrs", "non_default_appcr.yaml")
 			ocPath, err := exec.LookPath("oc")
 			Expect(err).NotTo(HaveOccurred())
-			cmd := exec.Command(ocPath, "apply", "-f", nonDefaultAppCR)
-			_, err = cmd.CombinedOutput()
+			_, _, err = runCommandWithOutput(ocPath, "apply", "-f", nonDefaultAppCR)
 			if err != nil {
 				Expect(err).NotTo(HaveOccurred())
 			}
@@ -321,8 +319,7 @@ var _ = Describe("GitOpsServiceController", func() {
 			ocPath, err := exec.LookPath("oc")
 			Expect(err).NotTo(HaveOccurred())
 			schedulerYAML := filepath.Join("..", "appcrs", "scheduler_appcr.yaml")
-			cmd := exec.Command(ocPath, "apply", "-f", schedulerYAML)
-			_, err = cmd.CombinedOutput()
+			_, _, err = runCommandWithOutput(ocPath, "apply", "-f", schedulerYAML)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func() error {
@@ -420,8 +417,7 @@ var _ = Describe("GitOpsServiceController", func() {
 			nginxAppCr := filepath.Join("..", "appcrs", "nginx_appcr.yaml")
 			ocPath, err := exec.LookPath("oc")
 			Expect(err).NotTo(HaveOccurred())
-			cmd := exec.Command(ocPath, "apply", "-f", nginxAppCr)
-			err = cmd.Run()
+			_, _, err = runCommandWithOutput(ocPath, "apply", "-f", nginxAppCr)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func() error {
@@ -487,8 +483,7 @@ var _ = Describe("GitOpsServiceController", func() {
 			nginxAppCr := filepath.Join("..", "appcrs", "nginx_default_ns_appcr.yaml")
 			ocPath, err := exec.LookPath("oc")
 			Expect(err).NotTo(HaveOccurred())
-			cmd := exec.Command(ocPath, "apply", "-f", nginxAppCr)
-			err = cmd.Run()
+			_, _, err = runCommandWithOutput(ocPath, "apply", "-f", nginxAppCr)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func() error {


### PR DESCRIPTION
**What type of PR is this?**
/kind code-refactoring

**What does this PR do / why we need it**:

I noticed that this test was failing in another PR:
```
[91m[1m[Fail] [0m[90mArgo CD metrics controller [0m[0mCheck if monitoring resources are created [0m[91m[1m[It] Role is created [0m
[37m/go/src/github.com/redhat-developer/gitops-operator/test/e2e/argocd_metrics_test.go:42[0m
```

However, it was not obvious why, because the output from oc is not printed in the failing case. This PR updates the command execution logic to output console stdout/stderr, so if this error occurs again we can know why.