### PR TITLE
GITOPS-6759: bump github.com/argoproj-labs/argocd-operator 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.5
 
 require (
 	github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241023053239-85db81b64541
-	github.com/argoproj-labs/argocd-operator v0.14.0-rc4
+	github.com/argoproj-labs/argocd-operator v0.14.1-0.20250417144336-f66b337d3325
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,6 @@ github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241023053239-85db81b64541 h1:T4JSu0lAPWsxmbPut0h08JFQz4Q1NFXCJraXisNgKMw=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241023053239-85db81b64541/go.mod h1:seR9B+tx6AbGaya+JA61HDBFciKx7FM7t/1IMhOwXlM=
-github.com/argoproj-labs/argocd-operator v0.14.0-rc4 h1:5jlgfsCrN9e2jRC5Cl7AfCHIuReHyncMAxWdeLbK3/E=
-github.com/argoproj-labs/argocd-operator v0.14.0-rc4/go.mod h1:UHe70eXnnCEfzp7EWRofMU+BFnPgZiT5OSqpuInEARA=
 github.com/argoproj-labs/argocd-operator v0.14.1-0.20250417144336-f66b337d3325 h1:EtEfxVcYMF6E4FyqjNgXfX8/sFS15PJySsd+K2Q+tn0=
 github.com/argoproj-labs/argocd-operator v0.14.1-0.20250417144336-f66b337d3325/go.mod h1:UHe70eXnnCEfzp7EWRofMU+BFnPgZiT5OSqpuInEARA=
 github.com/argoproj/argo-cd/v2 v2.12.3 h1:Bi4QahHTnKl3esU5MplQP1wraGhaTpvgAV4GsMqc3Zc=

--- a/go.sum
+++ b/go.sum
@@ -624,6 +624,8 @@ github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241023053239-85db81b64
 github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241023053239-85db81b64541/go.mod h1:seR9B+tx6AbGaya+JA61HDBFciKx7FM7t/1IMhOwXlM=
 github.com/argoproj-labs/argocd-operator v0.14.0-rc4 h1:5jlgfsCrN9e2jRC5Cl7AfCHIuReHyncMAxWdeLbK3/E=
 github.com/argoproj-labs/argocd-operator v0.14.0-rc4/go.mod h1:UHe70eXnnCEfzp7EWRofMU+BFnPgZiT5OSqpuInEARA=
+github.com/argoproj-labs/argocd-operator v0.14.1-0.20250417144336-f66b337d3325 h1:EtEfxVcYMF6E4FyqjNgXfX8/sFS15PJySsd+K2Q+tn0=
+github.com/argoproj-labs/argocd-operator v0.14.1-0.20250417144336-f66b337d3325/go.mod h1:UHe70eXnnCEfzp7EWRofMU+BFnPgZiT5OSqpuInEARA=
 github.com/argoproj/argo-cd/v2 v2.12.3 h1:Bi4QahHTnKl3esU5MplQP1wraGhaTpvgAV4GsMqc3Zc=
 github.com/argoproj/argo-cd/v2 v2.12.3/go.mod h1:2fh6q4NX/cylbH6Ktx/KjJsX7sOBwF3jbGnO0IZyNOc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
**What type of PR is this?**
bump github.com/argoproj-labs/argocd-operator to v0.14.1-0.20250417144336-f66b337d3325

Ref commit that is picked up by this version bump- https://github.com/argoproj-labs/argocd-operator/commit/f66b337d3325856099b64f3908383e84823c564e