### PR TITLE
RFE-9358: Add env var to disable Swagger UI exposure

### DIFF
--- a/controllers/argocd/argocd.go
+++ b/controllers/argocd/argocd.go
@@ -162,7 +162,7 @@ func getArgoRepoServerSpec() argoapp.ArgoCDRepoSpec {
 
 func getArgoServerSpec() argoapp.ArgoCDServerSpec {
 	return argoapp.ArgoCDServerSpec{
-		Route: argoapp.ArgoCDRouteSpec{Enabled: true},
+		Route: argoapp.ArgoCDRouteSpec{Enabled: true},		// Disable Swagger UI and OpenAPI spec exposure for security hardening.		// This addresses penetration test findings (RFE-9358) where unauthenticated		// API schema disclosure could allow attackers to map endpoints and identify		// authentication bypasses.		Env: []v1.EnvVar{			{				Name:  "ARGOCD_SERVER_DISABLE_SWAGGER",				Value: "true",			},		},
 		Resources: &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
 				v1.ResourceMemory: resourcev1.MustParse("128Mi"),


### PR DESCRIPTION
/kind feature

## Summary
- Adds `ARGOCD_SERVER_DISABLE_SWAGGER=true` environment variable to the default ArgoCD server spec
- This addresses penetration test findings (RFE-9358) where unauthenticated API schema disclosure could allow attackers to map endpoints

## Test plan
- [ ] Verify unit tests pass with `go test ./controllers/argocd/...`
- [ ] Deploy modified operator to test cluster
- [ ] Verify ArgoCD server deployment has the new env var set
- [ ] Once upstream ArgoCD supports this env var, verify /swagger-ui returns 404

## Notes
This change sets the environment variable, but requires a corresponding upstream ArgoCD change to read and act on it.

Jira: [RFE-9358](https://redhat.atlassian.net/browse/RFE-9358)