### PR TITLE
fix(Makefile): Use only tool name to pass `opm --container-tool`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,16 +174,16 @@ e2e-tests-sequential-ginkgo: ginkgo ## Runs kuttl e2e sequential tests
 .PHONY: e2e-tests-parallel-ginkgo ## Runs kuttl e2e parallel tests, (Defaults to 5 runs at a time)
 e2e-tests-parallel-ginkgo: ginkgo
 	@echo "Running GitOps Operator parallel Ginkgo E2E tests..."
-	$(GINKGO_CLI) -p -v -procs=5 --trace --timeout 30m -r ./test/openshift/e2e/ginkgo/parallel 
+	$(GINKGO_CLI) -p -v -procs=5 --trace --timeout 30m -r ./test/openshift/e2e/ginkgo/parallel
 
 .PHONY: e2e-tests-sequential
-e2e-tests-sequential: 
+e2e-tests-sequential:
 	CI=prow make e2e-tests-sequential-ginkgo ## Runs kuttl e2e sequentail tests
 #	@echo "Running GitOps Operator sequential E2E tests..."
 #	. ./scripts/run-kuttl-tests.sh  sequential
 
 .PHONY: e2e-tests-parallel ## Runs kuttl e2e parallel tests, (Defaults to 5 runs at a time)
-e2e-tests-parallel: 
+e2e-tests-parallel:
 	CI=prow make e2e-tests-parallel-ginkgo
 	# @echo "Running GitOps Operator parallel E2E tests..."
 	# . ./scripts/run-kuttl-tests.sh  parallel
@@ -196,12 +196,12 @@ e2e-non-olm-tests-sequential: ## Runs kuttl non-olm e2e sequentail tests
 .PHONY: e2e-non-olm-tests-parallel ## Runs kuttl non-olm e2e parallel tests, (Defaults to 5 runs at a time)
 e2e-non-olm-tests-parallel:
 	@echo "Running Non-OLM GitOps Operator parallel E2E tests..."
-	. ./hack/scripts/run-non-olm-kuttl-test.sh -t parallel	
+	. ./hack/scripts/run-non-olm-kuttl-test.sh -t parallel
 
 .PHONY: e2e-non-olm-tests-all ## Runs kuttl non-olm e2e parallel tests, (Defaults to 5 runs at a time)
 e2e-non-olm-tests-all:
 	@echo "Running Non-OLM GitOps Operator E2E tests..."
-	. ./hack/scripts/run-non-olm-kuttl-test.sh -t all		
+	. ./hack/scripts/run-non-olm-kuttl-test.sh -t all
 
 ##@ Build
 
@@ -354,7 +354,7 @@ endif
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool $(CONTAINER_RUNTIME) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) index add --container-tool $(shell basename $(CONTAINER_RUNTIME)) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push
@@ -364,7 +364,7 @@ catalog-push: ## Push a catalog image.
 
 .PHONY: gosec
 gosec: go_sec
-	$(GO_SEC) --exclude-dir "hack/upgrade-rollouts-manager"  ./... 
+	$(GO_SEC) --exclude-dir "hack/upgrade-rollouts-manager"  ./...
 
 .PHONY: lint
 lint: golangci_lint


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

Running `make catalog-build catalog-push` fails in a following way on machine with both `docker` and `podman`:

```
./bin/opm index add --container-tool /usr/bin/docker --mode semver --tag quay.io/ogondza/gitops-operator-catalog:v42.42.42 --bundles quay.io/ogondza/gitops-operator-bundle:42.42.42 
...
INFO[0000] building the index                            bundles="[quay.io/ogondza/gitops-operator-bundle:42.42.42]"
INFO[0003] Could not find optional dependencies file     file=bundle_tmp1709541790/metadata load=annotations with=./bundle_tmp1709541790
INFO[0003] Could not find optional properties file       file=bundle_tmp1709541790/metadata load=annotations with=./bundle_tmp1709541790
INFO[0003] Could not find optional dependencies file     file=bundle_tmp1709541790/metadata load=annotations with=./bundle_tmp1709541790
INFO[0003] Could not find optional properties file       file=bundle_tmp1709541790/metadata load=annotations with=./bundle_tmp1709541790
INFO[0003] Generating dockerfile                         bundles="[quay.io/ogondza/gitops-operator-bundle:42.42.42]"
INFO[0003] writing dockerfile: ./index.Dockerfile1405347037  bundles="[quay.io/ogondza/gitops-operator-bundle:42.42.42]"
INFO[0003] running podman build                          bundles="[quay.io/ogondza/gitops-operator-bundle:42.42.42]"
INFO[0003] [podman build --format docker -f ./index.Dockerfile1405347037 -t quay.io/ogondza/gitops-operator-catalog:v42.42.42 .]  bundles="[quay.io/ogondza/gitops-operator-bundle:42.42.42]"
make docker-push IMG=quay.io/ogondza/gitops-operator-catalog:v42.42.42
make[1]: Entering directory '/home/ogondza/code/argo/gitops-operator'
/usr/bin/docker push quay.io/ogondza/gitops-operator-catalog:v42.42.42
The push refers to repository [quay.io/ogondza/gitops-operator-catalog]
An image does not exist locally with the tag: quay.io/ogondza/gitops-operator-catalog
make[1]: *** [Makefile:222: docker-push] Error 1
make[1]: Leaving directory '/home/ogondza/code/argo/gitops-operator'
make: *** [Makefile:362: catalog-push] Error 2
```

Note it is tagged by `podman` (despite `--container-tool=/usr/bin/docker`), so pushing the tag by `docker` fails for obvious reasons. Turnes out `opm` ignores path silently, because it expects exact tool name (https://github.com/operator-framework/operator-registry/blob/017ab5353fec264c1fb1381b5d7088bb77b53b82/pkg/containertools/containertool.go#L34).

**Have you updated the necessary documentation?**

* [no] Documentation update is required by this PR.
* [no] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [no] Unit Test
* [no] E2E Test

**How to test changes / Special notes to the reviewer**:
