### PR TITLE
fix: wait for rolebinding in 1-084 to avoid intermittent fail

### DIFF
--- a/test/openshift/e2e/ginkgo/sequential/1-084_validate_prune_templates.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-084_validate_prune_templates.go
@@ -11,9 +11,11 @@ import (
 	argov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
+	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -47,6 +49,13 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 			ns.Labels["argocd.argoproj.io/managed-by"] = "openshift-gitops"
 			Expect(k8sClient.Update(ctx, ns)).To(Succeed())
+
+			By("waiting for the operator to create rolebindings in the managed namespace")
+			argoCDServerRB := &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops-argocd-server", Namespace: ns.Name},
+			}
+			Eventually(argoCDServerRB).Should(k8sFixture.ExistByName())
+
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What does this PR do / why we need it**:
- Fix intermittent failure by waiting for rolebinding in 1-084 to exist (which is created via managed-by label) before letting the test continue

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test


```
[38;5;243m------------------------------[0m
[0mGitOps Operator Sequential E2E Tests [38;5;243m1-084_validate_prune_templates [0m[1mvalidates that resources with duplicate GVKs can be pruned successfully with local sync[0m
[38;5;243m/go/src/github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/sequential/1-084_validate_prune_templates.go:57[0m
  Object exists in ExistByName: openshift-gitops
  HaveArgocdPhase: expected: Available / actual: Available
    Components:  Redis: Running Repo: Running Server:  Running ApplicationController: Running ApplicationSetController: Running NotificationsController:  SSO: Running
  [1mSTEP:[0m creating namespace 'gitops-e2e-test-0421a642-e6ce' [38;5;243m@ 07/01/26 19:13:05.469[0m
  [1mSTEP:[0m creating a temp dir for git repo [38;5;243m@ 07/01/26 19:13:05.837[0m
  [1mSTEP:[0m writing two OpenShift Templates (duplicate GVKs) to the working dir [38;5;243m@ 07/01/26 19:13:05.837[0m
  [1mSTEP:[0m logging into the Argo CD CLI [38;5;243m@ 07/01/26 19:13:05.837[0m
  executing command: argocd login (...)
  {"level":"warning","msg":"Failed to invoke grpc call. Use flag --grpc-web in grpc calls. To avoid this warning message, use flag --grpc-web.","time":"2026-07-01T19:13:06Z"}
  'admin:login' logged in successfully
  Context 'openshift-gitops-server-openshift-gitops.apps.ci-op-hi6vh47s-3fe53.ocp-gitops-qe.com' updated

  [1mSTEP:[0m Creating ArgoCD Application CR using the typed schema [38;5;243m@ 07/01/26 19:13:07.746[0m
  [1mSTEP:[0m syncing the application using the local dir [38;5;243m@ 07/01/26 19:13:07.83[0m
  executing command [argocd app sync app-kustomize-gitops-e2e-test-0421a642-e6ce --local /tmp/gitops-prune-test3191198142 --timeout 100]
  {"level":"warning","msg":"Failed to invoke grpc call. Use flag --grpc-web in grpc calls. To avoid this warning message, use flag --grpc-web.","time":"2026-07-01T19:13:08Z"}
  {"level":"warning","msg":"Failed to invoke grpc call. Use flag --grpc-web in grpc calls. To avoid this warning message, use flag --grpc-web.","time":"2026-07-01T19:13:09Z"}

  Name:               openshift-gitops/app-kustomize-gitops-e2e-test-0421a642-e6ce
  Project:            default
  Server:             https://kubernetes.default.svc
  Namespace:          gitops-e2e-test-0421a642-e6ce
  URL:                https://openshift-gitops-server-openshift-gitops.apps.ci-op-hi6vh47s-3fe53.ocp-gitops-qe.com/applications/app-kustomize-gitops-e2e-test-0421a642-e6ce
  Source:
  - Repo:             file:///tmp/gitops-prune-test3191198142.git
    Target:           HEAD
    Path:             .
  SyncWindow:         Sync Allowed
  Sync Policy:        Manual
  Sync Status:        OutOfSync from HEAD
  Health Status:      Missing

  Operation:          Sync
  Sync Revision:      
  Phase:              Failed
  Start:              2026-07-01 19:13:09 +0000 UTC
  Finished:           2026-07-01 19:13:09 +0000 UTC
  Duration:           0s
  Message:            one or more objects failed to apply, reason: templates.template.openshift.io is forbidden: User "system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller" cannot create resource "templates" in API group "template.openshift.io" in the namespace "gitops-e2e-test-0421a642-e6ce"

  GROUP                  KIND      NAMESPACE                      NAME                    STATUS     HEALTH   HOOK  MESSAGE
  template.openshift.io  Template  gitops-e2e-test-0421a642-e6ce  redis-template-gitops2  OutOfSync  Missing        templates.template.openshift.io is forbidden: User "system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller" cannot create resource "templates" in API group "template.openshift.io" in the namespace "gitops-e2e-test-0421a642-e6ce"
  template.openshift.io  Template  gitops-e2e-test-0421a642-e6ce  redis-template-gitops   OutOfSync  Missing        templates.template.openshift.io is forbidden: User "system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller" cannot create resource "templates" in API group "template.openshift.io" in the namespace "gitops-e2e-test-0421a642-e6ce"
  {"level":"fatal","msg":"Operation has completed with phase: Failed","time":"2026-07-01T19:13:10Z"}

  [38;5;9m[FAILED][0m in [It] - /go/src/github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/sequential/1-084_validate_prune_templates.go:173 [38;5;243m@ 07/01/26 19:13:10.261[0m
  executing command: [kubectl logs pod/openshift-gitops-operator-controller-manager-7f5ccf96d9-wtwnx manager -n openshift-gitops-operator]

```