### PR TITLE
Test updates for 1.20.4 release

### DIFF
--- a/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -405,7 +405,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			By("Create ArgoCD instance")
 
-			argoCD.Spec.ArgoCDAgent.Principal.Image = "quay.io/argoprojlabs/argocd-agent:v0.5.0"
+			argoCD.Spec.ArgoCDAgent.Principal.Image = "quay.io/argoprojlabs/argocd-agent:v0.7.7"
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 
 			By("Verify expected resources are created for principal pod")
@@ -416,7 +416,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			container := deploymentFixture.GetTemplateSpecContainerByName(argoCDAgentPrincipalName, *principalDeployment)
 			Expect(container).ToNot(BeNil())
-			Expect(container.Image).To(Equal("quay.io/argoprojlabs/argocd-agent:v0.5.0"))
+			Expect(container.Image).To(Equal("quay.io/argoprojlabs/argocd-agent:v0.7.7"))
 
 			By("Verify environment variables are set correctly")
 
@@ -435,7 +435,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				ac.Spec.ArgoCDAgent.Principal.LogFormat = "json"
 				ac.Spec.ArgoCDAgent.Principal.Server.KeepAliveMinInterval = "60s"
 				ac.Spec.ArgoCDAgent.Principal.Server.EnableWebSocket = ptr.To(true)
-				ac.Spec.ArgoCDAgent.Principal.Image = "quay.io/argoprojlabs/argocd-agent:v0.5.1"
+				ac.Spec.ArgoCDAgent.Principal.Image = "quay.io/argoprojlabs/argocd-agent:v0.7.7"
 
 				ac.Spec.ArgoCDAgent.Principal.Namespace.AllowedNamespaces = []string{"agent-managed", "agent-autonomous"}
 				ac.Spec.ArgoCDAgent.Principal.Namespace.EnableNamespaceCreate = ptr.To(true)
@@ -482,7 +482,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					if container == nil {
 						return false
 					}
-					return container.Image == "quay.io/argoprojlabs/argocd-agent:v0.5.1"
+					return container.Image == "quay.io/argoprojlabs/argocd-agent:v0.7.7"
 				}, "120s", "5s").Should(BeTrue(), "Principal deployment should have the updated image")
 
 			By("verify that deployment is in Ready state")

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -372,7 +372,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			By("Create ArgoCD instance")
 
-			argoCD.Spec.ArgoCDAgent.Agent.Image = "quay.io/argoprojlabs/argocd-agent:v0.5.0"
+			argoCD.Spec.ArgoCDAgent.Agent.Image = "quay.io/argoprojlabs/argocd-agent:v0.7.7"
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 
 			By("Verify expected resources are created for agent pod")
@@ -383,7 +383,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			container := deploymentFixture.GetTemplateSpecContainerByName(argoCDAgentAgentName, *agentDeployment)
 			Expect(container).ToNot(BeNil())
-			Expect(container.Image).To(Equal("quay.io/argoprojlabs/argocd-agent:v0.5.0"))
+			Expect(container.Image).To(Equal("quay.io/argoprojlabs/argocd-agent:v0.7.7"))
 
 			By("Verify environment variables are set correctly")
 
@@ -400,7 +400,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 				ac.Spec.ArgoCDAgent.Agent.LogLevel = "trace"
 				ac.Spec.ArgoCDAgent.Agent.LogFormat = "json"
-				ac.Spec.ArgoCDAgent.Agent.Image = "quay.io/argoprojlabs/argocd-agent:v0.5.1"
+				ac.Spec.ArgoCDAgent.Agent.Image = "quay.io/argoprojlabs/argocd-agent:v0.7.7"
 
 				ac.Spec.ArgoCDAgent.Agent.Client.KeepAliveInterval = "60s"
 				ac.Spec.ArgoCDAgent.Agent.Client.EnableWebSocket = ptr.To(true)
@@ -430,7 +430,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					if container == nil {
 						return false
 					}
-					return container.Image == "quay.io/argoprojlabs/argocd-agent:v0.5.1"
+					return container.Image == "quay.io/argoprojlabs/argocd-agent:v0.7.7"
 				}, "120s", "5s").Should(BeTrue(), "Agent deployment should have the updated image")
 
 			By("Verify environment variables are updated correctly")


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What does this PR do / why we need it**:
This PR updates the agent images for 1.20.4 RC build. 

The tests were previously asserting outdated development image tags (`v0.5.0` / `v0.5.1`), causing them to fail against the current 1.20.4 release release candidate. 

Changes include:
* **`1-051_validate_argocd_agent_principal_test.go`**: Bumped the expected principal agent image assertion to `v0.7.7`.
* **`1-052_validate_argocd_agent_agent_test.go`**: Bumped the expected cluster-side agent image assertion to `v0.7.7`.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes # 

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:

```bash
./bin/ginkgo -v -focus="1-051_validate_argocd_agent_principal|1-052_validate_argocd_agent_agent" -r ./test/openshift/e2e/ginkgo/sequential