### PR TITLE
ci fix - hardcode kustomize download to bypass github api rate limits

### DIFF
--- a/openshift-ci/build-root/Dockerfile
+++ b/openshift-ci/build-root/Dockerfile
@@ -3,6 +3,7 @@
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-4.16
 
 ARG KUBECTL_KUTTL_VERSION=0.12.1
+ARG KUSTOMIZE_VERSION=v5.1.1
 ARG OPERATOR_SDK_VERSION=1.35.0
 
 # Install kubectl tool which is used in e2e-tests
@@ -18,8 +19,7 @@ RUN curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/relea
      chmod +x /usr/local/bin/argocd
 
 # Install Kustomize
-RUN wget https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh && \
-    bash install_kustomize.sh /usr/local/bin && rm install_kustomize.sh
+RUN curl -sSL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz | tar -xz -C /usr/local/bin
 
 # Install operator-sdk
 RUN curl -L -o /usr/local/bin/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64 && \


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What does this PR do / why we need it**:
Fixes flaky OpenShift CI `images` job failures. 

The `install_kustomize.sh` script queries the GitHub API to find the Kustomize release version. Due to shared CI IPs, GitHub frequently blocks this with a `403 API Rate Limit Exceeded` error. The download silently fails, causing the `tar` command to crash the build. This PR replaces the script with a direct `curl | tar` download of the release tarball (matching how we install `kubectl` and `argocd`). This bypasses the GitHub API entirely and makes the CI build stable.

**Have you updated the necessary documentation?**
* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
Fixes # N/A

**Test acceptance criteria**:
* [ ] Unit Test
* [x] E2E Test

**How to test changes / Special notes to the reviewer**:
podman build -t ci-test .
podman run --rm ci-test kustomize version