### PR TITLE
fix: Add missing ingress.config.openshift.io permissions

### DIFF
--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -180,7 +180,7 @@ metadata:
     capabilities: Deep Insights
     console.openshift.io/plugins: '["gitops-plugin"]'
     containerImage: quay.io/redhat-developer/gitops-operator
-    createdAt: "2025-07-10T04:40:01Z"
+    createdAt: "2025-07-30T13:03:16Z"
     description: Enables teams to adopt GitOps principles for managing cluster configurations
       and application delivery across hybrid multi-cluster Kubernetes environments.
     features.operators.openshift.io/disconnected: "true"
@@ -570,6 +570,7 @@ spec:
           - config.openshift.io
           resources:
           - clusterversions
+          - ingresses
           verbs:
           - get
           - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -222,6 +222,7 @@ rules:
   - config.openshift.io
   resources:
   - clusterversions
+  - ingresses
   verbs:
   - get
   - list

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -199,6 +199,7 @@ type ReconcileGitopsService struct {
 //+kubebuilder:rbac:groups=argoproj.io,resources=notificationsconfigurations;notificationsconfigurations/finalizers,verbs=*
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;
 //+kubebuilder:rbac:groups="apiregistration.k8s.io",resources="apiservices",verbs=get;list
+// +kubebuilder:rbac:groups=config.openshift.io,resources=ingresses,verbs=get;list;watch
 
 // Reconcile reads that state of the cluster for a GitopsService object and makes changes based on the state read
 // and what is in the GitopsService.Spec


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

Add the missing permissions for ingress config required by operator for appset reconciliation 
**Which issue(s) this PR fixes**:

Fixes [GITOPS-7374](https://issues.redhat.com/browse/GITOPS-7374) 


