### PR TITLE
Re-enable fix for multi-arch Argo Rollouts E2E test images (v1.16)

### DIFF
--- a/scripts/run-rollouts-e2e-tests.sh
+++ b/scripts/run-rollouts-e2e-tests.sh
@@ -16,7 +16,7 @@ cd "$ROLLOUTS_TMP_DIR/argo-rollouts-manager"
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in go.mod of gitops-operator (which will usually be the most recent argo-rollouts-manager commit)
-TARGET_ROLLOUT_MANAGER_COMMIT=e1e9a742a9dd228fc3bb59ee9aba93b0800d08fa
+TARGET_ROLLOUT_MANAGER_COMMIT=ee5dc2da6990ba257bf71dee279c14efeec124c0
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in the version of argo-rollouts-manager that is in go.mod


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What does this PR do / why we need it**:
- Pick up this commit from Argo Rollouts operator E2E test script:
https://github.com/argoproj-labs/argo-rollouts-manager/commit/ee5dc2da6990ba257bf71dee279c14efeec124c0#diff-c633bb4c06830e58514630b546b8ddb0b1eaaa58c34a64a993ce5565f4346e61
- This enables a fix for running Argo Rollouts upstream E2E tests on non-x64 platforms (it was previously fixed, but I broke it :smile: )