### PR TITLE
Downgrade v1.16 to Argo Rollouts Manager v0.0.5

### DIFF
--- a/bundle/manifests/argoproj.io_analysisruns.yaml
+++ b/bundle/manifests/argoproj.io_analysisruns.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: analysisruns.argoproj.io
 spec:
@@ -94,11 +94,6 @@ spec:
                 items:
                   properties:
                     consecutiveErrorLimit:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      x-kubernetes-int-or-string: true
-                    consecutiveSuccessLimit:
                       anyOf:
                       - type: integer
                       - type: string
@@ -212,13 +207,6 @@ spec:
                               type: object
                             query:
                               type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                                namespaced:
-                                  type: boolean
-                              type: object
                           type: object
                         graphite:
                           properties:
@@ -3027,9 +3015,6 @@ spec:
                               type: string
                             query:
                               type: string
-                            timeout:
-                              format: int64
-                              type: integer
                           required:
                           - query
                           type: object
@@ -3081,15 +3066,6 @@ spec:
                               type: boolean
                             query:
                               type: string
-                            rangeQuery:
-                              properties:
-                                end:
-                                  type: string
-                                start:
-                                  type: string
-                                step:
-                                  type: string
-                              type: object
                             timeout:
                               format: int64
                               type: integer
@@ -3222,9 +3198,6 @@ spec:
                 items:
                   properties:
                     consecutiveError:
-                      format: int32
-                      type: integer
-                    consecutiveSuccess:
                       format: int32
                       type: integer
                     count:

--- a/bundle/manifests/argoproj.io_analysistemplates.yaml
+++ b/bundle/manifests/argoproj.io_analysistemplates.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: analysistemplates.argoproj.io
 spec:
@@ -90,11 +90,6 @@ spec:
                 items:
                   properties:
                     consecutiveErrorLimit:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      x-kubernetes-int-or-string: true
-                    consecutiveSuccessLimit:
                       anyOf:
                       - type: integer
                       - type: string
@@ -208,13 +203,6 @@ spec:
                               type: object
                             query:
                               type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                                namespaced:
-                                  type: boolean
-                              type: object
                           type: object
                         graphite:
                           properties:
@@ -3023,9 +3011,6 @@ spec:
                               type: string
                             query:
                               type: string
-                            timeout:
-                              format: int64
-                              type: integer
                           required:
                           - query
                           type: object
@@ -3077,15 +3062,6 @@ spec:
                               type: boolean
                             query:
                               type: string
-                            rangeQuery:
-                              properties:
-                                end:
-                                  type: string
-                                start:
-                                  type: string
-                                step:
-                                  type: string
-                              type: object
                             timeout:
                               format: int64
                               type: integer

--- a/bundle/manifests/argoproj.io_clusteranalysistemplates.yaml
+++ b/bundle/manifests/argoproj.io_clusteranalysistemplates.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: clusteranalysistemplates.argoproj.io
 spec:
@@ -90,11 +90,6 @@ spec:
                 items:
                   properties:
                     consecutiveErrorLimit:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      x-kubernetes-int-or-string: true
-                    consecutiveSuccessLimit:
                       anyOf:
                       - type: integer
                       - type: string
@@ -208,13 +203,6 @@ spec:
                               type: object
                             query:
                               type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                                namespaced:
-                                  type: boolean
-                              type: object
                           type: object
                         graphite:
                           properties:
@@ -3023,9 +3011,6 @@ spec:
                               type: string
                             query:
                               type: string
-                            timeout:
-                              format: int64
-                              type: integer
                           required:
                           - query
                           type: object
@@ -3077,15 +3062,6 @@ spec:
                               type: boolean
                             query:
                               type: string
-                            rangeQuery:
-                              properties:
-                                end:
-                                  type: string
-                                start:
-                                  type: string
-                                step:
-                                  type: string
-                              type: object
                             timeout:
                               format: int64
                               type: integer

--- a/bundle/manifests/argoproj.io_experiments.yaml
+++ b/bundle/manifests/argoproj.io_experiments.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: experiments.argoproj.io
 spec:

--- a/bundle/manifests/argoproj.io_rollouts.yaml
+++ b/bundle/manifests/argoproj.io_rollouts.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: rollouts.argoproj.io
 spec:
@@ -662,16 +662,6 @@ spec:
                                   - type: string
                                   x-kubernetes-int-or-string: true
                               type: object
-                            plugin:
-                              properties:
-                                config:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
                             setCanaryScale:
                               properties:
                                 matchTrafficWeight:
@@ -944,10 +934,6 @@ spec:
                                 type: object
                               annotationPrefix:
                                 type: string
-                              canaryIngressAnnotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
                               stableIngress:
                                 type: string
                               stableIngresses:
@@ -3731,45 +3717,6 @@ spec:
                     type: object
                   stablePingPong:
                     type: string
-                  stepPluginStatuses:
-                    items:
-                      properties:
-                        backoff:
-                          type: string
-                        disabled:
-                          type: boolean
-                        executions:
-                          format: int32
-                          type: integer
-                        finishedAt:
-                          format: date-time
-                          type: string
-                        index:
-                          format: int32
-                          type: integer
-                        message:
-                          type: string
-                        name:
-                          type: string
-                        operation:
-                          type: string
-                        phase:
-                          type: string
-                        startedAt:
-                          format: date-time
-                          type: string
-                        status:
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
-                        updatedAt:
-                          format: date-time
-                          type: string
-                      required:
-                      - index
-                      - name
-                      - operation
-                      type: object
-                    type: array
                   weights:
                     properties:
                       additional:

--- a/config/crd/bases/analysis-run-crd.yaml
+++ b/config/crd/bases/analysis-run-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: analysisruns.argoproj.io
 spec:
   group: argoproj.io
@@ -94,11 +94,6 @@ spec:
                 items:
                   properties:
                     consecutiveErrorLimit:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      x-kubernetes-int-or-string: true
-                    consecutiveSuccessLimit:
                       anyOf:
                       - type: integer
                       - type: string
@@ -212,13 +207,6 @@ spec:
                               type: object
                             query:
                               type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                                namespaced:
-                                  type: boolean
-                              type: object
                           type: object
                         graphite:
                           properties:
@@ -3027,9 +3015,6 @@ spec:
                               type: string
                             query:
                               type: string
-                            timeout:
-                              format: int64
-                              type: integer
                           required:
                           - query
                           type: object
@@ -3081,15 +3066,6 @@ spec:
                               type: boolean
                             query:
                               type: string
-                            rangeQuery:
-                              properties:
-                                end:
-                                  type: string
-                                start:
-                                  type: string
-                                step:
-                                  type: string
-                              type: object
                             timeout:
                               format: int64
                               type: integer
@@ -3222,9 +3198,6 @@ spec:
                 items:
                   properties:
                     consecutiveError:
-                      format: int32
-                      type: integer
-                    consecutiveSuccess:
                       format: int32
                       type: integer
                     count:

--- a/config/crd/bases/analysis-template-crd.yaml
+++ b/config/crd/bases/analysis-template-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: analysistemplates.argoproj.io
 spec:
   group: argoproj.io
@@ -90,11 +90,6 @@ spec:
                 items:
                   properties:
                     consecutiveErrorLimit:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      x-kubernetes-int-or-string: true
-                    consecutiveSuccessLimit:
                       anyOf:
                       - type: integer
                       - type: string
@@ -208,13 +203,6 @@ spec:
                               type: object
                             query:
                               type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                                namespaced:
-                                  type: boolean
-                              type: object
                           type: object
                         graphite:
                           properties:
@@ -3023,9 +3011,6 @@ spec:
                               type: string
                             query:
                               type: string
-                            timeout:
-                              format: int64
-                              type: integer
                           required:
                           - query
                           type: object
@@ -3077,15 +3062,6 @@ spec:
                               type: boolean
                             query:
                               type: string
-                            rangeQuery:
-                              properties:
-                                end:
-                                  type: string
-                                start:
-                                  type: string
-                                step:
-                                  type: string
-                              type: object
                             timeout:
                               format: int64
                               type: integer

--- a/config/crd/bases/cluster-analysis-template-crd.yaml
+++ b/config/crd/bases/cluster-analysis-template-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: clusteranalysistemplates.argoproj.io
 spec:
   group: argoproj.io
@@ -90,11 +90,6 @@ spec:
                 items:
                   properties:
                     consecutiveErrorLimit:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      x-kubernetes-int-or-string: true
-                    consecutiveSuccessLimit:
                       anyOf:
                       - type: integer
                       - type: string
@@ -208,13 +203,6 @@ spec:
                               type: object
                             query:
                               type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                                namespaced:
-                                  type: boolean
-                              type: object
                           type: object
                         graphite:
                           properties:
@@ -3023,9 +3011,6 @@ spec:
                               type: string
                             query:
                               type: string
-                            timeout:
-                              format: int64
-                              type: integer
                           required:
                           - query
                           type: object
@@ -3077,15 +3062,6 @@ spec:
                               type: boolean
                             query:
                               type: string
-                            rangeQuery:
-                              properties:
-                                end:
-                                  type: string
-                                start:
-                                  type: string
-                                step:
-                                  type: string
-                              type: object
                             timeout:
                               format: int64
                               type: integer

--- a/config/crd/bases/experiment-crd.yaml
+++ b/config/crd/bases/experiment-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: experiments.argoproj.io
 spec:
   group: argoproj.io

--- a/config/crd/bases/rollout-crd.yaml
+++ b/config/crd/bases/rollout-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: rollouts.argoproj.io
 spec:
   group: argoproj.io
@@ -662,16 +662,6 @@ spec:
                                   - type: string
                                   x-kubernetes-int-or-string: true
                               type: object
-                            plugin:
-                              properties:
-                                config:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
                             setCanaryScale:
                               properties:
                                 matchTrafficWeight:
@@ -944,10 +934,6 @@ spec:
                                 type: object
                               annotationPrefix:
                                 type: string
-                              canaryIngressAnnotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
                               stableIngress:
                                 type: string
                               stableIngresses:
@@ -3731,45 +3717,6 @@ spec:
                     type: object
                   stablePingPong:
                     type: string
-                  stepPluginStatuses:
-                    items:
-                      properties:
-                        backoff:
-                          type: string
-                        disabled:
-                          type: boolean
-                        executions:
-                          format: int32
-                          type: integer
-                        finishedAt:
-                          format: date-time
-                          type: string
-                        index:
-                          format: int32
-                          type: integer
-                        message:
-                          type: string
-                        name:
-                          type: string
-                        operation:
-                          type: string
-                        phase:
-                          type: string
-                        startedAt:
-                          format: date-time
-                          type: string
-                        status:
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
-                        updatedAt:
-                          format: date-time
-                          type: string
-                      required:
-                      - index
-                      - name
-                      - operation
-                      type: object
-                    type: array
                   weights:
                     properties:
                       additional:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.5
 
 require (
-	github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250212035559-38faac6d4127
+	github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241023053239-85db81b64541
 	github.com/argoproj-labs/argocd-operator v0.14.0-rc3
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250212035559-38faac6d4127 h1:chOb5NQfFybnoDHwdkjhC2Y9YgsSjNxgXIKLEGBgWho=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250212035559-38faac6d4127/go.mod h1:hX18xfJcnomx/k6urvDp/7+Zwa/y5aF1Mlhz5a2en4k=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241023053239-85db81b64541 h1:T4JSu0lAPWsxmbPut0h08JFQz4Q1NFXCJraXisNgKMw=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241023053239-85db81b64541/go.mod h1:seR9B+tx6AbGaya+JA61HDBFciKx7FM7t/1IMhOwXlM=
 github.com/argoproj-labs/argocd-operator v0.14.0-rc3 h1:F+YT1vysGVV/Npl9UcOAe6FpdbND1pm2vBC6YzE+iOc=
 github.com/argoproj-labs/argocd-operator v0.14.0-rc3/go.mod h1:UHe70eXnnCEfzp7EWRofMU+BFnPgZiT5OSqpuInEARA=
 github.com/argoproj/argo-cd/v2 v2.12.3 h1:Bi4QahHTnKl3esU5MplQP1wraGhaTpvgAV4GsMqc3Zc=

--- a/scripts/run-rollouts-e2e-tests.sh
+++ b/scripts/run-rollouts-e2e-tests.sh
@@ -1,155 +1,10 @@
 #!/bin/bash
 
 # The goal of this script is to run the Argo Rollouts operator tests from the argo-rollouts-manager repo against gitops-operator:
-# - Runs the cluster-scoped/namespace-scoped E2E tests of the Argo Rollouts operator
+# - Runs the (cluster-scoped) E2E tests of the Argo Rollouts operator
 # - Runs the upstream E2E tests from the argo-rollouts repo
 
 set -ex
-
-function wait_until_pods_running() {
-  echo -n "Waiting until all pods in namespace $1 are up"
-
-  # Wait for there to be only a single Pod line in 'oc get pods' (there should be no more 'terminating' pods, etc)
-  timeout="true"
-  for i in {1..30}; do
-    local num_pods="$(oc get pods --no-headers -n $1 | grep openshift-gitops-operator-controller-manager | wc -l 2>/dev/null)"
-
-    # Check the number of lines
-    if [[ "$num_lines" == "1" ]]; then
-      echo "Waiting for a single Pod entry in Namespace '$1': $num_pods"
-      sleep 5
-    else
-      timeout="false"
-      break
-    fi
-  done
-  if [ "$timeout" == "true" ]; then
-    echo -e "\n\nERROR: timeout waiting for expected number of pods"
-    return 1
-  fi
-
-  for i in {1..150}; do # timeout after 5 minutes
-    local pods="$(oc get pods --no-headers -n $1 | grep openshift-gitops-operator-controller-manager 2>/dev/null)"
-    # write it to tempfile
-    TempFile=$(mktemp)
-    oc get pods --no-headers -n $1 2>/dev/null >$TempFile
-
-    # All pods must be running
-    local not_running=$(echo "${pods}" | grep -v Running | grep -v Completed | wc -l)
-    if [[ -n "${pods}" && ${not_running} -eq 0 ]]; then
-      local all_ready=1
-      while read pod; do
-        local status=($(echo ${pod} | cut -f2 -d' ' | tr '/' ' '))
-        # All containers must be ready
-        [[ -z ${status[0]} ]] && all_ready=0 && break
-        [[ -z ${status[1]} ]] && all_ready=0 && break
-        [[ ${status[0]} -lt 1 ]] && all_ready=0 && break
-        [[ ${status[1]} -lt 1 ]] && all_ready=0 && break
-        [[ ${status[0]} -ne ${status[1]} ]] && all_ready=0 && break
-      done <${TempFile}
-      if ((all_ready)); then
-        echo -e "\nAll pods are up:\n${pods}"
-        return 0
-      fi
-    fi
-    echo -n "."
-    sleep 2
-  done
-  echo -e "\n\nERROR: timeout waiting for pods to come up\n${pods}"
-  return 1
-}
-
-function enable_rollouts_cluster_scoped_namespaces() {
-  
-  # This functions add this env var to operator:
-  # - CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES="argo-rollouts,test-rom-ns-1,rom-ns-1"
-
-  if ! [ -z $NON_OLM ]; then
-    oc set env deployment openshift-gitops-operator-controller-manager -n openshift-gitops-operator CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES="argo-rollouts,test-rom-ns-1,rom-ns-1"
-    
-  elif [ -z $CI ]; then 
-
-    oc patch -n openshift-gitops-operator subscription openshift-gitops-operator \
-      --type merge --patch '{"spec": {"config": {"env": [{"name": "CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES", "value": "argo-rollouts,test-rom-ns-1,rom-ns-1"}]}}}'
-
-  else
-
-    oc patch -n openshift-gitops-operator subscription `subscription=gitops-operator- && oc get subscription --all-namespaces | grep $subscription | head -1 | awk '{print $2}'` \
-      --type merge --patch '{"spec": {"config": {"env": [{"name": "CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES", "value": "argo-rollouts,test-rom-ns-1,rom-ns-1"}]}}}'
-  fi
-
-  # Loop to wait until CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES is added to the OpenShift GitOps Operator Deployment
-  for i in {1..30}; do
-    if oc get deployment openshift-gitops-operator-controller-manager -n openshift-gitops-operator -o jsonpath='{.spec.template.spec.containers[0].env}' | grep -q '{"name":"CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES","value":"argo-rollouts,test-rom-ns-1,rom-ns-1"}'; then
-      echo "CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES to be set"
-      break
-    else
-      echo "Waiting for CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES to be set"
-      sleep 5      
-    fi
-  done
-
-  # Verify the variable is set
-  if oc get deployment openshift-gitops-operator-controller-manager -n openshift-gitops-operator -o jsonpath='{.spec.template.spec.containers[0].env}' | grep -q '{"name":"CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES","value":"argo-rollouts,test-rom-ns-1,rom-ns-1"}'; then
-    echo "CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES is set."
-  else 
-    echo "ERROR: CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES was never set."
-    exit 1    
-  fi
-
-  # Deployment is correct, now wait for Pods to start
-  wait_until_pods_running "openshift-gitops-operator"
-
-}
-
-function disable_rollouts_cluster_scope_namespaces() {
-
-  # Remove the env var we previously added to operator
-
-  if ! [ -z $NON_OLM ]; then
-
-    oc set env deployment openshift-gitops-operator-controller-manager -n openshift-gitops-operator CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES=null
-      
-  elif [ -z $CI ]; then 
-
-    oc patch -n openshift-gitops-operator subscription openshift-gitops-operator \
-      --type json --patch '[{"op": "remove", "path": "/spec/config"}]'
-  else
-
-    oc patch -n openshift-gitops-operator subscription `subscription=gitops-operator- && oc get subscription --all-namespaces | grep $subscription | head -1 | awk '{print $2}'` \
-      --type json --patch '[{"op": "remove", "path": "/spec/config"}]'
-  fi
-
-
-  # Loop to wait until CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES is removed from the OpenShift GitOps Operator Deplyoment
-  for i in {1..30}; do
-    if oc get deployment openshift-gitops-operator-controller-manager -n openshift-gitops-operator -o jsonpath='{.spec.template.spec.containers[0].env}' | grep -q '{"name":"CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES","value":"argo-rollouts,test-rom-ns-1,rom-ns-1"}'; then
-      echo "Waiting for CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES to be removed"
-      sleep 5      
-    else
-      echo "CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES has been removed."
-      break
-    fi
-  done
-
-  # Verify it has been removed.
-  if oc get deployment openshift-gitops-operator-controller-manager -n openshift-gitops-operator -o jsonpath='{.spec.template.spec.containers[0].env}' | grep -q '{"name":"CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES","value":"argo-rollouts,test-rom-ns-1,rom-ns-1"}'; then
-    echo "ERROR: CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES was not successfully removed."
-    exit 1    
-  else 
-    echo "CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES was successfuly removed."
-  fi
-
-  # Wait for Pods to reflect the removal of the env var
-  wait_until_pods_running "openshift-gitops-operator"
-}
-
-
-enable_rollouts_cluster_scoped_namespaces
-
-trap disable_rollouts_cluster_scope_namespaces EXIT
-
-
 
 ROLLOUTS_TMP_DIR=$(mktemp -d)
 
@@ -161,7 +16,7 @@ cd "$ROLLOUTS_TMP_DIR/argo-rollouts-manager"
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in go.mod of gitops-operator (which will usually be the most recent argo-rollouts-manager commit)
-TARGET_ROLLOUT_MANAGER_COMMIT=38faac6d4127850207da231d153526a3777fa3bf
+TARGET_ROLLOUT_MANAGER_COMMIT=e1e9a742a9dd228fc3bb59ee9aba93b0800d08fa
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in the version of argo-rollouts-manager that is in go.mod
@@ -212,8 +67,6 @@ cd "$ROLLOUTS_TMP_DIR/rollouts-plugin-trafficrouter-openshift"
 git checkout $TARGET_OPENSHIFT_ROUTE_ROLLOUT_PLUGIN_COMMIT
 
 make test-e2e
-
-
 
 
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What does this PR do / why we need it**:
This PR re-targets GitOps Operator v1.16 to use Argo Rollouts Manager v0.0.5 (the most recent stable release of Argo Rollouts Manager). The corresponding Argo Rollouts version is v1.7.2.