### PR TITLE
fix CVE namespace-isolation break

### DIFF
--- a/controllers/argocd_metrics_controller_test.go
+++ b/controllers/argocd_metrics_controller_test.go
@@ -81,16 +81,19 @@ func newMetricsReconciler(t *testing.T, namespace, name string, disableMetrics *
 
 func TestReconcile_add_namespace_label(t *testing.T) {
 	testCases := []struct {
-		instanceName string
-		namespace    string
+		instanceName  string
+		namespace     string
+		expectedLabel string
 	}{
 		{
-			instanceName: argoCDInstanceName,
-			namespace:    "openshift-gitops",
+			instanceName:  argoCDInstanceName,
+			namespace:     "openshift-gitops",
+			expectedLabel: "openshift.io/cluster-monitoring",
 		},
 		{
-			instanceName: "instance-two",
-			namespace:    "namespace-two",
+			instanceName:  "instance-two",
+			namespace:     "namespace-two",
+			expectedLabel: "openshift.io/user-monitoring",
 		},
 	}
 	for _, tc := range testCases {
@@ -101,7 +104,7 @@ func TestReconcile_add_namespace_label(t *testing.T) {
 		ns := corev1.Namespace{}
 		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: tc.namespace}, &ns)
 		assert.NilError(t, err)
-		value := ns.Labels["openshift.io/cluster-monitoring"]
+		value := ns.Labels[tc.expectedLabel]
 		assert.Equal(t, value, "true")
 	}
 }


### PR DESCRIPTION
argocd adds cluster monitoring label if the ns contains openshift- prefix

**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:
This PR fixes the namespace isolation break, caused by using cluster-monitoring label for monitoring 
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes  [GITOPS-6251](https://issues.redhat.com/browse/GITOPS-6251)

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
