### PR TITLE
chore(e2e): sync DefaultClusterScopedRoleDisabled tests for principal/agent

### DIFF
--- a/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -35,12 +35,12 @@ import (
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argocdagent"
-	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
-	agentFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/agent"
-	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
-	deploymentFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/deployment"
-	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
-	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
+	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
+	agentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/agent"
+	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
+	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
+	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
+	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 )
 
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {

--- a/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -78,6 +78,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
 			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
+			fixture.SetEnvInOperatorSubscriptionOrDeployment("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "openshift-gitops, argocd-agent-principal-1-051")
+
 			ctx = context.Background()
 			ns, cleanupFunc = fixture.CreateNamespaceWithCleanupFunc("argocd-agent-principal-1-051")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -35,16 +35,15 @@ import (
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argocdagent"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
-	agentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/agent"
-	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
-	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
-	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
-	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
+	agentFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/agent"
+	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
+	deploymentFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/deployment"
+	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
+	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
 )
 
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
-
 	const (
 		argoCDName                    = "example"
 		argoCDAgentPrincipalName      = "example-agent-principal" // argoCDName + "-agent-principal"
@@ -54,7 +53,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 	)
 
 	Context("1-051_validate_argocd_agent_principal", func() {
-
 		var (
 			k8sClient                client.Client
 			ctx                      context.Context
@@ -71,16 +69,14 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			principalDeployment      *appsv1.Deployment
 			expectedEnvVariables     map[string]string
 			secretNames              agentFixture.AgentSecretNames
-			principalNetworkPolicy   *networkingv1.NetworkPolicy
 			principalRoute           *routev1.Route
+			principalNetworkPolicy   *networkingv1.NetworkPolicy
 			resourceProxyServiceName string
 			principalResources       agentFixture.PrincipalResources
 		)
 
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
-			fixture.SetEnvInOperatorSubscriptionOrDeployment("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "openshift-gitops, argocd-agent-principal-1-051")
-
 			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
 			ctx = context.Background()
 			ns, cleanupFunc = fixture.CreateNamespaceWithCleanupFunc("argocd-agent-principal-1-051")
@@ -192,12 +188,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					Namespace: ns.Name,
 				},
 			}
-			principalNetworkPolicy = &networkingv1.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-agent-principal-network-policy", argoCDName),
-					Namespace: ns.Name,
-				},
-			}
 
 			principalNetworkPolicy = &networkingv1.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
@@ -293,9 +283,9 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				ClusterRoleBinding:       clusterRoleBinding,
 				PrincipalDeployment:      principalDeployment,
 				PrincipalRoute:           principalRoute,
-				PrincipalNetworkPolicy:   principalNetworkPolicy,
 				SecretNames:              secretNames,
 				ServiceNames:             serviceNames,
+				PrincipalNetworkPolicy:   principalNetworkPolicy,
 				DeploymentNames:          deploymentNames,
 				ExpectRoute:              expectRoutePtr,
 			})
@@ -347,7 +337,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("should create argocd agent principal resources, and pod should start successfully with default image", func() {
-
 			// Add a custom environment variable to the principal server
 			argoCD.Spec.ArgoCDAgent.Principal.Env = []corev1.EnvVar{{Name: "TEST_ENV", Value: "test_value"}}
 
@@ -409,7 +398,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", func() {
-
 			By("Create ArgoCD instance")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Image = common.ArgoCDAgentPrincipalDefaultImageName
@@ -437,12 +425,11 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: argoCDName, Namespace: ns.Name}, argoCD)).To(Succeed())
 
 			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
-
 				ac.Spec.ArgoCDAgent.Principal.LogLevel = "trace"
 				ac.Spec.ArgoCDAgent.Principal.LogFormat = "json"
 				ac.Spec.ArgoCDAgent.Principal.Server.KeepAliveMinInterval = "60s"
 				ac.Spec.ArgoCDAgent.Principal.Server.EnableWebSocket = ptr.To(true)
-				ac.Spec.ArgoCDAgent.Principal.Image = "quay.io/argoprojlabs/argocd-agent:v0.8.1"
+				ac.Spec.ArgoCDAgent.Principal.Image = "quay.io/argoprojlabs/argocd-agent:v0.5.1"
 
 				ac.Spec.ArgoCDAgent.Principal.Namespace.AllowedNamespaces = []string{"agent-managed", "agent-autonomous"}
 				ac.Spec.ArgoCDAgent.Principal.Namespace.EnableNamespaceCreate = ptr.To(true)
@@ -460,7 +447,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					SecretName:   "argocd-agent-resource-proxy-tls-v2",
 					CASecretName: "argocd-agent-ca-v2",
 				}
-
 			})
 
 			By("Create required secrets and certificates for principal pod to start properly")
@@ -489,7 +475,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					if container == nil {
 						return false
 					}
-					return container.Image == "quay.io/argoprojlabs/argocd-agent:v0.8.1"
+					return container.Image == "quay.io/argoprojlabs/argocd-agent:v0.5.1"
 				}, "120s", "5s").Should(BeTrue(), "Principal deployment should have the updated image")
 
 			By("verify that deployment is in Ready state")
@@ -520,7 +506,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("should handle route disabled configuration correctly", func() {
-
 			By("Create ArgoCD instance with route disabled")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Server.Route = argov1beta1api.ArgoCDAgentPrincipalRouteSpec{
@@ -540,7 +525,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("should handle route enabled configuration correctly", func() {
-
 			By("Create ArgoCD instance with route enabled")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Server.Route = argov1beta1api.ArgoCDAgentPrincipalRouteSpec{
@@ -560,7 +544,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("should handle route toggle from enabled to disabled correctly", func() {
-
 			By("Create ArgoCD instance with route enabled")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Server.Route = argov1beta1api.ArgoCDAgentPrincipalRouteSpec{
@@ -626,7 +609,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("should handle service type ClusterIP configuration correctly", func() {
-
 			By("Create ArgoCD instance with service type ClusterIP")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Server.Service = argov1beta1api.ArgoCDAgentPrincipalServiceSpec{
@@ -651,7 +633,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("should handle service type LoadBalancer configuration correctly", func() {
-
 			By("Create ArgoCD instance with service type LoadBalancer")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Server.Service = argov1beta1api.ArgoCDAgentPrincipalServiceSpec{
@@ -676,7 +657,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("should handle service type updates correctly", func() {
-
 			By("Create ArgoCD instance with service type ClusterIP")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Server.Service = argov1beta1api.ArgoCDAgentPrincipalServiceSpec{
@@ -718,7 +698,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", func() {
-
 			By("Create namespace-scoped ArgoCD instance")
 
 			// Create namespace for hosting namespace-scoped ArgoCD instance with principal
@@ -772,7 +751,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("should delete existing cluster role and cluster role binding if ArgoCD instance is namespace-scoped", func() {
-
 			By("Create namespace-scoped ArgoCD instance namespace")
 
 			// Create namespace for hosting namespace-scoped ArgoCD instance with principal
@@ -916,7 +894,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", func() {
-
 			By("Create ArgoCD instance with principal enabled and prometheus enabled")
 
 			argoCD.Spec.Prometheus.Enabled = true
@@ -962,6 +939,42 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			})
 
 			Eventually(principalServiceMonitor, "2m", "2s").Should(k8sFixture.NotExistByName())
+		})
+
+		It("shouldn't create ClusterRole and ClusterRoleBinding for principal if spec.DefaultClusterScopedRoleDisabled is set", func() {
+			By("Create ArgoCD instance with principal enabled and DefaultClusterScopedRoleDisabled is true")
+			argoCD.Spec.DefaultClusterScopedRoleDisabled = true
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("Verify Argo CD CR is reconciled")
+			Eventually(principalDeployment).Should(k8sFixture.ExistByName())
+
+			By("Verify ClusterRole and ClusterRoleBinding do not exist")
+			Eventually(clusterRole, "60s", "2s").Should(k8sFixture.NotExistByName())
+			Eventually(clusterRoleBinding, "60s", "2s").Should(k8sFixture.NotExistByName())
+
+			Consistently(clusterRole, "15s", "2s").Should(k8sFixture.NotExistByName())
+			Consistently(clusterRoleBinding, "15s", "2s").Should(k8sFixture.NotExistByName())
+
+			By("Namespaced RBAC objects should still exist")
+			Eventually(role, "60s", "2s").Should(k8sFixture.ExistByName())
+			Eventually(roleBinding, "60s", "2s").Should(k8sFixture.ExistByName())
+
+			By("Unset DefaultClusterScopedRoleDisabled and make sure cluster scoped RBAC objects are created")
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.DefaultClusterScopedRoleDisabled = false
+			})
+			Eventually(clusterRole, "60s", "2s").Should(k8sFixture.ExistByName())
+			Eventually(clusterRoleBinding, "60s", "2s").Should(k8sFixture.ExistByName())
+
+			By("Setting DefaultClusterScopedRoleDisabled again deletes clusterRole and clusterRoleBinding")
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.DefaultClusterScopedRoleDisabled = true
+			})
+			Eventually(clusterRole, "60s", "2s").Should(k8sFixture.NotExistByName())
+			Eventually(clusterRoleBinding, "60s", "2s").Should(k8sFixture.NotExistByName())
+			Consistently(clusterRole, "10s", "2s").Should(k8sFixture.NotExistByName())
+			Consistently(clusterRoleBinding, "10s", "2s").Should(k8sFixture.NotExistByName())
 		})
 	})
 })

--- a/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -429,7 +429,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				ac.Spec.ArgoCDAgent.Principal.LogFormat = "json"
 				ac.Spec.ArgoCDAgent.Principal.Server.KeepAliveMinInterval = "60s"
 				ac.Spec.ArgoCDAgent.Principal.Server.EnableWebSocket = ptr.To(true)
-				ac.Spec.ArgoCDAgent.Principal.Image = "quay.io/argoprojlabs/argocd-agent:v0.5.1"
+				ac.Spec.ArgoCDAgent.Principal.Image = "quay.io/argoprojlabs/argocd-agent:v0.8.1"
 
 				ac.Spec.ArgoCDAgent.Principal.Namespace.AllowedNamespaces = []string{"agent-managed", "agent-autonomous"}
 				ac.Spec.ArgoCDAgent.Principal.Namespace.EnableNamespaceCreate = ptr.To(true)
@@ -475,7 +475,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					if container == nil {
 						return false
 					}
-					return container.Image == "quay.io/argoprojlabs/argocd-agent:v0.5.1"
+					return container.Image == "quay.io/argoprojlabs/argocd-agent:v0.8.1"
 				}, "120s", "5s").Should(BeTrue(), "Principal deployment should have the updated image")
 
 			By("verify that deployment is in Ready state")

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -624,7 +624,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("shouldn't create ClusterRole and ClusterRoleBinding for agent if spec.DefaultClusterScopedRoleDisabled is set", func() {
-			By("Create ArgoCD instance with principal enabled and DefaultClusterScopedRoleDisabled is true")
+			By("Create ArgoCD instance with agent enabled and DefaultClusterScopedRoleDisabled is true")
 			argoCD.Spec.DefaultClusterScopedRoleDisabled = true
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -67,6 +67,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
+			fixture.SetEnvInOperatorSubscriptionOrDeployment("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "openshift-gitops, argocd-agent-agent-1-052")
+
 			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
 			ctx = context.Background()
 			ns, cleanupFunc = fixture.CreateNamespaceWithCleanupFunc("argocd-agent-agent-1-052")

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -33,22 +33,20 @@ import (
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argocdagent/agent"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
-	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
-	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
-	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
-	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
+	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
+	deploymentFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/deployment"
+	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
+	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
 )
 
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
-
 	const (
 		argoCDName           = "example"
 		argoCDAgentAgentName = "example-agent-agent" // argoCDName + "-agent-agent"
 	)
 
 	Context("1-052_validate_argocd_agent_agent", func() {
-
 		var (
 			k8sClient            client.Client
 			ctx                  context.Context
@@ -69,8 +67,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
-			fixture.SetEnvInOperatorSubscriptionOrDeployment("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "openshift-gitops, argocd-agent-agent-1-052")
-
 			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
 			ctx = context.Background()
 			ns, cleanupFunc = fixture.CreateNamespaceWithCleanupFunc("argocd-agent-agent-1-052")
@@ -203,12 +199,12 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		// verifyExpectedResourcesExist will verify that the resources that are created for agent and ArgoCD are created.
 		verifyExpectedResourcesExist := func(ns *corev1.Namespace) {
-
 			By("verifying expected resources exist")
 			Eventually(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: secretNames[2], Namespace: ns.Name,
-				}}, "60s", "2s").Should(k8sFixture.ExistByName())
+				},
+			}, "60s", "2s").Should(k8sFixture.ExistByName())
 			Eventually(serviceAccount).Should(k8sFixture.ExistByName())
 			Eventually(role).Should(k8sFixture.ExistByName())
 			Eventually(roleBinding).Should(k8sFixture.ExistByName())
@@ -260,7 +256,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		// verifyResourcesDeleted will verify that the various resources that are created for agent are deleted.
 		verifyResourcesDeleted := func() {
-
 			By("verifying resources are deleted for agent pod")
 
 			Eventually(serviceAccount).Should(k8sFixture.NotExistByName())
@@ -323,7 +318,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("should create argocd agent agent resources with default image, but pod will not start without principal", func() {
-
 			// Add a custom environment variable to the agent client
 			argoCD.Spec.ArgoCDAgent.Agent.Env = []corev1.EnvVar{{Name: "TEST_ENV", Value: "test_value"}}
 
@@ -369,7 +363,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", func() {
-
 			By("Create ArgoCD instance")
 
 			argoCD.Spec.ArgoCDAgent.Agent.Image = common.ArgoCDAgentAgentDefaultImageName
@@ -397,10 +390,9 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: argoCDName, Namespace: ns.Name}, argoCD)).To(Succeed())
 
 			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
-
 				ac.Spec.ArgoCDAgent.Agent.LogLevel = "trace"
 				ac.Spec.ArgoCDAgent.Agent.LogFormat = "json"
-				ac.Spec.ArgoCDAgent.Agent.Image = "quay.io/argoprojlabs/argocd-agent:v0.8.1"
+				ac.Spec.ArgoCDAgent.Agent.Image = "quay.io/argoprojlabs/argocd-agent:v0.5.1"
 
 				ac.Spec.ArgoCDAgent.Agent.Client.KeepAliveInterval = "60s"
 				ac.Spec.ArgoCDAgent.Agent.Client.EnableWebSocket = ptr.To(true)
@@ -412,7 +404,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				ac.Spec.ArgoCDAgent.Agent.TLS.Insecure = ptr.To(true)
 				ac.Spec.ArgoCDAgent.Agent.TLS.SecretName = "argocd-agent-client-tls-v2"
 				ac.Spec.ArgoCDAgent.Agent.TLS.RootCASecretName = "argocd-agent-ca-v2"
-
 			})
 
 			By("Verify agent has the updated image we specified in ArgoCD CR")
@@ -430,7 +421,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					if container == nil {
 						return false
 					}
-					return container.Image == "quay.io/argoprojlabs/argocd-agent:v0.8.1"
+					return container.Image == "quay.io/argoprojlabs/argocd-agent:v0.5.1"
 				}, "120s", "5s").Should(BeTrue(), "Agent deployment should have the updated image")
 
 			By("Verify environment variables are updated correctly")
@@ -453,7 +444,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("should deploy agent via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", func() {
-
 			By("Create namespace-scoped ArgoCD instance")
 
 			// Create namespace for hosting namespace-scoped ArgoCD instance with agent
@@ -507,7 +497,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("should delete existing cluster role and cluster role binding if ArgoCD instance is namespace-scoped", func() {
-
 			By("Create namespace-scoped ArgoCD instance namespace")
 
 			// Create namespace for hosting namespace-scoped ArgoCD instance with agent
@@ -587,7 +576,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", func() {
-
 			By("Create ArgoCD instance with agent enabled and prometheus enabled")
 
 			argoCD.Spec.Prometheus.Enabled = true
@@ -633,6 +621,41 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			})
 
 			Eventually(agentServiceMonitor, "2m", "2s").Should(k8sFixture.NotExistByName())
+		})
+
+		It("shouldn't create ClusterRole and ClusterRoleBinding for agent if spec.DefaultClusterScopedRoleDisabled is set", func() {
+			By("Create ArgoCD instance with principal enabled and DefaultClusterScopedRoleDisabled is true")
+			argoCD.Spec.DefaultClusterScopedRoleDisabled = true
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("Verify Argo CD becomes available")
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+
+			By("Verify ClusterRole and ClusterRoleBinding do not exist")
+			Eventually(clusterRole, "60s", "2s").Should(k8sFixture.NotExistByName())
+			Eventually(clusterRoleBinding, "60s", "2s").Should(k8sFixture.NotExistByName())
+			Consistently(clusterRole, "15s", "2s").Should(k8sFixture.NotExistByName())
+			Consistently(clusterRoleBinding, "15s", "2s").Should(k8sFixture.NotExistByName())
+
+			By("Namespaced RBAC objects should still exist")
+			Eventually(role, "60s", "2s").Should(k8sFixture.ExistByName())
+			Eventually(roleBinding, "60s", "2s").Should(k8sFixture.ExistByName())
+
+			By("Unset DefaultClusterScopedRoleDisabled and make sure cluster scoped RBAC objects are created")
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.DefaultClusterScopedRoleDisabled = false
+			})
+			Eventually(clusterRole, "60s", "2s").Should(k8sFixture.ExistByName())
+			Eventually(clusterRoleBinding, "60s", "2s").Should(k8sFixture.ExistByName())
+
+			By("Setting DefaultClusterScopedRoleDisabled again deletes clusterRole and clusterRoleBinding")
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.DefaultClusterScopedRoleDisabled = true
+			})
+			Eventually(clusterRole, "60s", "2s").Should(k8sFixture.NotExistByName())
+			Eventually(clusterRoleBinding, "60s", "2s").Should(k8sFixture.NotExistByName())
+			Consistently(clusterRole, "10s", "2s").Should(k8sFixture.NotExistByName())
+			Consistently(clusterRoleBinding, "10s", "2s").Should(k8sFixture.NotExistByName())
 		})
 	})
 })

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -33,11 +33,11 @@ import (
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argocdagent/agent"
-	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
-	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
-	deploymentFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/deployment"
-	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
-	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
+	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
+	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
+	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
+	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
+	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 )
 
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
@@ -392,7 +392,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
 				ac.Spec.ArgoCDAgent.Agent.LogLevel = "trace"
 				ac.Spec.ArgoCDAgent.Agent.LogFormat = "json"
-				ac.Spec.ArgoCDAgent.Agent.Image = "quay.io/argoprojlabs/argocd-agent:v0.5.1"
+				ac.Spec.ArgoCDAgent.Agent.Image = "quay.io/argoprojlabs/argocd-agent:v0.8.1"
 
 				ac.Spec.ArgoCDAgent.Agent.Client.KeepAliveInterval = "60s"
 				ac.Spec.ArgoCDAgent.Agent.Client.EnableWebSocket = ptr.To(true)
@@ -421,7 +421,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					if container == nil {
 						return false
 					}
-					return container.Image == "quay.io/argoprojlabs/argocd-agent:v0.5.1"
+					return container.Image == "quay.io/argoprojlabs/argocd-agent:v0.8.1"
 				}, "120s", "5s").Should(BeTrue(), "Agent deployment should have the updated image")
 
 			By("Verify environment variables are updated correctly")


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

In Argo CD Operator PR [#2237](https://github.com/argoproj-labs/argocd-operator/pull/2237) there is a new e2e test added for both verifying the principal and agent for Argo CD Agent. This PR syncs those tests to this repo. 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

NA

**Test acceptance criteria**:

* [ ] Unit Test
* [X] E2E Test

**How to test changes / Special notes to the reviewer**:

Run e2e tests and ensure that they pass.