### PR TITLE
feat: watch and reconcile updates to the admin clusterrole

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -221,6 +221,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	argocdprovisioner.Register(openshift.ReconcilerHook, openshift.BuilderHook)
+
 	if err = (&argocdprovisioner.ReconcileArgoCD{
 		Client:        mgr.GetClient(),
 		Scheme:        mgr.GetScheme(),
@@ -267,8 +269,6 @@ func main() {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
-
-	argocdprovisioner.Register(openshift.ReconcilerHook)
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/controllers/argocd/openshift/openshift.go
+++ b/controllers/argocd/openshift/openshift.go
@@ -14,7 +14,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -119,7 +118,7 @@ func BuilderHook(_ *argoapp.ArgoCD, v interface{}, _ string) error {
 	logv.Info("updating the Argo CD controller to watch for changes to the admin ClusterRole")
 
 	clusterResourceHandler := handler.EnqueueRequestsFromMapFunc(adminClusterRoleMapper(bldr.Client))
-	bldr.Builder.Watches(&v1.ClusterRole{}, clusterResourceHandler,
+	bldr.Builder.Watches(&rbacv1.ClusterRole{}, clusterResourceHandler,
 		builder.WithPredicates(predicate.NewPredicateFuncs(func(o client.Object) bool {
 			return o.GetName() == "admin"
 		})))

--- a/controllers/argocd/openshift/openshift.go
+++ b/controllers/argocd/openshift/openshift.go
@@ -14,10 +14,16 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var log = logf.Log.WithName("openshift_controller_argocd")
@@ -98,6 +104,26 @@ func ReconcilerHook(cr *argoapp.ArgoCD, v interface{}, hint string) error {
 			o.Rules = policyRules
 		}
 	}
+	return nil
+}
+
+// BuilderHook updates the Argo CD controller builder to watch for changes to the "admin" ClusterRole
+func BuilderHook(_ *argoapp.ArgoCD, v interface{}, _ string) error {
+	logv := log.WithValues("module", "builder-hook")
+
+	bldr, ok := v.(*argocd.BuilderHook)
+	if !ok {
+		return nil
+	}
+
+	logv.Info("updating the Argo CD controller to watch for changes to the admin ClusterRole")
+
+	clusterResourceHandler := handler.EnqueueRequestsFromMapFunc(adminClusterRoleMapper(bldr.Client))
+	bldr.Builder.Watches(&v1.ClusterRole{}, clusterResourceHandler,
+		builder.WithPredicates(predicate.NewPredicateFuncs(func(o client.Object) bool {
+			return o.GetName() == "admin"
+		})))
+
 	return nil
 }
 
@@ -386,4 +412,34 @@ func initK8sClient() (*kubernetes.Clientset, error) {
 	}
 
 	return kClient, nil
+}
+
+// adminClusterRoleMapper maps changes to the "admin" ClusterRole to all Argo CD instances in the cluster
+func adminClusterRoleMapper(k8sClient client.Client) handler.MapFunc {
+	return func(ctx context.Context, o client.Object) []reconcile.Request {
+		var result = []reconcile.Request{}
+
+		// Only process the "admin" ClusterRole
+		if o.GetName() != "admin" {
+			return result
+		}
+
+		// Get all Argo CD instances in all namespaces
+		argocds := &argoapp.ArgoCDList{}
+		if err := k8sClient.List(ctx, argocds, &client.ListOptions{}); err != nil {
+			log.Error(err, "failed to list Argo CD instances for admin ClusterRole mapping")
+			return result
+		}
+
+		// Create reconcile requests for all Argo CD instances
+		for _, argocd := range argocds.Items {
+			namespacedName := client.ObjectKey{
+				Name:      argocd.Name,
+				Namespace: argocd.Namespace,
+			}
+			result = append(result, reconcile.Request{NamespacedName: namespacedName})
+		}
+
+		return result
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement


**What does this PR do / why we need it**:

Currently, we copy the rules from the admin cluster role when creating the application controller role. However, any updates to the admin cluster role are not synced to the application controller cluster role. So, the application controller may not have permissions to manage certain resources until the next reconciliation cycle.

Dependent on: https://github.com/argoproj-labs/argocd-operator/pull/1775

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-6367

**Test acceptance criteria**:

* [x] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:

1. Run the operator
2. Create a namespace with the managed-by label
3. Install any operator or aggregate any CRDs to the admin cluster role
4. Observe if the application controller role is updated to manage the new CRDs
