### PR TITLE
[1.13] fix CVE namespace-isolation break CVE-13484

### DIFF
--- a/controllers/argocd_metrics_controller_test.go
+++ b/controllers/argocd_metrics_controller_test.go
@@ -82,16 +82,19 @@ func newMetricsReconciler(t *testing.T, namespace, name string, disableMetrics *
 
 func TestReconcile_add_namespace_label(t *testing.T) {
 	testCases := []struct {
-		instanceName string
-		namespace    string
+		instanceName  string
+		namespace     string
+		expectedLabel string
 	}{
 		{
-			instanceName: argoCDInstanceName,
-			namespace:    "openshift-gitops",
+			instanceName:  argoCDInstanceName,
+			namespace:     "openshift-gitops",
+			expectedLabel: "openshift.io/cluster-monitoring",
 		},
 		{
-			instanceName: "instance-two",
-			namespace:    "namespace-two",
+			instanceName:  "instance-two",
+			namespace:     "namespace-two",
+			expectedLabel: "openshift.io/user-monitoring",
 		},
 	}
 	for _, tc := range testCases {
@@ -102,7 +105,7 @@ func TestReconcile_add_namespace_label(t *testing.T) {
 		ns := corev1.Namespace{}
 		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: tc.namespace}, &ns)
 		assert.NilError(t, err)
-		value := ns.Labels["openshift.io/cluster-monitoring"]
+		value := ns.Labels[tc.expectedLabel]
 		assert.Equal(t, value, "true")
 	}
 }

--- a/test/openshift/e2e/sequential/1-035_validate_argocd_secret_repopulate/05-argocd_login.yaml
+++ b/test/openshift/e2e/sequential/1-035_validate_argocd_secret_repopulate/05-argocd_login.yaml
@@ -4,7 +4,7 @@ commands:
 - script: |
     api_server=$(oc get routes -n openshift-gitops --field-selector metadata.name=openshift-gitops-server -o jsonpath="{.items[*]['spec.host']}")
     password=$(oc get secret openshift-gitops-cluster -n openshift-gitops -o jsonpath='{.data.admin\.password}' | base64 -d)
-    output=$(argocd login $api_server --username admin --password $password --insecure)
+    output=$(argocd login $api_server --username admin --password $password --insecure --skip-test-tls))
 
     if ! [[ "${output}" =~ "'admin:login' logged in successfully" ]]; then
       if [[ "${output}" == *"rpc error: code = Unknown desc = server.secretkey is missing" ]]; then

--- a/test/openshift/e2e/sequential/1-040_validate_quoted_RBAC_group_names/01-login_argocd_api_server.yaml
+++ b/test/openshift/e2e/sequential/1-040_validate_quoted_RBAC_group_names/01-login_argocd_api_server.yaml
@@ -5,7 +5,7 @@ commands:
     api_server=$(oc get routes -n openshift-gitops --field-selector metadata.name=openshift-gitops-server -o jsonpath="{.items[*]['spec.host']}")
     password=$(oc get secret openshift-gitops-cluster -n openshift-gitops -o jsonpath='{.data.admin\.password}' | base64 -d)
 
-    output=$(argocd login $api_server --username admin --password $password --insecure--skip-test-tls)
+    output=$(argocd login $api_server --username admin --password $password --insecure --skip-test-tls)
 
     if ! [[ "${output}" =~ "'admin:login' logged in successfully" ]]; then
       exit 1

--- a/test/openshift/e2e/sequential/1-040_validate_quoted_RBAC_group_names/01-login_argocd_api_server.yaml
+++ b/test/openshift/e2e/sequential/1-040_validate_quoted_RBAC_group_names/01-login_argocd_api_server.yaml
@@ -5,7 +5,7 @@ commands:
     api_server=$(oc get routes -n openshift-gitops --field-selector metadata.name=openshift-gitops-server -o jsonpath="{.items[*]['spec.host']}")
     password=$(oc get secret openshift-gitops-cluster -n openshift-gitops -o jsonpath='{.data.admin\.password}' | base64 -d)
 
-    output=$(argocd login $api_server --username admin --password $password --insecure)
+    output=$(argocd login $api_server --username admin --password $password --insecure--skip-test-tls)
 
     if ! [[ "${output}" =~ "'admin:login' logged in successfully" ]]; then
       exit 1


### PR DESCRIPTION
argocd adds cluster monitoring label if the ns contains openshift- prefix

**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:
This PR fixes the namespace isolation break, caused by using cluster-monitoring label for monitoring 
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes  [GITOPS-6251](https://issues.redhat.com/browse/GITOPS-6251)

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
