### PR TITLE
chore: update argocd-operator version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.4
 
 require (
 	github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250625125608-ebd6207c8bb1
-	github.com/argoproj-labs/argocd-operator v0.15.0-rc1
+	github.com/argoproj-labs/argocd-operator v0.15.0-rc1.0.20250730094838-0a8ead1f488a
 	github.com/argoproj/argo-cd/v3 v3.0.11
 	github.com/argoproj/gitops-engine v0.7.1-0.20250520182409-89c110b5952e
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250625125608-ebd6207c8bb1 h1:TjX3ZHPA3YOmoHZutzfvOQVKRO2Jt4JvDCPvI4VhWoA=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250625125608-ebd6207c8bb1/go.mod h1:yTwzKUV79YyI764hkXdVojGYBA9yKJk3qXx5mRuQ2Xc=
-github.com/argoproj-labs/argocd-operator v0.15.0-rc1 h1:/9AQac/svD+NlJoddaR0Qpv6IZNEIuCT9T+qSMg6Mcg=
-github.com/argoproj-labs/argocd-operator v0.15.0-rc1/go.mod h1:6rbhhiij9sAuSkUjNrSIcn83lgEc7w0huuImaARS7uA=
+github.com/argoproj-labs/argocd-operator v0.15.0-rc1.0.20250730094838-0a8ead1f488a h1:HJA9NeL7dOeJVuWaw12uK97SznJMmVfzQpBZo7p4N0o=
+github.com/argoproj-labs/argocd-operator v0.15.0-rc1.0.20250730094838-0a8ead1f488a/go.mod h1:6rbhhiij9sAuSkUjNrSIcn83lgEc7w0huuImaARS7uA=
 github.com/argoproj/argo-cd/v3 v3.0.11 h1:TAqk/GEBLevlxmBCR6kSR+fCLRInPic+n8qGg+FvcR4=
 github.com/argoproj/argo-cd/v3 v3.0.11/go.mod h1:ofadwxZACMBM+CGn+d0cytbqU4Xthj/pCjp2k2gekn4=
 github.com/argoproj/gitops-engine v0.7.1-0.20250520182409-89c110b5952e h1:65x5+7Vz3HPjFoj7+mFyCckgHrAhPwy4rnDp/AveD18=


### PR DESCRIPTION
Update argocd operator version to include [this commit](https://github.com/argoproj-labs/argocd-operator/commit/0a8ead1f488a00cc132b1b4c35a80518378f04ee) having fix for the bug https://issues.redhat.com/browse/GITOPS-7361

