### PR TITLE
fix(.golangci.yml): Configure staticcheck to ignore ginkgo/gomega dot-imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,13 @@ linters:
       - third_party$
       - builtin$
       - examples$
-
+  settings:
+    staticcheck:
+      # https://staticcheck.dev/docs/configuration/options/#dot_import_whitelist
+      dot-import-whitelist:
+        # Ginkgo testsuites
+        - github.com/onsi/gomega
+        - github.com/onsi/ginkgo/v2
 formatters:
   exclusions:
     generated: lax


### PR DESCRIPTION
Ignore dot imports for e2e test helpers

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
/kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring

**What does this PR do / why we need it**:

Ginkgo tests uses dot-imports that are reported as undesirable:

```go
	. "github.com/onsi/ginkgo/v2"
	. "github.com/onsi/gomega"
```

**Have you updated the necessary documentation?**

* [no] Documentation update is required by this PR.
* [no] Documentation has been updated.

**Which issue(s) this PR fixes**:

None

**Test acceptance criteria**:

* [no] Unit Test
* [no] E2E Test

**How to test changes / Special notes to the reviewer**:

Same fix in argocd-operator verified already: https://github.com/argoproj-labs/argocd-operator/pull/1880
