### PR TITLE
fix: Argo Rollouts UI extension installation error in initContainer due to read-only access

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.4
 
 require (
 	github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250625125608-ebd6207c8bb1
-	github.com/argoproj-labs/argocd-operator v0.15.0-rc1.0.20250804091357-a26a3e3f7f8f
+	github.com/argoproj-labs/argocd-operator v0.15.0-rc1.0.20250806035040-d11fbb89eedb
 	github.com/argoproj/argo-cd/v3 v3.0.11
 	github.com/argoproj/gitops-engine v0.7.1-0.20250520182409-89c110b5952e
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250625125608-ebd6207c8bb1 h1:TjX3ZHPA3YOmoHZutzfvOQVKRO2Jt4JvDCPvI4VhWoA=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250625125608-ebd6207c8bb1/go.mod h1:yTwzKUV79YyI764hkXdVojGYBA9yKJk3qXx5mRuQ2Xc=
-github.com/argoproj-labs/argocd-operator v0.15.0-rc1.0.20250804091357-a26a3e3f7f8f h1:UY/eQHVfFXYSvAXaSzkqw982aOd+9LfZ/ctgz9CZoCM=
-github.com/argoproj-labs/argocd-operator v0.15.0-rc1.0.20250804091357-a26a3e3f7f8f/go.mod h1:6rbhhiij9sAuSkUjNrSIcn83lgEc7w0huuImaARS7uA=
+github.com/argoproj-labs/argocd-operator v0.15.0-rc1.0.20250806035040-d11fbb89eedb h1:nP5aDIfwZZKSgaorp5BlNphfSQyvv8x4EzFAlyR+de0=
+github.com/argoproj-labs/argocd-operator v0.15.0-rc1.0.20250806035040-d11fbb89eedb/go.mod h1:6rbhhiij9sAuSkUjNrSIcn83lgEc7w0huuImaARS7uA=
 github.com/argoproj/argo-cd/v3 v3.0.11 h1:TAqk/GEBLevlxmBCR6kSR+fCLRInPic+n8qGg+FvcR4=
 github.com/argoproj/argo-cd/v3 v3.0.11/go.mod h1:ofadwxZACMBM+CGn+d0cytbqU4Xthj/pCjp2k2gekn4=
 github.com/argoproj/gitops-engine v0.7.1-0.20250520182409-89c110b5952e h1:65x5+7Vz3HPjFoj7+mFyCckgHrAhPwy4rnDp/AveD18=


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Description of the problem**
When Argo Rollouts UI extension was enabled, the init container failed with the following error message
```
++ basename -- file:///home/ext-installer/rollout-extension.tar
+ ext_filename=rollout-extension.tar
++ mktemp -d -t extension-XXXXXX
mktemp: failed to create directory via template '/tmp/extension-XXXXXX': Read-only file system
```
Error message was coming from this line.
https://github.com/rh-gitops-midstream/release/blob/eddad5e34e05bcd548144f65f35152377ec5c21f/containers/argocd-extensions/install.sh#L110
This breaking change was introduced by https://github.com/argoproj-labs/argocd-operator/pull/1659 when the container root file system was made read-only using the property settingreadOnlyRootFilesystem: true.

Since the temp directory `/tmp` was not mounted as an empty dir, it was using the root file system and the installation step failed.

**What does this PR do / why we need it:**
It mounts an additional volume tmp at the mount path /tmp this will allow the tar file extraction to directory under /tmp and the mktemp command to succeed. There were some gaps in the existing unit tests, which was also addressed.
