### PR TITLE
chore: update to latest commit of argocd-operator '73f08c092df7cce922d846b5af722500dde0f2f9'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.4
 
 require (
 	github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250731075119-a100fc1d88b8
-	github.com/argoproj-labs/argocd-operator v0.14.0-rc1.0.20250820003054-2264f895048a
+	github.com/argoproj-labs/argocd-operator v0.14.0-rc1.0.20250825094300-73f08c092df7
 	github.com/argoproj/argo-cd/v3 v3.1.0-rc2
 	github.com/argoproj/gitops-engine v0.7.1-0.20250617174952-093aef0dad58
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250731075119-a100fc1d88b8 h1:6+eo7BKrNkSIhQ1nnyCUloSNrGzghlb8r8e7GokoeBo=
 github.com/argoproj-labs/argo-rollouts-manager v0.0.6-0.20250731075119-a100fc1d88b8/go.mod h1:yTwzKUV79YyI764hkXdVojGYBA9yKJk3qXx5mRuQ2Xc=
-github.com/argoproj-labs/argocd-operator v0.14.0-rc1.0.20250820003054-2264f895048a h1:t44X2qp5Skx/oJISgLcpatPNFKxGy7qMlqsxaKK52J8=
-github.com/argoproj-labs/argocd-operator v0.14.0-rc1.0.20250820003054-2264f895048a/go.mod h1:7zgj/iHFq1r1OZmLX9yxUAarttxnklMbqZb/63euXA8=
+github.com/argoproj-labs/argocd-operator v0.14.0-rc1.0.20250825094300-73f08c092df7 h1:Y7UmKUW707B7xVLjfnBVkQgM00Dmi7JOCxB9WZ092zE=
+github.com/argoproj-labs/argocd-operator v0.14.0-rc1.0.20250825094300-73f08c092df7/go.mod h1:7zgj/iHFq1r1OZmLX9yxUAarttxnklMbqZb/63euXA8=
 github.com/argoproj/argo-cd/v3 v3.1.0-rc2 h1:oT9whFw3tShGkW1WrHJReFkAJvmsgS2KGJkcRIFSnt8=
 github.com/argoproj/argo-cd/v3 v3.1.0-rc2/go.mod h1:vrxw1sapzdI3nnkwRKP84cMTzYjOKP7XsEy5fW1FQgg=
 github.com/argoproj/gitops-engine v0.7.1-0.20250617174952-093aef0dad58 h1:9ESamu44v3dR9j/I4/4Aa1Fx3QSIE8ElK1CR8Z285uk=


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
- Update gitops-operator to latest from argocd-operator

