### PR TITLE
[GITOPS-7475]: Default argocd instance does not get recreated after deletion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,14 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= ""
 
+
+# Try to detect Docker or Podman
+CONTAINER_RUNTIME := $(shell command -v docker 2> /dev/null || command -v podman 2> /dev/null)
+
+# If neither Docker nor Podman is found, print an error message and exit
+ifeq ($(CONTAINER_RUNTIME),)
+$(warning "No container runtime (Docker or Podman) found in PATH. Please install one of them.")
+endif
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
@@ -206,12 +214,12 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES=argo-rollouts,test-rom-ns-1,rom-ns-1,openshift-gitops  ARGOCD_CLUSTER_CONFIG_NAMESPACES=openshift-gitops  REDIS_CONFIG_PATH="build/redis"   go run ./cmd/main.go
 
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+docker-build: test ## Build $(CONTAINER_RUNTIME) image with the manager.
+	$(CONTAINER_RUNTIME) build -t ${IMG} .
 
 .PHONY: docker-push
-docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+docker-push: ## Push $(CONTAINER_RUNTIME) image with the manager.
+	$(CONTAINER_RUNTIME) push ${IMG}
 
 ##@ Build Dependencies
 
@@ -305,11 +313,11 @@ bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metada
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	$(CONTAINER_RUNTIME) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
-	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
+	$(MAKE) $(CONTAINER_RUNTIME)-push IMG=$(BUNDLE_IMG)
 
 .PHONY: opm
 OPM = ./bin/opm
@@ -346,12 +354,12 @@ endif
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) index add --container-tool $(CONTAINER_RUNTIME) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
-	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+	$(MAKE) $(CONTAINER_RUNTIME)-push IMG=$(CATALOG_IMG)
 
 
 .PHONY: gosec

--- a/Makefile
+++ b/Makefile
@@ -214,11 +214,11 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES=argo-rollouts,test-rom-ns-1,rom-ns-1,openshift-gitops  ARGOCD_CLUSTER_CONFIG_NAMESPACES=openshift-gitops  REDIS_CONFIG_PATH="build/redis"   go run ./cmd/main.go
 
 .PHONY: docker-build
-docker-build: test ## Build $(CONTAINER_RUNTIME) image with the manager.
+docker-build: test ## Build container image with the manager.
 	$(CONTAINER_RUNTIME) build -t ${IMG} .
 
 .PHONY: docker-push
-docker-push: ## Push $(CONTAINER_RUNTIME) image with the manager.
+docker-push: ## Push container image with the manager.
 	$(CONTAINER_RUNTIME) push ${IMG}
 
 ##@ Build Dependencies
@@ -359,7 +359,7 @@ catalog-build: opm ## Build a catalog image.
 # Push the catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
-	$(MAKE) $(CONTAINER_RUNTIME)-push IMG=$(CATALOG_IMG)
+	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
 
 .PHONY: gosec

--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ bundle-build: ## Build the bundle image.
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
-	$(MAKE) $(CONTAINER_RUNTIME)-push IMG=$(BUNDLE_IMG)
+	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
 
 .PHONY: opm
 OPM = ./bin/opm

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -112,7 +112,11 @@ func (r *ReconcileGitopsService) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
 				return obj.GetName() == "openshift-gitops"
 			})),
-		).
+		).Watches(&argoapp.ArgoCD{},
+		&handler.EnqueueRequestForObject{},
+		builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+			return obj.GetName() == "openshift-gitops" && obj.GetNamespace() == "openshift-gitops"
+		}))).
 		Complete(r)
 }
 

--- a/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
@@ -40,7 +40,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies that ArgoCD instance can be manually deleted and resources are cleaned up", func() {
+		It("verifies that the default ArgoCD instance from openshift-gitops namespace is recreated when deleted manually", func() {
 
 			openshiftGitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package sequential
 
 import (
+	"context"
+
 	"github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -25,6 +27,7 @@ import (
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 	statefulsetFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/statefulset"
+	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -37,13 +40,71 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies that DISABLE_DEFAULT_ARGOCD_INSTANCE env var will delete the argo cd instance from openshift-gitops, and that default Argo CD instance will be restored when the env var is removed", func() {
+		It("verifies that ArgoCD instance can be manually deleted and resources are cleaned up", func() {
 
+			openshiftGitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying that the openshift-gitops ArgoCD instance exists initially")
+			Eventually(openshiftGitopsArgoCD).Should(k8sFixture.ExistByName())
+			Eventually(openshiftGitopsArgoCD).Should(argocdFixture.BeAvailable())
+
+			By("verifying associated deployments exist")
+			deploymentsToVerify := []string{
+				"openshift-gitops-server",
+				"openshift-gitops-redis",
+				"openshift-gitops-repo-server",
+				"openshift-gitops-applicationset-controller",
+			}
+
+			for _, deplName := range deploymentsToVerify {
+				depl := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: deplName, Namespace: "openshift-gitops"},
+				}
+				Eventually(depl).Should(k8sFixture.ExistByName())
+			}
+
+			ss := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "openshift-gitops-application-controller",
+					Namespace: "openshift-gitops",
+				},
+			}
+			Eventually(ss).Should(k8sFixture.ExistByName())
+
+			By("manually deleting the openshift-gitops ArgoCD instance")
+			k8sClient, _ := utils.GetE2ETestKubeClient()
+			err = k8sClient.Delete(context.Background(), openshiftGitopsArgoCD)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying ArgoCD CR gets recreated automatically by the operator")
+			openshiftGitopsArgoCD = &v1beta1.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "openshift-gitops",
+					Namespace: "openshift-gitops",
+				},
+			}
+			Eventually(openshiftGitopsArgoCD, "3m", "5s").Should(k8sFixture.ExistByName())
+			Eventually(openshiftGitopsArgoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+
+			By("verifying deployments and statefulset are recreated and become ready")
+			for _, deplName := range deploymentsToVerify {
+				depl := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: deplName, Namespace: "openshift-gitops"},
+				}
+				Eventually(depl, "3m", "5s").Should(k8sFixture.ExistByName())
+				Eventually(depl, "5m", "5s").Should(deployment.HaveReadyReplicas(1))
+			}
+
+			Eventually(ss, "3m", "5s").Should(k8sFixture.ExistByName())
+			Eventually(ss, "5m", "5s").Should(statefulsetFixture.HaveReadyReplicas(1))
+		})
+
+		It("verifies that DISABLE_DEFAULT_ARGOCD_INSTANCE env var will delete the argo cd instance from openshift-gitops, and that default Argo CD instance will be restored when the env var is removed", func() {
 			if fixture.EnvLocalRun() {
 				Skip("when running locally, there is no subscription or operator deployment to modify, so this test is skipped.")
 				return
 			}
-
 			openshiftGitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug


**What does this PR do / why we need it**:

Before these changes, deleting the default ArgoCD instance (openshift-gitops) did not trigger its automatic recreation. However, with these changes, the default instance is now correctly recreated when it is deleted.

**Have you updated the necessary documentation?**
No documentation required.

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-7475

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:

Deploy the GitOps Operator, then delete the default openshift-gitops instance from the openshift-gitops namespace. Verify if the instance is automatically recreated.
