### PR TITLE
Update v1.15 branch to point to Rollouts E2E test fixes

### DIFF
--- a/scripts/run-rollouts-e2e-tests.sh
+++ b/scripts/run-rollouts-e2e-tests.sh
@@ -16,7 +16,7 @@ cd "$ROLLOUTS_TMP_DIR/argo-rollouts-manager"
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in go.mod of gitops-operator (which will usually be the most recent argo-rollouts-manager commit)
-TARGET_ROLLOUT_MANAGER_COMMIT=85db81b64541a2e0f10616acca8b24ac63f46b42
+TARGET_ROLLOUT_MANAGER_COMMIT=e1e9a742a9dd228fc3bb59ee9aba93b0800d08fa
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in the version of argo-rollouts-manager that is in go.mod


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`
/kind failing-test

**What does this PR do / why we need it**:
This updates v1.15 E2E test script to use backported fixes to E2E tests. The actual version of Rollouts Manager (operator) still remains the same.
