### PR TITLE
Update to latest commit of argo-rollouts-manager '0607aa099af96126aaeb9a228e83023f934d167a'

### DIFF
--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -180,7 +180,7 @@ metadata:
     capabilities: Deep Insights
     console.openshift.io/plugins: '["gitops-plugin"]'
     containerImage: quay.io/redhat-developer/gitops-operator
-    createdAt: "2025-03-07T13:13:07Z"
+    createdAt: "2025-04-23T12:29:26Z"
     description: Enables teams to adopt GitOps principles for managing cluster configurations
       and application delivery across hybrid multi-cluster Kubernetes environments.
     features.operators.openshift.io/disconnected: "true"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.5
 
 require (
-	github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250314083117-bb5580b286c5
+	github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250410050943-0607aa099af9
 	github.com/argoproj-labs/argocd-operator v0.14.0-rc1.0.20250407060436-d8bd8635e78c
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250314083117-bb5580b286c5 h1:w/B/Zn/kuxTqNozZyDxAz2cXp1zC2wr67bU5nkktfNw=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250314083117-bb5580b286c5/go.mod h1:hX18xfJcnomx/k6urvDp/7+Zwa/y5aF1Mlhz5a2en4k=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250410050943-0607aa099af9 h1:KVcKcUPYUqEjzNU7eTU7sq5DkbrFFC14hN/8sbapWVs=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250410050943-0607aa099af9/go.mod h1:hX18xfJcnomx/k6urvDp/7+Zwa/y5aF1Mlhz5a2en4k=
 github.com/argoproj-labs/argocd-operator v0.14.0-rc1.0.20250407060436-d8bd8635e78c h1:rBpU8LkWMK2d3hMYJOSh7U2yESEKGLnaMKyMH4ML/zE=
 github.com/argoproj-labs/argocd-operator v0.14.0-rc1.0.20250407060436-d8bd8635e78c/go.mod h1:UHe70eXnnCEfzp7EWRofMU+BFnPgZiT5OSqpuInEARA=
 github.com/argoproj/argo-cd/v2 v2.12.3 h1:Bi4QahHTnKl3esU5MplQP1wraGhaTpvgAV4GsMqc3Zc=

--- a/scripts/run-rollouts-e2e-tests.sh
+++ b/scripts/run-rollouts-e2e-tests.sh
@@ -161,7 +161,7 @@ cd "$ROLLOUTS_TMP_DIR/argo-rollouts-manager"
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in go.mod of gitops-operator (which will usually be the most recent argo-rollouts-manager commit)
-TARGET_ROLLOUT_MANAGER_COMMIT=836ab677ea4d20a39a16c9f7c8162827cd259ee8
+TARGET_ROLLOUT_MANAGER_COMMIT=0607aa099af96126aaeb9a228e83023f934d167a
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in the version of argo-rollouts-manager that is in go.mod
@@ -215,6 +215,7 @@ cd "$ROLLOUTS_TMP_DIR/rollouts-plugin-trafficrouter-openshift"
 git checkout $TARGET_OPENSHIFT_ROUTE_ROLLOUT_PLUGIN_COMMIT
 
 make test-e2e
+
 
 
 


### PR DESCRIPTION


Update to most recent 'argo-rollouts-manager' commit: https://github.com/argoproj-labs/argo-rollouts-manager/commit/0607aa099af96126aaeb9a228e83023f934d167a