### PR TITLE
Update to latest commit of argo-rollouts-manager '25ad7d58a5c7dc400876ece381f9adc6148b0ad7'

### DIFF
--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -190,7 +190,7 @@ metadata:
     capabilities: Deep Insights
     console.openshift.io/plugins: '["gitops-plugin"]'
     containerImage: quay.io/redhat-developer/gitops-operator
-    createdAt: "2026-04-21T13:41:53Z"
+    createdAt: "2026-04-24T14:56:46Z"
     description: Enables teams to adopt GitOps principles for managing cluster configurations
       and application delivery across hybrid multi-cluster Kubernetes environments.
     features.operators.openshift.io/disconnected: "true"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/redhat-developer/gitops-operator
 go 1.25.5
 
 require (
-	github.com/argoproj-labs/argo-rollouts-manager v0.0.9-0.20260410162909-2c47622e05c4
+	github.com/argoproj-labs/argo-rollouts-manager v0.0.9-0.20260416124436-25ad7d58a5c7
 	github.com/argoproj-labs/argocd-image-updater v1.1.1
 	github.com/argoproj-labs/argocd-operator v0.17.0-rc1.0.20260410174833-e8a74112682f
 	github.com/argoproj/argo-cd/v3 v3.3.6

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuW
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.9-0.20260410162909-2c47622e05c4 h1:5yOGNVMV5RYpTuS4UCjFyVXZgVVwCZs9kkXMfg472Dg=
-github.com/argoproj-labs/argo-rollouts-manager v0.0.9-0.20260410162909-2c47622e05c4/go.mod h1:HUfsiRtK/HIsFTzK++im6UiWsqsswoF2yN2kpD9a27k=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.9-0.20260416124436-25ad7d58a5c7 h1:VQNrANq/TjAEaU61h8eLtClxDy5edYCyYlAsU/26RQo=
+github.com/argoproj-labs/argo-rollouts-manager v0.0.9-0.20260416124436-25ad7d58a5c7/go.mod h1:HUfsiRtK/HIsFTzK++im6UiWsqsswoF2yN2kpD9a27k=
 github.com/argoproj-labs/argocd-image-updater v1.1.1 h1:7YDaR3WX2NMsDKp0wN7TRaRRHaVHQ94tSybi2P99MGk=
 github.com/argoproj-labs/argocd-image-updater v1.1.1/go.mod h1:gMHiNrGNwNSt4ljf0ykcnmNvXBk/NJ+Z17AnZVe7V7I=
 github.com/argoproj-labs/argocd-operator v0.17.0-rc1.0.20260410174833-e8a74112682f h1:yGPeMiJsZAQk3u57vjm5NbG247jsm9C2PLI7+rryyBc=

--- a/scripts/run-rollouts-e2e-tests.sh
+++ b/scripts/run-rollouts-e2e-tests.sh
@@ -217,7 +217,7 @@ cd "$ROLLOUTS_TMP_DIR/argo-rollouts-manager"
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in go.mod of gitops-operator (which will usually be the most recent argo-rollouts-manager commit)
-TARGET_ROLLOUT_MANAGER_COMMIT=1824164aac67c5eb8e331238ec9f602809537ab4
+TARGET_ROLLOUT_MANAGER_COMMIT=25ad7d58a5c7dc400876ece381f9adc6148b0ad7
 
 # This commit value will be automatically updated by calling 'hack/upgrade-rollouts-manager/go-run.sh':
 # - It should always point to the same argo-rollouts-manager commit that is referenced in the version of argo-rollouts-manager that is in go.mod


### PR DESCRIPTION


Update to most recent 'argo-rollouts-manager' commit: https://github.com/argoproj-labs/argo-rollouts-manager/commit/25ad7d58a5c7dc400876ece381f9adc6148b0ad7