### PR TITLE
fix(redis): Regression for masterauth field causing NOAUTH Authentication required error

### DIFF
--- a/build/redis/redis.conf.tpl
+++ b/build/redis/redis.conf.tpl
@@ -21,3 +21,5 @@ repl-diskless-sync yes
 save ""
 protected-mode no
 aclfile /app/config/redis-auth/users.acl
+masterauth __REPLACE_DEFAULT_AUTH__
+


### PR DESCRIPTION
**What type of PR is this?**
/kind bug



**What does this PR do / why we need it**:
RCA: masterauth has been removed in redis.conf.tpl as part of this pr https://github.com/redhat-developer/gitops-operator/pull/1124, but init.sh script use sed command to overwrite REPLACE_DEFAULT_AUTH with password. sed command will replace the existing but field itself is removed, so password is not getting added in redis.conf
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
https://redhat.atlassian.net/browse/GITOPS-10178
**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:

- Deploy redis with ha enabled, ha.enabled: true
- verify the redis pods are up and check the below commands for ha proxy pods.

```
kubectl logs -f openshift-gitops-redis-ha-server-1 -n openshift-gitops
oc exec -it openshift-gitops-redis-ha-server-0 -n openshift-gitops -- \
sh -c 'REDISCLI_AUTH=$(cat /app/config/redis-auth/auth) redis-cli INFO replication'
oc exec -it openshift-gitops-redis-ha-server-0  -n openshift-gitops -- cat /data/conf/redis.conf
```
