### PR TITLE
Feat: disable GitOps Service and default instance on xKS clusters

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -224,7 +224,6 @@ func main() {
 
 	// Setup Scheme for OpenShift Config if available
 	// Disables default Argo CD instance if the cluster doesn't contain OpenShift config API
-
 	if util.IsConfigAPIFound() {
 		registerComponentOrExit(mgr, configv1.AddToScheme)
 	}
@@ -267,7 +266,6 @@ func main() {
 		}
 	} else {
 		setupLog.Info("skipping GitopsService controller setup", "reason", "OpenShift Config API not available")
-
 	}
 
 	if util.IsRouteAPIFound() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -223,8 +223,13 @@ func main() {
 	registerComponentOrExit(mgr, argov1beta1api.AddToScheme)
 
 	// Setup Scheme for OpenShift Config if available
+	var disableDefault bool
+	disableDefault = strings.ToLower(os.Getenv(common.DisableDefaultInstallEnvVar)) == "true"
 	if util.IsConfigAPIFound() {
 		registerComponentOrExit(mgr, configv1.AddToScheme)
+	} else {
+		setupLog.Info("Non-OpenShift cluster detected, disabling default Argo CD instance")
+		disableDefault = true
 	}
 
 	registerComponentOrExit(mgr, rolloutManagerApi.AddToScheme)
@@ -257,7 +262,7 @@ func main() {
 	if err = (&controllers.ReconcileGitopsService{
 		Client:                client,
 		Scheme:                mgr.GetScheme(),
-		DisableDefaultInstall: strings.ToLower(os.Getenv(common.DisableDefaultInstallEnvVar)) == "true",
+		DisableDefaultInstall: disableDefault,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GitopsService")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -223,6 +223,7 @@ func main() {
 	registerComponentOrExit(mgr, argov1beta1api.AddToScheme)
 
 	// Setup Scheme for OpenShift Config if available
+	// Disables default Argo CD instance if the cluster doesn't contain OpenShift config API
 	var disableDefault bool
 	disableDefault = strings.ToLower(os.Getenv(common.DisableDefaultInstallEnvVar)) == "true"
 	if util.IsConfigAPIFound() {
@@ -259,13 +260,17 @@ func main() {
 		}
 	}
 
-	if err = (&controllers.ReconcileGitopsService{
-		Client:                client,
-		Scheme:                mgr.GetScheme(),
-		DisableDefaultInstall: disableDefault,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "GitopsService")
-		os.Exit(1)
+	if util.IsOpenShiftCluster() {
+		if err = (&controllers.ReconcileGitopsService{
+			Client:                client,
+			Scheme:                mgr.GetScheme(),
+			DisableDefaultInstall: disableDefault,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "GitopsService")
+			os.Exit(1)
+		}
+	} else {
+		setupLog.Info("Non-OpenShift cluster detected, skipping GitopsService controller setup")
 	}
 
 	if util.IsRouteAPIFound() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -224,13 +224,9 @@ func main() {
 
 	// Setup Scheme for OpenShift Config if available
 	// Disables default Argo CD instance if the cluster doesn't contain OpenShift config API
-	var disableDefault bool
-	disableDefault = strings.ToLower(os.Getenv(common.DisableDefaultInstallEnvVar)) == "true"
+
 	if util.IsConfigAPIFound() {
 		registerComponentOrExit(mgr, configv1.AddToScheme)
-	} else {
-		setupLog.Info("Non-OpenShift cluster detected, disabling default Argo CD instance")
-		disableDefault = true
 	}
 
 	registerComponentOrExit(mgr, rolloutManagerApi.AddToScheme)
@@ -264,13 +260,14 @@ func main() {
 		if err = (&controllers.ReconcileGitopsService{
 			Client:                client,
 			Scheme:                mgr.GetScheme(),
-			DisableDefaultInstall: disableDefault,
+			DisableDefaultInstall: strings.ToLower(os.Getenv(common.DisableDefaultInstallEnvVar)) == "true",
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "GitopsService")
 			os.Exit(1)
 		}
 	} else {
-		setupLog.Info("Non-OpenShift cluster detected, skipping GitopsService controller setup")
+		setupLog.Info("skipping GitopsService controller setup", "reason", "OpenShift Config API not available")
+
 	}
 
 	if util.IsRouteAPIFound() {

--- a/controllers/argocd/argocd.go
+++ b/controllers/argocd/argocd.go
@@ -94,7 +94,7 @@ func getArgoDexSpec() *argoapp.ArgoCDDexSpec {
 }
 
 func getArgoSSOSpec(client client.Client) *argoapp.ArgoCDSSOSpec {
-	if !util.IsConfigAPIFound() {
+	if !util.IsOpenShiftCluster() {
 		log.Info("non-OpenShift cluster detected, skipping SSO/Dex configuration")
 		return nil
 	}

--- a/controllers/argocd/argocd.go
+++ b/controllers/argocd/argocd.go
@@ -21,12 +21,16 @@ import (
 
 	argoapp "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	argoappController "github.com/argoproj-labs/argocd-operator/controllers/argocd"
+	"github.com/redhat-developer/gitops-operator/controllers/util"
 	v1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 )
+
+var log = logf.Log.WithName("controller_argocd")
 
 var (
 	defaultAdminPolicy = "g, system:cluster-admins, role:admin\ng, cluster-admins, role:admin\n"
@@ -90,7 +94,12 @@ func getArgoDexSpec() *argoapp.ArgoCDDexSpec {
 }
 
 func getArgoSSOSpec(client client.Client) *argoapp.ArgoCDSSOSpec {
-	if argoappController.IsOpenShiftCluster() && argoappController.IsExternalAuthenticationEnabledOnCluster(context.TODO(), client) {
+	if !util.IsConfigAPIFound() {
+		log.Info("non-OpenShift cluster detected, skipping SSO/Dex configuration")
+		return nil
+	}
+	if argoappController.IsExternalAuthenticationEnabledOnCluster(context.TODO(), client) {
+		log.Info("external authentication enabled on cluster, skipping SSO/Dex configuration")
 		return nil
 	}
 	return &argoapp.ArgoCDSSOSpec{

--- a/controllers/argocd/argocd_test.go
+++ b/controllers/argocd/argocd_test.go
@@ -22,6 +22,7 @@ import (
 
 	argoapp "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/redhat-developer/gitops-operator/controllers/util"
 	"gotest.tools/assert"
 	v1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
@@ -30,6 +31,9 @@ import (
 )
 
 func TestArgoCD(t *testing.T) {
+	util.SetConfigAPIFound(true)
+	defer util.SetConfigAPIFound(false)
+
 	scheme := runtime.NewScheme()
 	_ = argoapp.AddToScheme(scheme)
 	_ = configv1.AddToScheme(scheme)
@@ -199,6 +203,9 @@ func TestArgoCD(t *testing.T) {
 }
 
 func TestDexConfiguration(t *testing.T) {
+	util.SetConfigAPIFound(true)
+	defer util.SetConfigAPIFound(false)
+
 	scheme := runtime.NewScheme()
 	_ = argoapp.AddToScheme(scheme)
 	_ = configv1.AddToScheme(scheme)
@@ -222,4 +229,20 @@ func TestDexConfiguration(t *testing.T) {
 		DefaultPolicy: &testDefaultArgoCDRole,
 	}
 	assert.DeepEqual(t, testArgoCD.Spec.RBAC, testRBAC)
+}
+
+func TestSSOSkippedOnNonOpenShift(t *testing.T) {
+	util.SetConfigAPIFound(false)
+
+	scheme := runtime.NewScheme()
+	_ = argoapp.AddToScheme(scheme)
+	_ = configv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	testArgoCD, _ := NewCR("openshift-gitops", "openshift-gitops", fakeClient)
+
+	assert.Assert(t, testArgoCD.Spec.SSO == nil, "SSO should be nil on non-OpenShift clusters")
 }

--- a/controllers/argocd/argocd_test.go
+++ b/controllers/argocd/argocd_test.go
@@ -233,6 +233,7 @@ func TestDexConfiguration(t *testing.T) {
 
 func TestSSOSkippedOnNonOpenShift(t *testing.T) {
 	util.SetConfigAPIFound(false)
+	defer util.SetConfigAPIFound(true)
 
 	scheme := runtime.NewScheme()
 	_ = argoapp.AddToScheme(scheme)

--- a/controllers/argocd/argocd_test.go
+++ b/controllers/argocd/argocd_test.go
@@ -231,9 +231,9 @@ func TestDexConfiguration(t *testing.T) {
 	assert.DeepEqual(t, testArgoCD.Spec.RBAC, testRBAC)
 }
 
+// kubernetes environment test, no defer required as the Config API is false by default
 func TestSSOSkippedOnNonOpenShift(t *testing.T) {
 	util.SetConfigAPIFound(false)
-	defer util.SetConfigAPIFound(true)
 
 	scheme := runtime.NewScheme()
 	_ = argoapp.AddToScheme(scheme)

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -121,6 +121,11 @@ func IsConfigAPIFound() bool {
 	return configAPIFound
 }
 
+// used as a shortcut to check if the cluster is an OpenShift cluster
+func IsOpenShiftCluster() bool {
+	return configAPIFound
+}
+
 // verify if the Config.Openshift.io API is found
 func verifyConfigAPI() error {
 	found, err := argoutil.VerifyAPI(configv1.GroupName, configv1.GroupVersion.Version)

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -116,12 +116,12 @@ func InspectCluster() error {
 	return stderrors.Join(errs...)
 }
 
-// used as a shortcut to check if the Config.Openshift.io API is found
+// IsConfigAPIFound return true if the CRD config.openshift.io is available in the cluster and false otherwise.
 func IsConfigAPIFound() bool {
 	return configAPIFound
 }
 
-// used as a shortcut to check if the cluster is an OpenShift cluster
+// IsOpenShiftCluster uses IsConfigAPIFound to check if the cluster is an OpenShift cluster.
 func IsOpenShiftCluster() bool {
 	return IsConfigAPIFound()
 }
@@ -136,6 +136,7 @@ func verifyConfigAPI() error {
 	return nil
 }
 
+// IsConsoleAPIFound return true if the CRD console.openshift.io is available in the cluster.
 func IsConsoleAPIFound() bool {
 	return consoleAPIFound
 }
@@ -149,6 +150,7 @@ func verifyConsoleAPI() error {
 	return nil
 }
 
+// IsRouteAPIFound return true if the CRD route.openshift.io is available in the cluster.
 func IsRouteAPIFound() bool {
 	return routeAPIFound
 }
@@ -174,10 +176,12 @@ func verifyMonitoringAPI() error {
 	return nil
 }
 
+// IsMonitoringAPIFound return true if the CRD monitoring.coreos.com is available in the cluster.
 func IsMonitoringAPIFound() bool {
 	return monitoringAPIFound
 }
 
+// IsTemplateAPIFound return true if the CRD template.openshift.io is available in the cluster.
 func IsTemplateAPIFound() bool {
 	return templateAPIFound
 }
@@ -191,6 +195,7 @@ func verifyTemplateAPI() error {
 	return nil
 }
 
+// IsAppsAPIFound return true if the CRD apps.openshift.io is available in the cluster.
 func IsAppsAPIFound() bool {
 	return appsAPIFound
 }
@@ -204,6 +209,7 @@ func verifyAppsAPI() error {
 	return nil
 }
 
+// IsOAuthAPIFound return true if the CRD oauth.openshift.io is available in the cluster.
 func IsOAuthAPIFound() bool {
 	return oauthAPIFound
 }
@@ -217,6 +223,7 @@ func verifyOAuthAPI() error {
 	return nil
 }
 
+// IsOLMAPIFound return true if the CRD operators.coreos.com is available in the cluster.
 func IsOLMAPIFound() bool {
 	return olmAPIFound
 }

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -116,14 +116,14 @@ func InspectCluster() error {
 	return stderrors.Join(errs...)
 }
 
-// used as a shortcut to check if the cluster is an OpenShift cluster
+// used as a shortcut to check if the Config.Openshift.io API is found
 func IsConfigAPIFound() bool {
 	return configAPIFound
 }
 
 // used as a shortcut to check if the cluster is an OpenShift cluster
 func IsOpenShiftCluster() bool {
-	return configAPIFound
+	return IsConfigAPIFound()
 }
 
 // verify if the Config.Openshift.io API is found


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:

The OpenShift GitOps Operator assumes an OpenShift cluster today: it registers the `GitopsService` controller, auto-creates a default Argo CD instance in `openshift-gitops`, and configures Dex/SSO against OpenShift authentication.
On xKS (non-OpenShift Kubernetes) clusters, those behaviors are not required and can cause failures.
  
This PR detects non-OpenShift clusters at startup by checking whether the `config.openshift.io` API is present (via existing `InspectCluster()` discovery). When it is not found, the operator:
  1. **Skips `ReconcileGitopsService` controller registration** — this controller manages OpenShift-specific resources (default Argo CD instance, console plugin backend, RBAC, namespace setup, and related reconciliation) that do not apply on xKS.
  2. **Prevents default Argo CD instance provisioning** — no `openshift-gitops` Argo CD CR is created on xKS.
  3. **Skips SSO/Dex in the default Argo CD CR template** — `getArgoSSOSpec()` returns `nil` on non-OpenShift clusters, so Dex is not configured when `NewCR()` is used.
  On OpenShift clusters, behavior is unchanged. The existing `DISABLE_DEFAULT_ARGOCD_INSTANCE` environment variable continues to work as before.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://redhat.atlassian.net/browse/GITOPS-9943

**Test acceptance criteria**:

* [x] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:

On xKS (vanilla Kubernetes or cluster without config.openshift.io):
  1. Install the operator.
  2. Confirm operator logs contain: Non-OpenShift cluster detected, skipping GitopsService controller setup
  3. Confirm no Argo CD CR named openshift-gitops is created in openshift-gitops.
  4. Confirm the GitopsService controller is not running (no reconciliation of console plugin backend resources).

On OpenShift:
  1. Install the operator without DISABLE_DEFAULT_ARGOCD_INSTANCE.
  2. Confirm default Argo CD instance is still created in openshift-gitops.
  3. Confirm GitopsService controller runs and console plugin resources are reconciled as before.