### PR TITLE
Backport Subscription update logic for v1.16 Rollouts E2E tests 

### DIFF
--- a/scripts/run-rollouts-e2e-tests.sh
+++ b/scripts/run-rollouts-e2e-tests.sh
@@ -6,6 +6,150 @@
 
 set -ex
 
+function wait_until_pods_running() {
+  echo -n "Waiting until all pods in namespace $1 are up"
+
+  # Wait for there to be only a single Pod line in 'oc get pods' (there should be no more 'terminating' pods, etc)
+  timeout="true"
+  for i in {1..30}; do
+    local num_pods="$(oc get pods --no-headers -n $1 | grep openshift-gitops-operator-controller-manager | wc -l 2>/dev/null)"
+
+    # Check the number of lines
+    if [[ "$num_lines" == "1" ]]; then
+      echo "Waiting for a single Pod entry in Namespace '$1': $num_pods"
+      sleep 5
+    else
+      timeout="false"
+      break
+    fi
+  done
+  if [ "$timeout" == "true" ]; then
+    echo -e "\n\nERROR: timeout waiting for expected number of pods"
+    return 1
+  fi
+
+  for i in {1..150}; do # timeout after 5 minutes
+    local pods="$(oc get pods --no-headers -n $1 | grep openshift-gitops-operator-controller-manager 2>/dev/null)"
+    # write it to tempfile
+    TempFile=$(mktemp)
+    oc get pods --no-headers -n $1 2>/dev/null >$TempFile
+
+    # All pods must be running
+    local not_running=$(echo "${pods}" | grep -v Running | grep -v Completed | wc -l)
+    if [[ -n "${pods}" && ${not_running} -eq 0 ]]; then
+      local all_ready=1
+      while read pod; do
+        local status=($(echo ${pod} | cut -f2 -d' ' | tr '/' ' '))
+        # All containers must be ready
+        [[ -z ${status[0]} ]] && all_ready=0 && break
+        [[ -z ${status[1]} ]] && all_ready=0 && break
+        [[ ${status[0]} -lt 1 ]] && all_ready=0 && break
+        [[ ${status[1]} -lt 1 ]] && all_ready=0 && break
+        [[ ${status[0]} -ne ${status[1]} ]] && all_ready=0 && break
+      done <${TempFile}
+      if ((all_ready)); then
+        echo -e "\nAll pods are up:\n${pods}"
+        return 0
+      fi
+    fi
+    echo -n "."
+    sleep 2
+  done
+  echo -e "\n\nERROR: timeout waiting for pods to come up\n${pods}"
+  return 1
+}
+
+function enable_rollouts_cluster_scoped_namespaces() {
+  
+  # This functions add this env var to operator:
+  # - CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES="argo-rollouts,test-rom-ns-1,rom-ns-1"
+
+  if ! [ -z $NON_OLM ]; then
+    oc set env deployment openshift-gitops-operator-controller-manager -n openshift-gitops-operator CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES="argo-rollouts,test-rom-ns-1,rom-ns-1"
+    
+  elif [ -z $CI ]; then 
+
+    oc patch -n openshift-gitops-operator subscription openshift-gitops-operator \
+      --type merge --patch '{"spec": {"config": {"env": [{"name": "CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES", "value": "argo-rollouts,test-rom-ns-1,rom-ns-1"}]}}}'
+
+  else
+
+    oc patch -n openshift-gitops-operator subscription `subscription=gitops-operator- && oc get subscription --all-namespaces | grep $subscription | head -1 | awk '{print $2}'` \
+      --type merge --patch '{"spec": {"config": {"env": [{"name": "CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES", "value": "argo-rollouts,test-rom-ns-1,rom-ns-1"}]}}}'
+  fi
+
+  # Loop to wait until CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES is added to the OpenShift GitOps Operator Deployment
+  for i in {1..30}; do
+    if oc get deployment openshift-gitops-operator-controller-manager -n openshift-gitops-operator -o jsonpath='{.spec.template.spec.containers[0].env}' | grep -q '{"name":"CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES","value":"argo-rollouts,test-rom-ns-1,rom-ns-1"}'; then
+      echo "CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES to be set"
+      break
+    else
+      echo "Waiting for CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES to be set"
+      sleep 5      
+    fi
+  done
+
+  # Verify the variable is set
+  if oc get deployment openshift-gitops-operator-controller-manager -n openshift-gitops-operator -o jsonpath='{.spec.template.spec.containers[0].env}' | grep -q '{"name":"CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES","value":"argo-rollouts,test-rom-ns-1,rom-ns-1"}'; then
+    echo "CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES is set."
+  else 
+    echo "ERROR: CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES was never set."
+    exit 1    
+  fi
+
+  # Deployment is correct, now wait for Pods to start
+  wait_until_pods_running "openshift-gitops-operator"
+
+}
+
+function disable_rollouts_cluster_scope_namespaces() {
+
+  # Remove the env var we previously added to operator
+
+  if ! [ -z $NON_OLM ]; then
+
+    oc set env deployment openshift-gitops-operator-controller-manager -n openshift-gitops-operator CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES=null
+      
+  elif [ -z $CI ]; then 
+
+    oc patch -n openshift-gitops-operator subscription openshift-gitops-operator \
+      --type json --patch '[{"op": "remove", "path": "/spec/config"}]'
+  else
+
+    oc patch -n openshift-gitops-operator subscription `subscription=gitops-operator- && oc get subscription --all-namespaces | grep $subscription | head -1 | awk '{print $2}'` \
+      --type json --patch '[{"op": "remove", "path": "/spec/config"}]'
+  fi
+
+
+  # Loop to wait until CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES is removed from the OpenShift GitOps Operator Deplyoment
+  for i in {1..30}; do
+    if oc get deployment openshift-gitops-operator-controller-manager -n openshift-gitops-operator -o jsonpath='{.spec.template.spec.containers[0].env}' | grep -q '{"name":"CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES","value":"argo-rollouts,test-rom-ns-1,rom-ns-1"}'; then
+      echo "Waiting for CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES to be removed"
+      sleep 5      
+    else
+      echo "CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES has been removed."
+      break
+    fi
+  done
+
+  # Verify it has been removed.
+  if oc get deployment openshift-gitops-operator-controller-manager -n openshift-gitops-operator -o jsonpath='{.spec.template.spec.containers[0].env}' | grep -q '{"name":"CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES","value":"argo-rollouts,test-rom-ns-1,rom-ns-1"}'; then
+    echo "ERROR: CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES was not successfully removed."
+    exit 1    
+  else 
+    echo "CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES was successfuly removed."
+  fi
+
+  # Wait for Pods to reflect the removal of the env var
+  wait_until_pods_running "openshift-gitops-operator"
+}
+
+
+enable_rollouts_cluster_scoped_namespaces
+
+trap disable_rollouts_cluster_scope_namespaces EXIT
+
+
 ROLLOUTS_TMP_DIR=$(mktemp -d)
 
 cd $ROLLOUTS_TMP_DIR


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
- This change backports existing Argo Rollouts E2E test subscription logic (already on `master` branch) to 1.16 branch. 
- The script changes ensure that `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES=(..)` is set to the correct value when running Rollouts E2E tests.
