### PR TITLE
hardcode kustomize download to bypass github api rate limits

### DIFF
--- a/openshift-ci/build-root/Dockerfile
+++ b/openshift-ci/build-root/Dockerfile
@@ -5,6 +5,7 @@ USER root
 
 ARG OPERATOR_SDK_VERSION=1.35.0
 ARG KUSTOMIZE_VERSION=v5.8.1
+ARG KUSTOMIZE_SHA256="029a7f0f4e1932c52a0476cf02a0fd855c0bb85694b82c338fc648dcb53a819d"
 
 # Install kubectl tool which is used in e2e-tests
 RUN curl -sSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
@@ -14,8 +15,11 @@ RUN curl -sSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s 
 RUN curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64 && \
      chmod +x /usr/local/bin/argocd
 
-# Install Kustomize
-RUN curl -sSL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz | tar -xz -C /usr/local/bin
+# Install Kustomize with checksum validation
+RUN curl -sSL -o kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
+    echo "${KUSTOMIZE_SHA256}  kustomize.tar.gz" | sha256sum -c - && \
+    tar -xzf kustomize.tar.gz -C /usr/local/bin && \
+    rm kustomize.tar.gz
 
 # Install operator-sdk
 RUN curl -L -o /usr/local/bin/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64 && \

--- a/openshift-ci/build-root/Dockerfile
+++ b/openshift-ci/build-root/Dockerfile
@@ -4,6 +4,7 @@ FROM quay.io/devtools_gitops/go-toolset:1.26.2
 USER root
 
 ARG OPERATOR_SDK_VERSION=1.35.0
+ARG KUSTOMIZE_VERSION=v5.8.1
 
 # Install kubectl tool which is used in e2e-tests
 RUN curl -sSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
@@ -14,8 +15,7 @@ RUN curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/relea
      chmod +x /usr/local/bin/argocd
 
 # Install Kustomize
-RUN wget https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh && \
-    bash install_kustomize.sh /usr/local/bin && rm install_kustomize.sh
+RUN curl -sSL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz | tar -xz -C /usr/local/bin
 
 # Install operator-sdk
 RUN curl -L -o /usr/local/bin/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64 && \


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What does this PR do / why we need it**:
Fixes flaky OpenShift CI `images` job failures. 

The `install_kustomize.sh` script in the CI Dockerfile queries the GitHub API, which frequently gets blocked by rate limits (`403 API Rate Limit Exceeded`) due to shared CI IPs. This causes a silent download failure and crashes the build during the `tar` extraction. This PR replaces the script with a direct `curl | tar` download of Kustomize `v5.8.1`. This bypasses the GitHub API completely and makes the CI build deterministic.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes # 

**Test acceptance criteria**:

* [ ] Unit Test
* [x] E2E Test

**How to test changes / Special notes to the reviewer**:
podman build -t ci-test .