### PR TITLE
Update to latest version of Argo Rollouts Route plugin E2E tests on 'master' branch

### DIFF
--- a/scripts/run-rollouts-e2e-tests.sh
+++ b/scripts/run-rollouts-e2e-tests.sh
@@ -165,7 +165,7 @@ TARGET_ROLLOUT_MANAGER_COMMIT=ebd6207c8bb1352eac450307573fdb0dbd5e7bd0
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in the version of argo-rollouts-manager that is in go.mod
-TARGET_OPENSHIFT_ROUTE_ROLLOUT_PLUGIN_COMMIT=8b4125a7f9ecffb0247df91a4c890f88c0c523b7
+TARGET_OPENSHIFT_ROUTE_ROLLOUT_PLUGIN_COMMIT=1495bbad184a05cde955fb21dcf35d05c3e58d98
 
 git checkout $TARGET_ROLLOUT_MANAGER_COMMIT
 


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:

A fix for a race condition in the Argo Rollouts Route plugin E2E tests was made as part of https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-openshift/commit/1495bbad184a05cde955fb21dcf35d05c3e58d98

This PR adopts that commit to run it as part of gitops-operator rollouts E2E tests.

**Note**: This test doesn't currently run as part of PR E2E tests, but I have verified it manually, locally against `master` branch.


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
