### PR TITLE
Update to latest commit of argo-rollouts-manager 'f21adc07bd2caf5b362155aaaebbc1232478c3bb'

### DIFF
--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -180,7 +180,7 @@ metadata:
     capabilities: Deep Insights
     console.openshift.io/plugins: '["gitops-plugin"]'
     containerImage: quay.io/redhat-developer/gitops-operator
-    createdAt: "2025-05-22T20:36:55Z"
+    createdAt: "2025-06-18T10:09:44Z"
     description: Enables teams to adopt GitOps principles for managing cluster configurations
       and application delivery across hybrid multi-cluster Kubernetes environments.
     features.operators.openshift.io/disconnected: "true"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.5
 
 require (
-	github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250429111039-a07ef1782da6
+	github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250617204159-f21adc07bd2c
 	github.com/argoproj-labs/argocd-operator v0.14.0-rc1.0.20250522132021-d72738feaad2
 	github.com/argoproj/argo-cd/v2 v2.12.10
 	github.com/argoproj/gitops-engine v0.7.1-0.20250129155113-faf5a4e5c37d

--- a/go.sum
+++ b/go.sum
@@ -633,8 +633,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250429111039-a07ef1782da6 h1:xcrzWnpLbMf96g2fDKMTdJttIdPKF1FX44sUjNlgeqc=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250429111039-a07ef1782da6/go.mod h1:yTwzKUV79YyI764hkXdVojGYBA9yKJk3qXx5mRuQ2Xc=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250617204159-f21adc07bd2c h1:LIMeFXb0OKcGWph+9phdYXDZf2Hml5465nihWWRBjb4=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250617204159-f21adc07bd2c/go.mod h1:yTwzKUV79YyI764hkXdVojGYBA9yKJk3qXx5mRuQ2Xc=
 github.com/argoproj-labs/argocd-operator v0.14.0-rc1.0.20250522132021-d72738feaad2 h1:uK35oxwOViSqTLd+OrRPeeyEsCrJbrXU1ahXkBzIO2Q=
 github.com/argoproj-labs/argocd-operator v0.14.0-rc1.0.20250522132021-d72738feaad2/go.mod h1:uypkOLu9XKFJMtohSRI6LWONz3D4dX/43Cie+wCC0Jk=
 github.com/argoproj/argo-cd/v2 v2.12.10 h1:Qe5cBSnGy0wXAVdMKH69gWZYZ1CwHHxSOdavE4t+sAg=

--- a/scripts/run-rollouts-e2e-tests.sh
+++ b/scripts/run-rollouts-e2e-tests.sh
@@ -161,7 +161,7 @@ cd "$ROLLOUTS_TMP_DIR/argo-rollouts-manager"
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in go.mod of gitops-operator (which will usually be the most recent argo-rollouts-manager commit)
-TARGET_ROLLOUT_MANAGER_COMMIT=a07ef1782da6cd99da6ed58e223136deb90ab4af
+TARGET_ROLLOUT_MANAGER_COMMIT=f21adc07bd2caf5b362155aaaebbc1232478c3bb
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in the version of argo-rollouts-manager that is in go.mod
@@ -215,6 +215,7 @@ cd "$ROLLOUTS_TMP_DIR/rollouts-plugin-trafficrouter-openshift"
 git checkout $TARGET_OPENSHIFT_ROUTE_ROLLOUT_PLUGIN_COMMIT
 
 make test-e2e
+
 
 
 


### PR DESCRIPTION


Update to most recent 'argo-rollouts-manager' commit: https://github.com/argoproj-labs/argo-rollouts-manager/commit/f21adc07bd2caf5b362155aaaebbc1232478c3bb