### PR TITLE
fix: fix intermittent test failure in 1-023_validate_repo_server_tls

### DIFF
--- a/test/openshift/e2e/ginkgo/parallel/1-023_validate_repo_server_tls_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-023_validate_repo_server_tls_test.go
@@ -118,6 +118,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			}).Should(BeTrue())
 
+			Eventually(argoCDTest_1_23_custom, "5m", "5s").Should(argocdFixture.BeAvailable())
+
 			By("ensuring we can deploy to the namespace via the ArgoCD instance")
 			app := &argocdv1alpha1.Application{
 				ObjectMeta: metav1.ObjectMeta{Name: "guestbook", Namespace: nsTest_1_23_custom.Name},


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test


**What does this PR do / why we need it**:
- Fixes intermittent test failure in `1-023_validate_repo_server_tls`
- AFAICT we are not waiting long enough for ArgoCD instance to become ready after modifying ArgoCD CR:
```
    status:
      conditions:
      - lastTransitionTime: "2026-06-22T06:00:17Z"
        message: 'Failed to load target state: failed to generate manifest for source
          1 of 1: rpc error: code = Unavailable desc = connection error: desc = "transport:
          authentication handshake failed: tls: failed to verify certificate: x509:
          certificate is valid for localhost, reposerver, not argocd-repo-server.test-1-23-custom.svc.cluster.local"'
        type: ComparisonError
      controllerNamespace: test-1-23-custom
```

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

