### PR TITLE
chore(imageupdater): sync Image Updater CRD with upstream

### DIFF
--- a/bundle/manifests/argocd-image-updater.argoproj.io_imageupdaters.yaml
+++ b/bundle/manifests/argocd-image-updater.argoproj.io_imageupdaters.yaml
@@ -14,7 +14,20 @@ spec:
     singular: imageupdater
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.applicationsMatched
+      name: Apps
+      type: integer
+    - jsonPath: .status.imagesManaged
+      name: Images
+      type: integer
+    - jsonPath: .status.lastCheckedAt
+      name: Last Checked
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ImageUpdater is the Schema for the imageupdaters API
@@ -306,6 +319,25 @@ spec:
                                 Branch to commit updates to.
                                 Required if write-back method is Git and this is not specified at the spec level.
                               type: string
+                            pullRequest:
+                              description: |-
+                                PullRequest configures creation of pull requests when writing back image updates to Git.
+                                When set, the controller opens a PR instead of pushing to the branch.
+                                If not specified write back config method is `git`.
+                              properties:
+                                github:
+                                  description: GitHub configures PR creation via the
+                                    GitHub API.
+                                  type: object
+                                gitlab:
+                                  description: GitLab configures MR creation via the
+                                    GitLab API.
+                                  type: object
+                              type: object
+                              x-kubernetes-validations:
+                              - message: Exactly one of github or gitlab must be set
+                                rule: '(has(self.github) ? 1 : 0) + (has(self.gitlab)
+                                  ? 1 : 0) == 1'
                             repository:
                               description: |-
                                 Repository URL to commit changes to.
@@ -390,14 +422,6 @@ spec:
                       This acts as the default if not overridden at a more specific level.
                     type: string
                 type: object
-              namespace:
-                description: |-
-                  Namespace indicates the target namespace of the applications.
-
-                  Deprecated: This field is deprecated and will be removed in a future release.
-                  The controller now uses the ImageUpdater CR's namespace (metadata.namespace)
-                  to determine which namespace to search for applications. This field is ignored.
-                type: string
               writeBackConfig:
                 description: |-
                   WriteBackConfig provides global default settings for how and where to write back image updates.
@@ -413,6 +437,25 @@ spec:
                           Branch to commit updates to.
                           Required if write-back method is Git and this is not specified at the spec level.
                         type: string
+                      pullRequest:
+                        description: |-
+                          PullRequest configures creation of pull requests when writing back image updates to Git.
+                          When set, the controller opens a PR instead of pushing to the branch.
+                          If not specified write back config method is `git`.
+                        properties:
+                          github:
+                            description: GitHub configures PR creation via the GitHub
+                              API.
+                            type: object
+                          gitlab:
+                            description: GitLab configures MR creation via the GitLab
+                              API.
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Exactly one of github or gitlab must be set
+                          rule: '(has(self.github) ? 1 : 0) + (has(self.gitlab) ?
+                            1 : 0) == 1'
                       repository:
                         description: |-
                           Repository URL to commit changes to.
@@ -444,7 +487,15 @@ spec:
           status:
             description: ImageUpdaterStatus defines the observed state of ImageUpdater
             properties:
+              applicationsMatched:
+                description: ApplicationsMatched is the number of Argo CD applications
+                  matched by this CR's selectors.
+                format: int32
+                minimum: 0
+                type: integer
               conditions:
+                description: Conditions represent the latest available observations
+                  of the resource's state.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -500,48 +551,73 @@ spec:
                   - type
                   type: object
                 type: array
-              imageStatus:
-                description: ImageStatus indicates the detailed status for the list
-                  of managed images
-                items:
-                  description: ImageStatus contains information for an image:version
-                    and its update status in hosting applications
-                  properties:
-                    applications:
-                      description: Applications contains a list of applications and
-                        when the image was last updated therein
-                      items:
-                        description: ImageApplicationLastUpdated contains information
-                          for an application and when the image was last updated therein
-                        properties:
-                          appName:
-                            description: AppName indicates and namespace and the application
-                              name
-                            type: string
-                          lastUpdatedAt:
-                            description: LastUpdatedAt indicates when the image in
-                              this application was last updated
-                            format: date-time
-                            type: string
-                        required:
-                        - appName
-                        type: object
-                      type: array
-                    name:
-                      description: Name indicates the image name
-                      type: string
-                    version:
-                      description: Version indicates the image version
-                      type: string
-                  required:
-                  - name
-                  - version
-                  type: object
-                type: array
-              reconciledAt:
-                description: LastUpdatedAt indicates when the image updater last ran
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              imagesManaged:
+                description: ImagesManaged is the number of images that were eligible
+                  for update checking.
+                format: int32
+                minimum: 0
+                type: integer
+              lastCheckedAt:
+                description: LastCheckedAt indicates when the controller last checked
+                  for image updates.
                 format: date-time
                 type: string
+              lastUpdatedAt:
+                description: LastUpdatedAt indicates when the controller last performed
+                  an image update.
+                format: date-time
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                minimum: 0
+                type: integer
+              recentUpdates:
+                description: RecentUpdates contains the list of image updates performed
+                  during the last update cycle.
+                items:
+                  description: RecentUpdate records a single image update performed
+                    during the last update.
+                  properties:
+                    alias:
+                      description: Alias is the alias of the image configuration that
+                        was updated.
+                      type: string
+                    applicationsUpdated:
+                      description: ApplicationsUpdated is the number of applications
+                        in which this image was updated.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    image:
+                      description: Image is the full image reference.
+                      type: string
+                    message:
+                      description: Message provides a human-readable description of
+                        the update action.
+                      type: string
+                    newVersion:
+                      description: NewVersion is the new tag or digest the image was
+                        updated to.
+                      type: string
+                    updatedAt:
+                      description: UpdatedAt is the timestamp when the update was
+                        applied.
+                      format: date-time
+                      type: string
+                  required:
+                  - alias
+                  - applicationsUpdated
+                  - image
+                  - newVersion
+                  - updatedAt
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
             type: object
         type: object
     served: true

--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -190,7 +190,7 @@ metadata:
     capabilities: Deep Insights
     console.openshift.io/plugins: '["gitops-plugin"]'
     containerImage: quay.io/redhat-developer/gitops-operator
-    createdAt: "2026-06-03T18:12:37Z"
+    createdAt: "2026-06-11T15:05:37Z"
     description: Enables teams to adopt GitOps principles for managing cluster configurations
       and application delivery across hybrid multi-cluster Kubernetes environments.
     features.operators.openshift.io/disconnected: "true"

--- a/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml
+++ b/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml
@@ -1,9 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
-  creationTimestamp: null
   name: imageupdaters.argocd-image-updater.argoproj.io
 spec:
   group: argocd-image-updater.argoproj.io
@@ -14,7 +14,20 @@ spec:
     singular: imageupdater
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.applicationsMatched
+      name: Apps
+      type: integer
+    - jsonPath: .status.imagesManaged
+      name: Images
+      type: integer
+    - jsonPath: .status.lastCheckedAt
+      name: Last Checked
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ImageUpdater is the Schema for the imageupdaters API
@@ -306,6 +319,25 @@ spec:
                                 Branch to commit updates to.
                                 Required if write-back method is Git and this is not specified at the spec level.
                               type: string
+                            pullRequest:
+                              description: |-
+                                PullRequest configures creation of pull requests when writing back image updates to Git.
+                                When set, the controller opens a PR instead of pushing to the branch.
+                                If not specified write back config method is `git`.
+                              properties:
+                                github:
+                                  description: GitHub configures PR creation via the
+                                    GitHub API.
+                                  type: object
+                                gitlab:
+                                  description: GitLab configures MR creation via the
+                                    GitLab API.
+                                  type: object
+                              type: object
+                              x-kubernetes-validations:
+                              - message: Exactly one of github or gitlab must be set
+                                rule: '(has(self.github) ? 1 : 0) + (has(self.gitlab)
+                                  ? 1 : 0) == 1'
                             repository:
                               description: |-
                                 Repository URL to commit changes to.
@@ -390,14 +422,6 @@ spec:
                       This acts as the default if not overridden at a more specific level.
                     type: string
                 type: object
-              namespace:
-                description: |-
-                  Namespace indicates the target namespace of the applications.
-
-                  Deprecated: This field is deprecated and will be removed in a future release.
-                  The controller now uses the ImageUpdater CR's namespace (metadata.namespace)
-                  to determine which namespace to search for applications. This field is ignored.
-                type: string
               writeBackConfig:
                 description: |-
                   WriteBackConfig provides global default settings for how and where to write back image updates.
@@ -413,6 +437,25 @@ spec:
                           Branch to commit updates to.
                           Required if write-back method is Git and this is not specified at the spec level.
                         type: string
+                      pullRequest:
+                        description: |-
+                          PullRequest configures creation of pull requests when writing back image updates to Git.
+                          When set, the controller opens a PR instead of pushing to the branch.
+                          If not specified write back config method is `git`.
+                        properties:
+                          github:
+                            description: GitHub configures PR creation via the GitHub
+                              API.
+                            type: object
+                          gitlab:
+                            description: GitLab configures MR creation via the GitLab
+                              API.
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Exactly one of github or gitlab must be set
+                          rule: '(has(self.github) ? 1 : 0) + (has(self.gitlab) ?
+                            1 : 0) == 1'
                       repository:
                         description: |-
                           Repository URL to commit changes to.
@@ -444,7 +487,15 @@ spec:
           status:
             description: ImageUpdaterStatus defines the observed state of ImageUpdater
             properties:
+              applicationsMatched:
+                description: ApplicationsMatched is the number of Argo CD applications
+                  matched by this CR's selectors.
+                format: int32
+                minimum: 0
+                type: integer
               conditions:
+                description: Conditions represent the latest available observations
+                  of the resource's state.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -500,57 +551,76 @@ spec:
                   - type
                   type: object
                 type: array
-              imageStatus:
-                description: ImageStatus indicates the detailed status for the list
-                  of managed images
-                items:
-                  description: ImageStatus contains information for an image:version
-                    and its update status in hosting applications
-                  properties:
-                    applications:
-                      description: Applications contains a list of applications and
-                        when the image was last updated therein
-                      items:
-                        description: ImageApplicationLastUpdated contains information
-                          for an application and when the image was last updated therein
-                        properties:
-                          appName:
-                            description: AppName indicates and namespace and the application
-                              name
-                            type: string
-                          lastUpdatedAt:
-                            description: LastUpdatedAt indicates when the image in
-                              this application was last updated
-                            format: date-time
-                            type: string
-                        required:
-                        - appName
-                        type: object
-                      type: array
-                    name:
-                      description: Name indicates the image name
-                      type: string
-                    version:
-                      description: Version indicates the image version
-                      type: string
-                  required:
-                  - name
-                  - version
-                  type: object
-                type: array
-              reconciledAt:
-                description: LastUpdatedAt indicates when the image updater last ran
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              imagesManaged:
+                description: ImagesManaged is the number of images that were eligible
+                  for update checking.
+                format: int32
+                minimum: 0
+                type: integer
+              lastCheckedAt:
+                description: LastCheckedAt indicates when the controller last checked
+                  for image updates.
                 format: date-time
                 type: string
+              lastUpdatedAt:
+                description: LastUpdatedAt indicates when the controller last performed
+                  an image update.
+                format: date-time
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                minimum: 0
+                type: integer
+              recentUpdates:
+                description: RecentUpdates contains the list of image updates performed
+                  during the last update cycle.
+                items:
+                  description: RecentUpdate records a single image update performed
+                    during the last update.
+                  properties:
+                    alias:
+                      description: Alias is the alias of the image configuration that
+                        was updated.
+                      type: string
+                    applicationsUpdated:
+                      description: ApplicationsUpdated is the number of applications
+                        in which this image was updated.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    image:
+                      description: Image is the full image reference.
+                      type: string
+                    message:
+                      description: Message provides a human-readable description of
+                        the update action.
+                      type: string
+                    newVersion:
+                      description: NewVersion is the new tag or digest the image was
+                        updated to.
+                      type: string
+                    updatedAt:
+                      description: UpdatedAt is the timestamp when the update was
+                        applied.
+                      format: date-time
+                      type: string
+                  required:
+                  - alias
+                  - applicationsUpdated
+                  - image
+                  - newVersion
+                  - updatedAt
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
             type: object
         type: object
     served: true
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null


### PR DESCRIPTION
**What type of PR is this?**

> /kind cleanup

**What does this PR do / why we need it**:
Sync Image Updater CRD with argocd operator https://github.com/argoproj-labs/argocd-operator/blob/v0.19.0-rc2/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
https://redhat.atlassian.net/browse/GITOPS-9973

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
