### PR TITLE
Update component versions for 1.18

### DIFF
--- a/test/openshift/e2e/ginkgo/parallel/1-031_validate_toolchain_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-031_validate_toolchain_test.go
@@ -85,20 +85,25 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 		It("verifies that toolchain versions have the expected values", func() {
 
 			// These variables need to be maintained according to the component matrix: https://spaces.redhat.com/display/GITOPS/GitOps+Component+Matrix
-			expected_kustomizeVersion := "v5.7.1"
-			expected_helmVersion := "v3.18.6"
-			expected_argocdVersion := "v3.1.16"
-
+			var expected_kustomizeVersion string
+			var expected_helmVersion string
+			var expected_argocdVersion string
 			var expected_dexVersion string
 			var expected_redisVersion string
 
 			if os.Getenv("CI") == "prow" {
 				// when running against openshift-ci
+				expected_kustomizeVersion = "v5.7.0"
+				expected_helmVersion = "v3.18.4"
+				expected_argocdVersion = "v3.1.5"
 				expected_dexVersion = "v2.43.0"
 				expected_redisVersion = "7.2.7"
 
 			} else {
 				// when running against RC/ released version of gitops
+				expected_kustomizeVersion = "v5.7.1"
+				expected_helmVersion = "v3.18.6"
+				expected_argocdVersion = "v3.1.16"
 				expected_dexVersion = "v2.43.1"
 				expected_redisVersion = "7.2.11"
 			}

--- a/test/openshift/e2e/ginkgo/parallel/1-031_validate_toolchain_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-031_validate_toolchain_test.go
@@ -85,9 +85,9 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 		It("verifies that toolchain versions have the expected values", func() {
 
 			// These variables need to be maintained according to the component matrix: https://spaces.redhat.com/display/GITOPS/GitOps+Component+Matrix
-			expected_kustomizeVersion := "v5.7.0"
-			expected_helmVersion := "v3.18.4"
-			expected_argocdVersion := "v3.1.5"
+			expected_kustomizeVersion := "v5.7.1"
+			expected_helmVersion := "v3.18.6"
+			expected_argocdVersion := "v3.1.16"
 
 			var expected_dexVersion string
 			var expected_redisVersion string
@@ -99,8 +99,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			} else {
 				// when running against RC/ released version of gitops
-				expected_dexVersion = "v2.43.0"
-				expected_redisVersion = "7.2.10"
+				expected_dexVersion = "v2.43.1"
+				expected_redisVersion = "7.2.11"
 			}
 
 			By("locating pods containing toolchain in openshift-gitops")


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does this PR do / why we need it**:
This PR fixes an E2E test (`1-031_validate_toolchain`) that is currently failing against the GitOps Operator 1.18.6 RC builds due to version mismatches. 

Component versions updated to align with the latest 1.18.6 component matrix:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes 

**Test acceptance criteria**:

* [ ] Unit Test
* [x] E2E Test

**How to test changes / Special notes to the reviewer**:
To verify this fix locally, ensure you are logged into a cluster running the 1.18.6 RC build and run the following isolated Ginkgo command:

```bash
./bin/ginkgo -v -focus="1-031_validate_toolchain" -r ./test/openshift/e2e/ginkgo/parallel