### PR TITLE
fix: Target Down for metrics monitor

### DIFF
--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -190,7 +190,7 @@ metadata:
     capabilities: Deep Insights
     console.openshift.io/plugins: '["gitops-plugin"]'
     containerImage: quay.io/redhat-developer/gitops-operator
-    createdAt: "2026-06-16T17:25:03Z"
+    createdAt: "2026-06-29T14:44:36Z"
     description: Enables teams to adopt GitOps principles for managing cluster configurations
       and application delivery across hybrid multi-cluster Kubernetes environments.
     features.operators.openshift.io/disconnected: "true"
@@ -864,6 +864,7 @@ spec:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=:8443
                 - --leader-elect
+                - --metrics-secure=true
                 command:
                 - /usr/local/bin/manager
                 env:
@@ -910,10 +911,18 @@ spec:
                     - ALL
                   readOnlyRootFilesystem: true
                   runAsNonRoot: true
+                volumeMounts:
+                - mountPath: /tmp/k8s-metrics-server/serving-certs
+                  name: metrics-certs
+                  readOnly: true
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: openshift-gitops-operator-controller-manager
               terminationGracePeriodSeconds: 10
+              volumes:
+              - name: metrics-certs
+                secret:
+                  secretName: gitops-operator-metrics-tls
       permissions:
       - rules:
         - apiGroups:

--- a/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -190,7 +190,7 @@ metadata:
     capabilities: Deep Insights
     console.openshift.io/plugins: '["gitops-plugin"]'
     containerImage: quay.io/redhat-developer/gitops-operator
-    createdAt: "2026-06-29T14:44:36Z"
+    createdAt: "2026-06-30T06:15:57Z"
     description: Enables teams to adopt GitOps principles for managing cluster configurations
       and application delivery across hybrid multi-cluster Kubernetes environments.
     features.operators.openshift.io/disconnected: "true"
@@ -922,7 +922,7 @@ spec:
               volumes:
               - name: metrics-certs
                 secret:
-                  secretName: gitops-operator-metrics-tls
+                  secretName: openshift-gitops-operator-metrics-tls
       permissions:
       - rules:
         - apiGroups:

--- a/bundle/manifests/openshift-gitops-operator-metrics-service_v1_service.yaml
+++ b/bundle/manifests/openshift-gitops-operator-metrics-service_v1_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: kube-rbac-proxy-tls
+    service.beta.openshift.io/serving-cert-secret-name: gitops-operator-metrics-tls
   creationTimestamp: null
   labels:
     control-plane: gitops-operator

--- a/bundle/manifests/openshift-gitops-operator-metrics-service_v1_service.yaml
+++ b/bundle/manifests/openshift-gitops-operator-metrics-service_v1_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: gitops-operator-metrics-tls
+    service.beta.openshift.io/serving-cert-secret-name: openshift-gitops-operator-metrics-tls
   creationTimestamp: null
   labels:
     control-plane: gitops-operator

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -93,7 +93,7 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
-
+	var secureMetrics = false
 	var enableHTTP2 = false
 	var skipControllerNameValidation = true
 	var disableClusterTLSProfile = false
@@ -107,6 +107,8 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", enableHTTP2, "If HTTP/2 should be enabled for the metrics and webhook servers.")
 	flag.BoolVar(&disableClusterTLSProfile, "disable-cluster-tls-profile", false, "Disable use of the cluster TLS security profile")
+	flag.BoolVar(&secureMetrics, "metrics-secure", secureMetrics, "If the metrics endpoint should be served securely.")
+
 	//Configure log level
 	logLevelStr := strings.ToLower(os.Getenv("LOG_LEVEL"))
 	logLevel := zapcore.InfoLevel
@@ -179,11 +181,7 @@ func main() {
 	}
 	webhookServer := webhook.NewServer(webhookServerOptions)
 
-	metricsServerOptions := metricsserver.Options{
-		BindAddress:    metricsAddr,
-		TLSOpts:        tlsOpts,
-		FilterProvider: filters.WithAuthenticationAndAuthorization,
-	}
+	metricsServerOptions := buildMetricsServerOptions(metricsAddr, secureMetrics, []func(*tls.Config){disableHTTP2})
 
 	// Set default manager options
 	options := ctrl.Options{
@@ -471,4 +469,19 @@ func initK8sClient() (*kubernetes.Clientset, error) {
 	}
 
 	return k8sClient, nil
+}
+
+func buildMetricsServerOptions(metricsAddr string, secureMetrics bool, tlsOpts []func(*tls.Config)) metricsserver.Options {
+	opts := metricsserver.Options{
+		SecureServing: secureMetrics,
+		BindAddress:   metricsAddr,
+		TLSOpts:       tlsOpts,
+	}
+
+	if secureMetrics {
+		opts.FilterProvider = filters.WithAuthenticationAndAuthorization
+		opts.CertDir = "/tmp/k8s-metrics-server/serving-certs"
+	}
+
+	return opts
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -181,7 +181,7 @@ func main() {
 	}
 	webhookServer := webhook.NewServer(webhookServerOptions)
 
-	metricsServerOptions := buildMetricsServerOptions(metricsAddr, secureMetrics, []func(*tls.Config){disableHTTP2})
+	metricsServerOptions := buildMetricsServerOptions(metricsAddr, secureMetrics, tlsOpts)
 
 	// Set default manager options
 	options := ctrl.Options{

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -15,6 +15,7 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=:8443"
         - "--leader-elect"
+        - "--metrics-secure=true"
         ports:
         - name: metrics
           containerPort: 8443

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,6 +69,6 @@ spec:
       volumes:
       - name: metrics-certs
         secret:
-          secretName: gitops-operator-metrics-tls
+          secretName: openshift-gitops-operator-metrics-tls
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,7 +27,8 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
-      - command:
+      - name: manager
+        command:
           - /usr/local/bin/manager
         env:
         - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
@@ -47,7 +48,6 @@ spec:
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 20
-        name: manager
         readinessProbe:
           httpGet:
             path: /readyz
@@ -62,5 +62,13 @@ spec:
               - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+        volumeMounts:
+        - name: metrics-certs
+          mountPath: /tmp/k8s-metrics-server/serving-certs
+          readOnly: true
+      volumes:
+      - name: metrics-certs
+        secret:
+          secretName: gitops-operator-metrics-tls
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/rbac/metrics_service.yaml
+++ b/config/rbac/metrics_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: kube-rbac-proxy-tls
+    service.beta.openshift.io/serving-cert-secret-name: gitops-operator-metrics-tls
   labels:
     control-plane: gitops-operator
   name: metrics-service

--- a/config/rbac/metrics_service.yaml
+++ b/config/rbac/metrics_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: gitops-operator-metrics-tls
+    service.beta.openshift.io/serving-cert-secret-name: openshift-gitops-operator-metrics-tls
   labels:
     control-plane: gitops-operator
   name: metrics-service


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What does this PR do / why we need it**:
Target Down alerts are firing because of https handling is not happening as kube-rbac-proxy image has been deprecated. Implemented metrics monitor to work for https from prometheus scraping from controller main code.
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
https://redhat.atlassian.net/browse/GITOPS-10273
**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
> Deploy gitops operator with namespace having openshift.io/cluster-monitoring:'true' label on openshift-gitops-operator namespace
> check alerts and target all are up.