### PR TITLE
feat: add per-component priorityClassName to ArgoCD CRD (RFE-8802)

### DIFF
--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -250,6 +250,11 @@ spec:
                       by the ApplicationSet controller. Defaults to ArgoCDDefaultLogLevel
                       if not set.  Valid options are debug,info, error, and warn.
                     type: string
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   resources:
                     description: Resources defines the Compute Resources required
                       by the container for ApplicationSet.
@@ -1292,6 +1297,11 @@ spec:
                       operations
                     format: int32
                     type: integer
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   processors:
                     description: Processors contains the options for the Application
                       Controller processors.
@@ -2529,6 +2539,11 @@ spec:
                     type: boolean
                   image:
                     description: Image is the Redis container image.
+                    type: string
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
                     type: string
                   resources:
                     description: Resources defines the Compute Resources required
@@ -4337,6 +4352,11 @@ spec:
                     description: MountSAToken describes whether you would like to
                       have the Repo server mount the service account token
                     type: boolean
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   replicas:
                     description: Replicas defines the number of replicas for argocd-repo-server.
                       Value should be greater than or equal to 0. Default is nil.
@@ -8379,6 +8399,11 @@ spec:
                           If empty, Prometheus uses the global scrape timeout.
                         type: string
                     type: object
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   replicas:
                     description: Replicas defines the number of replicas for argocd-server.
                       Default is nil. Value should be greater than or equal to 0.
@@ -8593,6 +8618,11 @@ spec:
                         description: OpenShiftOAuth enables OpenShift OAuth authentication
                           for the Dex server.
                         type: boolean
+                      priorityClassName:
+                        description: |-
+                          PriorityClassName is the name of the PriorityClass resource to assign to the Dex
+                          pod. The PriorityClass must already exist in the cluster.
+                        type: string
                       resources:
                         description: Resources defines the Compute Resources required
                           by the container for Dex.
@@ -9384,6 +9414,11 @@ spec:
                     type: string
                   logformat:
                     description: 'Deprecated: use LogFormat instead.'
+                    type: string
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
                     type: string
                   resources:
                     description: Resources defines the Compute Resources required
@@ -14114,6 +14149,11 @@ spec:
                       operations
                     format: int32
                     type: integer
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   processors:
                     description: Processors contains the options for the Application
                       Controller processors.
@@ -19032,6 +19072,11 @@ spec:
                   image:
                     description: Image is the Redis container image.
                     type: string
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   remote:
                     description: Remote specifies the remote URL of the Redis container.
                       (optional, by default, a local instance managed by the operator
@@ -20858,6 +20903,11 @@ spec:
                     description: MountSAToken describes whether you would like to
                       have the Repo server mount the service account token
                     type: boolean
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   remote:
                     description: Remote specifies the remote URL of the Repo Server
                       container. (optional, by default, a local instance managed by
@@ -26676,6 +26726,11 @@ spec:
                           If empty, Prometheus uses the global scrape timeout.
                         type: string
                     type: object
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   replicas:
                     description: Replicas defines the number of replicas for argocd-server.
                       Default is nil. Value should be greater than or equal to 0.
@@ -30536,6 +30591,11 @@ spec:
                         description: OpenShiftOAuth enables OpenShift OAuth authentication
                           for the Dex server.
                         type: boolean
+                      priorityClassName:
+                        description: |-
+                          PriorityClassName is the name of the PriorityClass resource to assign to the Dex
+                          pod. The PriorityClass must already exist in the cluster.
+                        type: string
                       resources:
                         description: Resources defines the Compute Resources required
                           by the container for Dex.

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -239,6 +239,11 @@ spec:
                       by the ApplicationSet controller. Defaults to ArgoCDDefaultLogLevel
                       if not set.  Valid options are debug,info, error, and warn.
                     type: string
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   resources:
                     description: Resources defines the Compute Resources required
                       by the container for ApplicationSet.
@@ -1281,6 +1286,11 @@ spec:
                       operations
                     format: int32
                     type: integer
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   processors:
                     description: Processors contains the options for the Application
                       Controller processors.
@@ -2518,6 +2528,11 @@ spec:
                     type: boolean
                   image:
                     description: Image is the Redis container image.
+                    type: string
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
                     type: string
                   resources:
                     description: Resources defines the Compute Resources required
@@ -4326,6 +4341,11 @@ spec:
                     description: MountSAToken describes whether you would like to
                       have the Repo server mount the service account token
                     type: boolean
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   replicas:
                     description: Replicas defines the number of replicas for argocd-repo-server.
                       Value should be greater than or equal to 0. Default is nil.
@@ -8368,6 +8388,11 @@ spec:
                           If empty, Prometheus uses the global scrape timeout.
                         type: string
                     type: object
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   replicas:
                     description: Replicas defines the number of replicas for argocd-server.
                       Default is nil. Value should be greater than or equal to 0.
@@ -8582,6 +8607,11 @@ spec:
                         description: OpenShiftOAuth enables OpenShift OAuth authentication
                           for the Dex server.
                         type: boolean
+                      priorityClassName:
+                        description: |-
+                          PriorityClassName is the name of the PriorityClass resource to assign to the Dex
+                          pod. The PriorityClass must already exist in the cluster.
+                        type: string
                       resources:
                         description: Resources defines the Compute Resources required
                           by the container for Dex.
@@ -9373,6 +9403,11 @@ spec:
                     type: string
                   logformat:
                     description: 'Deprecated: use LogFormat instead.'
+                    type: string
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
                     type: string
                   resources:
                     description: Resources defines the Compute Resources required
@@ -14103,6 +14138,11 @@ spec:
                       operations
                     format: int32
                     type: integer
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   processors:
                     description: Processors contains the options for the Application
                       Controller processors.
@@ -19021,6 +19061,11 @@ spec:
                   image:
                     description: Image is the Redis container image.
                     type: string
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   remote:
                     description: Remote specifies the remote URL of the Redis container.
                       (optional, by default, a local instance managed by the operator
@@ -20847,6 +20892,11 @@ spec:
                     description: MountSAToken describes whether you would like to
                       have the Repo server mount the service account token
                     type: boolean
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   remote:
                     description: Remote specifies the remote URL of the Repo Server
                       container. (optional, by default, a local instance managed by
@@ -26665,6 +26715,11 @@ spec:
                           If empty, Prometheus uses the global scrape timeout.
                         type: string
                     type: object
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName is the name of the PriorityClass resource to assign to this component's
+                      pod. The PriorityClass must already exist in the cluster.
+                    type: string
                   replicas:
                     description: Replicas defines the number of replicas for argocd-server.
                       Default is nil. Value should be greater than or equal to 0.
@@ -30525,6 +30580,11 @@ spec:
                         description: OpenShiftOAuth enables OpenShift OAuth authentication
                           for the Dex server.
                         type: boolean
+                      priorityClassName:
+                        description: |-
+                          PriorityClassName is the name of the PriorityClass resource to assign to the Dex
+                          pod. The PriorityClass must already exist in the cluster.
+                        type: string
                       resources:
                         description: Resources defines the Compute Resources required
                           by the container for Dex.


### PR DESCRIPTION
## Summary

Exposes `priorityClassName` per core ArgoCD component in the `ArgoCD` Custom Resource, resolving [RFE-8802](https://redhat.atlassian.net/browse/RFE-8802).

Without this field, ArgoCD pods use the cluster's global default PriorityClass and are at risk of eviction during resource contention. This change gives cluster administrators fine-grained control over scheduling priority per component.

## New fields

| Field | Workload |
|---|---|
| `spec.controller.priorityClassName` | Application Controller StatefulSet |
| `spec.server.priorityClassName` | ArgoCD Server Deployment |
| `spec.repo.priorityClassName` | Repo Server Deployment |
| `spec.redis.priorityClassName` | Redis Deployment |
| `spec.applicationSet.priorityClassName` | ApplicationSet Controller Deployment |
| `spec.sso.dex.priorityClassName` | Dex Server Deployment |

## Changes

- `config/crd/bases/argoproj.io_argocds.yaml` — CRD base schema updated for `v1alpha1` and `v1beta1`
- `bundle/manifests/argoproj.io_argocds.yaml` — OLM bundle manifest updated for `v1alpha1` and `v1beta1`

## Example usage

```yaml
apiVersion: argoproj.io/v1beta1
kind: ArgoCD
metadata:
  name: argocd-instance
spec:
  controller:
    priorityClassName: high-priority
  server:
    priorityClassName: high-priority
  repo:
    priorityClassName: high-priority
  redis:
    priorityClassName: high-priority
  applicationSet:
    priorityClassName: high-priority
  sso:
    dex:
      priorityClassName: high-priority
```

## Upstream dependency

The controller-side implementation (Go type definitions, reconcilers, conversion functions between `v1alpha1`↔`v1beta1`, and unit tests) is tracked upstream in [argoproj-labs/argocd-operator#2125](https://github.com/argoproj-labs/argocd-operator/issues/2125). The `go.mod` dependency bump will follow once that upstream change is merged and tagged.

Resolves: RFE-8802