### PR TITLE
Fix panic in e2e tests related to local users

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -171,6 +171,9 @@ var _ = BeforeSuite(func() {
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
 		K8sClient: k8sClient,
+		LocalUsers: &argocdprovisioner.LocalUsersInfo{
+			TokenRenewalTimers: map[string]*argocdprovisioner.TokenRenewalTimer{},
+		},
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/nondefaulte2e/suite_test.go
+++ b/test/nondefaulte2e/suite_test.go
@@ -158,6 +158,9 @@ var _ = BeforeSuite(func() {
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
 		K8sClient: k8sClient,
+		LocalUsers: &argocdprovisioner.LocalUsersInfo{
+			TokenRenewalTimers: map[string]*argocdprovisioner.TokenRenewalTimer{},
+		},
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
Fixes a panic in the e2e tests due to the test setup code not properly initializing the `ReconcileArgoCD` struct.