### PR TITLE
Re-enable fix for multi-arch Argo Rollouts E2E test images (master branch)

### DIFF
--- a/scripts/run-rollouts-e2e-tests.sh
+++ b/scripts/run-rollouts-e2e-tests.sh
@@ -161,7 +161,7 @@ cd "$ROLLOUTS_TMP_DIR/argo-rollouts-manager"
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in go.mod of gitops-operator (which will usually be the most recent argo-rollouts-manager commit)
-TARGET_ROLLOUT_MANAGER_COMMIT=bb5580b286c595f91dfc21382df494e5fb8f9a46
+TARGET_ROLLOUT_MANAGER_COMMIT=836ab677ea4d20a39a16c9f7c8162827cd259ee8
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in the version of argo-rollouts-manager that is in go.mod


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What does this PR do / why we need it**:
- Pick up this commit from Argo Rollouts operator E2E test script:
https://github.com/argoproj-labs/argo-rollouts-manager/commit/836ab677ea4d20a39a16c9f7c8162827cd259ee8
- This enables a fix for running Argo Rollouts upstream E2E tests on non-x64 platforms (it was previously fixed, but I broke it :smile: )