### PR TITLE
chore: Update argocd-operator to latest for v1.15.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.5
 
 require (
 	github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241023053239-85db81b64541
-	github.com/argoproj-labs/argocd-operator v0.13.1-0.20250210115427-a78dcf85ec2a
+	github.com/argoproj-labs/argocd-operator v0.13.2-0.20250515115421-168deb59ac7f
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,8 @@ github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241023053239-85db81b64541 h1:T4JSu0lAPWsxmbPut0h08JFQz4Q1NFXCJraXisNgKMw=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.5-0.20241023053239-85db81b64541/go.mod h1:seR9B+tx6AbGaya+JA61HDBFciKx7FM7t/1IMhOwXlM=
-github.com/argoproj-labs/argocd-operator v0.13.1-0.20250210115427-a78dcf85ec2a h1:uvpIGA/dfKr2wCEJC9JgGSm9wLdZa+4ozdFUGxqYRQA=
-github.com/argoproj-labs/argocd-operator v0.13.1-0.20250210115427-a78dcf85ec2a/go.mod h1:C+XJqZ/Amd2+HWo8DznSo3pSUNfsC6woSrNRWGHze2g=
+github.com/argoproj-labs/argocd-operator v0.13.2-0.20250515115421-168deb59ac7f h1:JP1q+sZD2XK00KVfjXCyzFUcOksIVxZKbY0ipaU0jeM=
+github.com/argoproj-labs/argocd-operator v0.13.2-0.20250515115421-168deb59ac7f/go.mod h1:C+XJqZ/Amd2+HWo8DznSo3pSUNfsC6woSrNRWGHze2g=
 github.com/argoproj/argo-cd/v2 v2.12.3 h1:Bi4QahHTnKl3esU5MplQP1wraGhaTpvgAV4GsMqc3Zc=
 github.com/argoproj/argo-cd/v2 v2.12.3/go.mod h1:2fh6q4NX/cylbH6Ktx/KjJsX7sOBwF3jbGnO0IZyNOc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
Update Argo CD Operator to latest https://github.com/argoproj-labs/argocd-operator/commit/168deb59ac7f074b43c1147e28a942e5afaa643e