### PR TITLE
[v1.13] Backport CVE-2025-13888: fix CVE namespace-isolation break (#897)

### DIFF
--- a/controllers/argocd_metrics_controller_test.go
+++ b/controllers/argocd_metrics_controller_test.go
@@ -82,16 +82,19 @@ func newMetricsReconciler(t *testing.T, namespace, name string, disableMetrics *
 
 func TestReconcile_add_namespace_label(t *testing.T) {
 	testCases := []struct {
-		instanceName string
-		namespace    string
+		instanceName  string
+		namespace     string
+		expectedLabel string
 	}{
 		{
-			instanceName: argoCDInstanceName,
-			namespace:    "openshift-gitops",
+			instanceName:  argoCDInstanceName,
+			namespace:     "openshift-gitops",
+			expectedLabel: "openshift.io/cluster-monitoring",
 		},
 		{
-			instanceName: "instance-two",
-			namespace:    "namespace-two",
+			instanceName:  "instance-two",
+			namespace:     "namespace-two",
+			expectedLabel: "openshift.io/user-monitoring",
 		},
 	}
 	for _, tc := range testCases {
@@ -102,7 +105,7 @@ func TestReconcile_add_namespace_label(t *testing.T) {
 		ns := corev1.Namespace{}
 		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: tc.namespace}, &ns)
 		assert.NilError(t, err)
-		value := ns.Labels["openshift.io/cluster-monitoring"]
+		value := ns.Labels[tc.expectedLabel]
 		assert.Equal(t, value, "true")
 	}
 }


### PR DESCRIPTION
Backport of upstream fix for CVE-2025-13888 to `v1.13`.

- Upstream commit: [bc6ac3e03d](https://github.com/redhat-developer/gitops-operator/commit/bc6ac3e03d7c8b3db5d8f1770c868396a4c2dcef) — fix CVE namespace-isolation break (#897)
- Cherry-picked with `git cherry-pick -x` (original author preserved).

Apply was clean against the current tip of the target branch. No code changes on top of the upstream fix.

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**: