### PR TITLE
Update to latest commit of argo-rollouts-manager 'bb5580b286c595f91dfc21382df494e5fb8f9a46'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.5
 
 require (
-	github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250212035559-38faac6d4127
+	github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250314083117-bb5580b286c5
 	github.com/argoproj-labs/argocd-operator v0.14.0-rc4
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250212035559-38faac6d4127 h1:chOb5NQfFybnoDHwdkjhC2Y9YgsSjNxgXIKLEGBgWho=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250212035559-38faac6d4127/go.mod h1:hX18xfJcnomx/k6urvDp/7+Zwa/y5aF1Mlhz5a2en4k=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250314083117-bb5580b286c5 h1:w/B/Zn/kuxTqNozZyDxAz2cXp1zC2wr67bU5nkktfNw=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250314083117-bb5580b286c5/go.mod h1:hX18xfJcnomx/k6urvDp/7+Zwa/y5aF1Mlhz5a2en4k=
 github.com/argoproj-labs/argocd-operator v0.14.0-rc4 h1:5jlgfsCrN9e2jRC5Cl7AfCHIuReHyncMAxWdeLbK3/E=
 github.com/argoproj-labs/argocd-operator v0.14.0-rc4/go.mod h1:UHe70eXnnCEfzp7EWRofMU+BFnPgZiT5OSqpuInEARA=
 github.com/argoproj/argo-cd/v2 v2.12.3 h1:Bi4QahHTnKl3esU5MplQP1wraGhaTpvgAV4GsMqc3Zc=

--- a/scripts/run-rollouts-e2e-tests.sh
+++ b/scripts/run-rollouts-e2e-tests.sh
@@ -161,7 +161,7 @@ cd "$ROLLOUTS_TMP_DIR/argo-rollouts-manager"
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in go.mod of gitops-operator (which will usually be the most recent argo-rollouts-manager commit)
-TARGET_ROLLOUT_MANAGER_COMMIT=38faac6d4127850207da231d153526a3777fa3bf
+TARGET_ROLLOUT_MANAGER_COMMIT=bb5580b286c595f91dfc21382df494e5fb8f9a46
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in the version of argo-rollouts-manager that is in go.mod
@@ -170,8 +170,11 @@ TARGET_OPENSHIFT_ROUTE_ROLLOUT_PLUGIN_COMMIT=8b4125a7f9ecffb0247df91a4c890f88c0c
 git checkout $TARGET_ROLLOUT_MANAGER_COMMIT
 
 # 1) Run E2E tests from argo-rollouts-manager repo
+# We use 'DISABLE_METRICS=true' since metrics gathering only works when run directly via Rollouts E2E tests
 
-make test-e2e
+DISABLE_METRICS=true make test-e2e
+
+
 
 # Clean up old namespaces created by test
 # NOTE: remove this once this is handled by 'make test-e2e' in argo-rollouts-manager repo
@@ -212,6 +215,7 @@ cd "$ROLLOUTS_TMP_DIR/rollouts-plugin-trafficrouter-openshift"
 git checkout $TARGET_OPENSHIFT_ROUTE_ROLLOUT_PLUGIN_COMMIT
 
 make test-e2e
+
 
 
 


### PR DESCRIPTION
**What type of PR is this?**
> /kind failing-test

**What does this PR do / why we need it**:
- Fix failing E2E Rollouts test script when run standalone, by updating to latest Argo Rollouts Manager test commit.
