### PR TITLE
Switch to quay.io repo for nginx-unprivileged image to avoid docker hub rate limiting

### DIFF
--- a/test/examples/nginx/nginx.yaml
+++ b/test/examples/nginx/nginx.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: quay.io/nginx/nginx-unprivileged
         ports:
         - containerPort: 80


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
- At present our E2E tests are using `nginxinc/nginx-unprivileged` from Docker Hub. Unfortunately, Docker Hub has strict rate-limiting for unauthenticated users.
- Fortunately, the nginx open source project maintains `nginx-unprivileged` image on quay.io.
- I've verified that the E2E tests still pass with new image location.