### PR TITLE
fix(olm-deploy): Use subscription name compatible with what tests expect

### DIFF
--- a/hack/scripts/olm-deploy.sh
+++ b/hack/scripts/olm-deploy.sh
@@ -5,7 +5,7 @@ trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
-SUBSCRIPTION_NAME="gitops-operator"
+SUBSCRIPTION_NAME="openshift-gitops-operator"
 OPERATOR_NAMESPACE="openshift-gitops-operator"
 VERSION="$(git describe --tags --dirty | sed 's/^v//')-$(date '+%Y%m%d-%H%M%S')"
 
@@ -79,7 +79,7 @@ metadata:
   namespace: $OPERATOR_NAMESPACE
 spec:
   channel: latest
-  name: $SUBSCRIPTION_NAME
+  name: gitops-operator
   installPlanApproval: Automatic
   source: devel-gitops-service-source
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
The new name is explicitly expected by some tests https://github.com/redhat-developer/gitops-operator/blob/71974fd4b6c39969dc717ce9b5b77b79fb826064/test/openshift/e2e/ginkgo/fixture/fixture.go#L429

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [n/a] Documentation update is required by this PR.
* [n/a] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [n/a] Unit Test
* [n/a] E2E Test

**How to test changes / Special notes to the reviewer**:

```
./bin/ginkgo -v -focus 'should create argocd agent principal resources, and pod should start successfully with default image' -r ./test/openshift/e2e/ginkgo/sequential/
```

@jgwest, PTAL