### PR TITLE
[v1.17] Fix: Skip error log when console link is disabled and absent (#949)

### DIFF
--- a/controllers/argocd_controller.go
+++ b/controllers/argocd_controller.go
@@ -142,25 +142,26 @@ func (r *ReconcileArgoCDRoute) Reconcile(ctx context.Context, request reconcile.
 
 	consoleLink := newConsoleLink(argoCDRouteURL, "Cluster Argo CD")
 
-	found := &console.ConsoleLink{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: consoleLink.Name}, found)
-
-	if err != nil {
-		if errors.IsNotFound(err) {
-			if !isConsoleLinkDisabled() {
-				reqLogger.Info("Creating a new ConsoleLink", "ConsoleLink.Name", consoleLink.Name)
-				return reconcile.Result{}, r.Client.Create(ctx, consoleLink)
-			}
-		}
-		reqLogger.Error(err, "ConsoleLink not found", "ConsoleLink.Name", consoleLink.Name)
-		return reconcile.Result{}, err
-	}
 	if isConsoleLinkDisabled() {
 		return reconcile.Result{}, r.deleteConsoleLinkIfPresent(ctx, reqLogger)
-	} else if found.Spec.Href != argoCDRouteURL {
-		reqLogger.Info("Updating the existing ConsoleLink", "ConsoleLink.Name", consoleLink.Name)
-		found.Spec.Href = argoCDRouteURL
-		return reconcile.Result{}, r.Client.Update(ctx, found)
+	} else {
+		found := &console.ConsoleLink{}
+		err = r.Client.Get(ctx, types.NamespacedName{Name: consoleLink.Name}, found)
+
+		if err != nil {
+			if errors.IsNotFound(err) {
+				reqLogger.Info("Creating a new ConsoleLink ", "ConsoleLink.Name", consoleLink.Name)
+				return reconcile.Result{}, r.Client.Create(ctx, consoleLink)
+			} else {
+				reqLogger.Error(err, "Failed to get ConsoleLink", "ConsoleLink.Name", consoleLink.Name)
+				return reconcile.Result{}, err
+			}
+		}
+		if found.Spec.Href != argoCDRouteURL {
+			reqLogger.Info("Updating the existing ConsoleLink ", "ConsoleLink.Name", consoleLink.Name)
+			found.Spec.Href = argoCDRouteURL
+			return reconcile.Result{}, r.Client.Update(ctx, found)
+		}
 	}
 
 	reqLogger.Info("Skip reconcile: ConsoleLink already exists", "ConsoleLink.Name", consoleLink.Name)

--- a/controllers/argocd_controller_test.go
+++ b/controllers/argocd_controller_test.go
@@ -83,6 +83,7 @@ func TestReconcile_delete_consolelink(t *testing.T) {
 		name                   string
 		setEnvVarFunc          func(*testing.T, string)
 		envVar                 string
+		consoleLinkPrevExist   bool
 		consoleLinkShouldExist bool
 		wantErr                bool
 		Err                    error
@@ -92,6 +93,17 @@ func TestReconcile_delete_consolelink(t *testing.T) {
 			setEnvVarFunc: func(t *testing.T, envVar string) {
 				t.Setenv(disableArgoCDConsoleLink, envVar)
 			},
+			consoleLinkPrevExist:   true,
+			consoleLinkShouldExist: false,
+			envVar:                 "true",
+			wantErr:                false,
+		},
+		{
+			name: "DISABLE_DEFAULT_ARGOCD_CONSOLELINK is set to true and consoleLink doesn't exist previously",
+			setEnvVarFunc: func(t *testing.T, envVar string) {
+				t.Setenv(disableArgoCDConsoleLink, envVar)
+			},
+			consoleLinkPrevExist:   false,
 			consoleLinkShouldExist: false,
 			envVar:                 "true",
 			wantErr:                false,
@@ -102,6 +114,7 @@ func TestReconcile_delete_consolelink(t *testing.T) {
 				t.Setenv(disableArgoCDConsoleLink, envVar)
 			},
 			envVar:                 "false",
+			consoleLinkPrevExist:   true,
 			consoleLinkShouldExist: true,
 			wantErr:                false,
 		},
@@ -109,6 +122,7 @@ func TestReconcile_delete_consolelink(t *testing.T) {
 			name:                   "DISABLE_DEFAULT_ARGOCD_CONSOLELINK isn't set and consoleLink doesn't get deleted",
 			setEnvVarFunc:          nil,
 			envVar:                 "",
+			consoleLinkPrevExist:   true,
 			consoleLinkShouldExist: true,
 			wantErr:                false,
 		},
@@ -118,7 +132,10 @@ func TestReconcile_delete_consolelink(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			reconcileArgoCD, fakeClient := newFakeReconcileArgoCD(argoCDRoute, consoleLink)
 			consoleLink := newConsoleLink("https://test.com", "Cluster Argo CD")
-			fakeClient.Create(context.TODO(), consoleLink)
+			if test.consoleLinkPrevExist {
+				err := fakeClient.Create(context.TODO(), consoleLink)
+				assert.NilError(t, err)
+			}
 
 			if test.setEnvVarFunc != nil {
 				test.setEnvVarFunc(t, test.envVar)


### PR DESCRIPTION
cherry-pick of #949
* Skip error log when console link is disabled and absent
* Remove ConsoleLink when disabled, otherwise reconcile

(cherry picked from commit 9e522bfe8f97721bf3b8c23844f529d45acce0bd)

