### PR TITLE
Added unit-test codecov upload

### DIFF
--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -27,3 +27,16 @@ cd ../..
 
 # Run unit
 make test
+
+# Upload coverage to codecov.io - failures here should not fail the build
+(
+  set +e
+  CODECOV_TOKEN_FILE="/var/run/codecov-token/CODECOV_TOKEN"
+  if [[ ! -f "${CODECOV_TOKEN_FILE}" ]]; then
+    echo "Codecov token not found at ${CODECOV_TOKEN_FILE}, skipping upload"
+    exit 0
+  fi
+  curl -OSs --fail-with-body https://cli.codecov.io/latest/linux/codecov
+  chmod +x codecov
+  CODECOV_TOKEN="$(cat "${CODECOV_TOKEN_FILE}")" ./codecov upload-process --flag unit-tests --file cover.out
+) || echo "Coverage upload to codecov.io failed, continuing"

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -36,7 +36,22 @@ make test
     echo "Codecov token not found at ${CODECOV_TOKEN_FILE}, skipping upload"
     exit 0
   fi
-  curl -OSs --fail-with-body https://cli.codecov.io/latest/linux/codecov
-  chmod +x codecov
-  CODECOV_TOKEN="$(cat "${CODECOV_TOKEN_FILE}")" ./codecov upload-process --flag unit-tests --file cover.out
+  CODECOV_TOKEN="$(cat "${CODECOV_TOKEN_FILE}")"
+  COMMIT="$(git rev-parse HEAD)"
+  BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+  QUERY="token=${CODECOV_TOKEN}&commit=${COMMIT}&branch=${BRANCH}&flags=unit-tests"
+
+  # Step 1: request an upload slot; response is two lines: report URL, S3 URL.
+  RESPONSE=$(curl -sX POST -H 'Accept: text/plain' "https://codecov.io/upload/v4?${QUERY}")
+  S3_URL=$(echo "${RESPONSE}" | sed -n 2p)
+  if [[ -z "${S3_URL}" ]]; then
+    echo "Codecov did not return an upload URL, aborting"
+    exit 1
+  fi
+
+  # Step 2: PUT the coverage file to GCS (Codecov uses GCS, not AWS S3;
+  # x-amz-storage-class is not supported and causes a 400).
+  curl -fiX PUT --data-binary @cover.out \
+    -H 'Content-Type: text/plain' \
+    "${S3_URL}"
 ) || echo "Coverage upload to codecov.io failed, continuing"


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
We should be tracking our code coverage, this should enable it in such away that it won't cause test to fail if upload fails.
