### PR TITLE
Mark openshift & xKS e2e tests 

### DIFF
--- a/.github/workflows/kind-ci-automation.yaml
+++ b/.github/workflows/kind-ci-automation.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           cluster_name: gitops-test
+          config: test/kind-config.yaml
 
       # TODO: check if porting is required for non-OCP clusters
       - name: Disable webhook and conversion for non-OCP cluster
@@ -61,7 +62,6 @@ jobs:
       - name: Deploy operator
         run: |
           set -o pipefail
-          echo "manifests: $(KUSTOMIZE) build config/default"
           make deploy IMG=${{ env.IMG }} 2>&1 | tee "${{ env.LOG_DIR }}/deploy.log"
 
       - name: Verify Controller Manager deployment is available

--- a/.github/workflows/kind-ci-automation.yaml
+++ b/.github/workflows/kind-ci-automation.yaml
@@ -1,4 +1,4 @@
-name: Build, Deploy and Test on kind
+name: Build, Deploy and Test on KinD
 
 on:
   pull_request:

--- a/.github/workflows/kind-ci-automation.yaml
+++ b/.github/workflows/kind-ci-automation.yaml
@@ -8,6 +8,7 @@ on:
 
 env:
   IMG: gitops-operator:test
+  LOG_DIR: /tmp/kind-ci-artifacts
 
 jobs:
   ci-build:
@@ -21,6 +22,9 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: 'go.mod'
+
+      - name: Prepare log directory
+        run: mkdir -p "${{ env.LOG_DIR }}"
 
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
@@ -40,7 +44,8 @@ jobs:
   
       - name: Build manager image
         run: |
-          make docker-build IMG=${{ env.IMG }}
+          set -o pipefail
+          make docker-build IMG=${{ env.IMG }} 2>&1 | tee "${{ env.LOG_DIR }}/docker-build.log"
 
       - name: Load image into kind
         run: |
@@ -52,103 +57,37 @@ jobs:
 
       - name: Deploy operator
         run: |
+          set -o pipefail
           echo "manifests: $(KUSTOMIZE) build config/default"
-          make deploy IMG=${{ env.IMG }} | tee /tmp/deploy.log
+          make deploy IMG=${{ env.IMG }} 2>&1 | tee "${{ env.LOG_DIR }}/deploy.log"
 
       - name: Verify Controller Manager deployment is available
         run: |
-          kubectl get deployment -n openshift-gitops-operator
-          kubectl describe deployment -n openshift-gitops-operator
-          kubectl wait --for=condition=available --timeout=300s \
-            deployment/openshift-gitops-operator-controller-manager \
-            -n openshift-gitops-operator
+          set -o pipefail
+          {
+            kubectl get deployment -n openshift-gitops-operator
+            kubectl describe deployment -n openshift-gitops-operator
+            kubectl wait --for=condition=available --timeout=300s \
+              deployment/openshift-gitops-operator-controller-manager \
+              -n openshift-gitops-operator
+          } 2>&1 | tee "${{ env.LOG_DIR }}/verify-deployment.log"
 
-      - name: Create ArgoCD instance
+      - name: Run E2E tests Sequential on xKS
         run: |
-          kubectl create ns test-argocd
-          kubectl apply -f - <<'EOF'
-          apiVersion: argoproj.io/v1beta1
-          kind: ArgoCD
-          metadata:
-            name: argocd
-            namespace: test-argocd
-          EOF
+          set -o pipefail
+          NON_OLM=true make e2e-xks-tests-sequential-ginkgo 2>&1 | tee "${{ env.LOG_DIR }}/e2e-sequential.log"
 
-      - name: Wait for ArgoCD component pods to exist
+      - name: Run E2E tests Parallel on xKS
         run: |
-          EXPECTED_LABELS=("argocd-application-controller" "argocd-redis" "argocd-repo-server" "argocd-server")
-          TIMEOUT=300
-          INTERVAL=10
-          ELAPSED=0
+          set -o pipefail
+          NON_OLM=true make e2e-xks-tests-parallel-ginkgo 2>&1 | tee "${{ env.LOG_DIR }}/e2e-parallel.log"
 
-          echo "Waiting for ArgoCD component pods to exist in test-argocd..."
-          while true; do
-            ALL_EXIST=true
-            for label in "${EXPECTED_LABELS[@]}"; do
-              if ! kubectl get pod -n test-argocd -l "app.kubernetes.io/name=${label}" --no-headers 2>/dev/null | grep -q .; then
-                ALL_EXIST=false
-                break
-              fi
-            done
-
-            if $ALL_EXIST; then
-              echo "All ArgoCD component pods exist after ${ELAPSED}s."
-              break
-            fi
-
-            if [ $ELAPSED -ge $TIMEOUT ]; then
-              echo "Timed out after ${TIMEOUT}s waiting for ArgoCD pods."
-              kubectl get pods -n test-argocd
-              kubectl get argocd -n test-argocd -o yaml
-              exit 1
-            fi
-
-            sleep $INTERVAL
-            ELAPSED=$((ELAPSED + INTERVAL))
-          done
-
-      - name: Verify ArgoCD components are ready
-        run: |
-          kubectl get pods -n test-argocd
-          kubectl wait --for=condition=Ready -n test-argocd pod --timeout=300s \
-            -l 'app.kubernetes.io/name in (argocd-application-controller,argocd-redis,argocd-repo-server,argocd-server)'
-          echo "All ArgoCD components are ready."
-          kubectl get pods -n test-argocd
-
-      - name: Collect operator debug info on failure
-        if: failure()
-        run: |
-          echo "=== Deployment status ==="
-          kubectl get deployment -n openshift-gitops-operator -o wide || true
-          echo ""
-          echo "=== Pod status ==="
-          kubectl get pods -n openshift-gitops-operator -o wide || true
-          echo ""
-          echo "=== Pod descriptions ==="
-          kubectl describe pods -n openshift-gitops-operator || true
-          echo ""
-          echo "=== Controller manager logs ==="
-          kubectl logs deployment/openshift-gitops-operator-controller-manager \
-            -n openshift-gitops-operator --all-containers=true --tail=200 || true
-          echo ""
-          echo "=== Events in operator namespace ==="
-          kubectl get events -n openshift-gitops-operator --sort-by='.lastTimestamp' || true
-          echo ""
-          echo "=== CRD conversion config ==="
-          kubectl get crd argocds.argoproj.io -o jsonpath='{.spec.conversion}' || true
-          echo ""
-
-      - name: Collect ArgoCD debug info on failure
-        if: failure()
-        run: |
-          echo "=== ArgoCD resources ==="
-          kubectl get argocds -n test-argocd -o yaml 2>/dev/null || true
-          echo ""
-          echo "=== Pods in test-argocd ==="
-          kubectl get pods -n test-argocd -o wide 2>/dev/null || true
-          echo ""
-          echo "=== Pod descriptions in test-argocd ==="
-          kubectl describe pods -n test-argocd 2>/dev/null || true
-          echo ""
-          echo "=== Events in test-argocd ==="
-          kubectl get events -n test-argocd --sort-by='.lastTimestamp' 2>/dev/null || true
+      - name: Upload CI artifacts
+        if: always()
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df2034c6ff2643ca6 # v4.3.2
+        with:
+          name: kind-ci-artifacts-${{ github.run_id }}
+          path: ${{ env.LOG_DIR }}/
+          if-no-files-found: ignore
+          retention-days: 7
+      

--- a/.github/workflows/kind-ci-automation.yaml
+++ b/.github/workflows/kind-ci-automation.yaml
@@ -6,6 +6,9 @@ on:
       - "master"
       - "v*"
 
+permissions:
+  contents: read
+
 env:
   IMG: gitops-operator:test
   LOG_DIR: /tmp/kind-ci-artifacts
@@ -84,7 +87,7 @@ jobs:
 
       - name: Upload CI artifacts
         if: always()
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df2034c6ff2643ca6 # v4.3.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kind-ci-artifacts-${{ github.run_id }}
           path: ${{ env.LOG_DIR }}/

--- a/.github/workflows/kind-ci-automation.yaml
+++ b/.github/workflows/kind-ci-automation.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           cluster_name: gitops-test
+          config: test/kind-config.yaml
 
       # TODO: check if porting is required for non-OCP clusters
       - name: Disable webhook and conversion for non-OCP cluster
@@ -65,7 +66,6 @@ jobs:
       - name: Deploy operator
         run: |
           set -o pipefail
-          echo "manifests: $(KUSTOMIZE) build config/default"
           make deploy IMG=${{ env.IMG }} 2>&1 | tee "${{ env.LOG_DIR }}/deploy.log"
 
       - name: Verify Controller Manager deployment is available

--- a/.github/workflows/kind-ci-automation.yaml
+++ b/.github/workflows/kind-ci-automation.yaml
@@ -12,6 +12,7 @@ on:
 
 env:
   IMG: gitops-operator:test
+  LOG_DIR: /tmp/kind-ci-artifacts
 
 jobs:
   ci-build:
@@ -25,6 +26,9 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: 'go.mod'
+
+      - name: Prepare log directory
+        run: mkdir -p "${{ env.LOG_DIR }}"
 
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
@@ -44,7 +48,8 @@ jobs:
   
       - name: Build manager image
         run: |
-          make docker-build IMG=${{ env.IMG }}
+          set -o pipefail
+          make docker-build IMG=${{ env.IMG }} 2>&1 | tee "${{ env.LOG_DIR }}/docker-build.log"
 
       - name: Load image into kind
         run: |
@@ -56,103 +61,37 @@ jobs:
 
       - name: Deploy operator
         run: |
+          set -o pipefail
           echo "manifests: $(KUSTOMIZE) build config/default"
-          make deploy IMG=${{ env.IMG }} | tee /tmp/deploy.log
+          make deploy IMG=${{ env.IMG }} 2>&1 | tee "${{ env.LOG_DIR }}/deploy.log"
 
       - name: Verify Controller Manager deployment is available
         run: |
-          kubectl get deployment -n openshift-gitops-operator
-          kubectl describe deployment -n openshift-gitops-operator
-          kubectl wait --for=condition=available --timeout=300s \
-            deployment/openshift-gitops-operator-controller-manager \
-            -n openshift-gitops-operator
+          set -o pipefail
+          {
+            kubectl get deployment -n openshift-gitops-operator
+            kubectl describe deployment -n openshift-gitops-operator
+            kubectl wait --for=condition=available --timeout=300s \
+              deployment/openshift-gitops-operator-controller-manager \
+              -n openshift-gitops-operator
+          } 2>&1 | tee "${{ env.LOG_DIR }}/verify-deployment.log"
 
-      - name: Create ArgoCD instance
+      - name: Run E2E tests Sequential on xKS
         run: |
-          kubectl create ns test-argocd
-          kubectl apply -f - <<'EOF'
-          apiVersion: argoproj.io/v1beta1
-          kind: ArgoCD
-          metadata:
-            name: argocd
-            namespace: test-argocd
-          EOF
+          set -o pipefail
+          NON_OLM=true make e2e-xks-tests-sequential-ginkgo 2>&1 | tee "${{ env.LOG_DIR }}/e2e-sequential.log"
 
-      - name: Wait for ArgoCD component pods to exist
+      - name: Run E2E tests Parallel on xKS
         run: |
-          EXPECTED_LABELS=("argocd-application-controller" "argocd-redis" "argocd-repo-server" "argocd-server")
-          TIMEOUT=300
-          INTERVAL=10
-          ELAPSED=0
+          set -o pipefail
+          NON_OLM=true make e2e-xks-tests-parallel-ginkgo 2>&1 | tee "${{ env.LOG_DIR }}/e2e-parallel.log"
 
-          echo "Waiting for ArgoCD component pods to exist in test-argocd..."
-          while true; do
-            ALL_EXIST=true
-            for label in "${EXPECTED_LABELS[@]}"; do
-              if ! kubectl get pod -n test-argocd -l "app.kubernetes.io/name=${label}" --no-headers 2>/dev/null | grep -q .; then
-                ALL_EXIST=false
-                break
-              fi
-            done
-
-            if $ALL_EXIST; then
-              echo "All ArgoCD component pods exist after ${ELAPSED}s."
-              break
-            fi
-
-            if [ $ELAPSED -ge $TIMEOUT ]; then
-              echo "Timed out after ${TIMEOUT}s waiting for ArgoCD pods."
-              kubectl get pods -n test-argocd
-              kubectl get argocd -n test-argocd -o yaml
-              exit 1
-            fi
-
-            sleep $INTERVAL
-            ELAPSED=$((ELAPSED + INTERVAL))
-          done
-
-      - name: Verify ArgoCD components are ready
-        run: |
-          kubectl get pods -n test-argocd
-          kubectl wait --for=condition=Ready -n test-argocd pod --timeout=300s \
-            -l 'app.kubernetes.io/name in (argocd-application-controller,argocd-redis,argocd-repo-server,argocd-server)'
-          echo "All ArgoCD components are ready."
-          kubectl get pods -n test-argocd
-
-      - name: Collect operator debug info on failure
-        if: failure()
-        run: |
-          echo "=== Deployment status ==="
-          kubectl get deployment -n openshift-gitops-operator -o wide || true
-          echo ""
-          echo "=== Pod status ==="
-          kubectl get pods -n openshift-gitops-operator -o wide || true
-          echo ""
-          echo "=== Pod descriptions ==="
-          kubectl describe pods -n openshift-gitops-operator || true
-          echo ""
-          echo "=== Controller manager logs ==="
-          kubectl logs deployment/openshift-gitops-operator-controller-manager \
-            -n openshift-gitops-operator --all-containers=true --tail=200 || true
-          echo ""
-          echo "=== Events in operator namespace ==="
-          kubectl get events -n openshift-gitops-operator --sort-by='.lastTimestamp' || true
-          echo ""
-          echo "=== CRD conversion config ==="
-          kubectl get crd argocds.argoproj.io -o jsonpath='{.spec.conversion}' || true
-          echo ""
-
-      - name: Collect ArgoCD debug info on failure
-        if: failure()
-        run: |
-          echo "=== ArgoCD resources ==="
-          kubectl get argocds -n test-argocd -o yaml 2>/dev/null || true
-          echo ""
-          echo "=== Pods in test-argocd ==="
-          kubectl get pods -n test-argocd -o wide 2>/dev/null || true
-          echo ""
-          echo "=== Pod descriptions in test-argocd ==="
-          kubectl describe pods -n test-argocd 2>/dev/null || true
-          echo ""
-          echo "=== Events in test-argocd ==="
-          kubectl get events -n test-argocd --sort-by='.lastTimestamp' 2>/dev/null || true
+      - name: Upload CI artifacts
+        if: always()
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df2034c6ff2643ca6 # v4.3.2
+        with:
+          name: kind-ci-artifacts-${{ github.run_id }}
+          path: ${{ env.LOG_DIR }}/
+          if-no-files-found: ignore
+          retention-days: 7
+      

--- a/.github/workflows/kind-ci-automation.yaml
+++ b/.github/workflows/kind-ci-automation.yaml
@@ -10,6 +10,9 @@ on:
       - "master"
       - "v*"
 
+permissions:
+  contents: read
+
 env:
   IMG: gitops-operator:test
   LOG_DIR: /tmp/kind-ci-artifacts
@@ -88,7 +91,7 @@ jobs:
 
       - name: Upload CI artifacts
         if: always()
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df2034c6ff2643ca6 # v4.3.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kind-ci-artifacts-${{ github.run_id }}
           path: ${{ env.LOG_DIR }}/

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,9 @@ SHELL = /usr/bin/env bash -o pipefail
 # example: go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v3
 GINKGO_VERSION := $(shell go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)
 
+# XKS_LABEL_FILTER is the label filter for XKS tests.
+XKS_LABEL_FILTER ?= "!openshfit"
+
 .PHONY: all
 all: build
 
@@ -181,12 +184,12 @@ e2e-tests-parallel:
 .PHONY: e2e-xks-tests-sequential-ginkgo
 e2e-xks-tests-sequential-ginkgo: ginkgo ## Runs Ginkgo e2e sequential tests
 	@echo "Running GitOps Operator sequential Ginkgo E2E tests..."
-	$(GINKGO_CLI) -v --trace --label-filter="!notOnXKS" --timeout 240m -r ./test/openshift/e2e/ginkgo/sequential
+	$(GINKGO_CLI) -v --trace --label-filter="$(XKS_LABEL_FILTER)" --timeout 240m -r ./test/openshift/e2e/ginkgo/sequential
 
 .PHONY: e2e-xks-tests-parallel-ginkgo ## Runs Ginkgo e2e parallel tests, (Defaults to 5 runs at a time)
 e2e-xks-tests-parallel-ginkgo: ginkgo
 	@echo "Running GitOps Operator parallel Ginkgo E2E tests..."
-	$(GINKGO_CLI) -p -v -procs=5 --trace --label-filter="!notOnXKS" --timeout 60m -r ./test/openshift/e2e/ginkgo/parallel
+	$(GINKGO_CLI) -p -v -procs=5 --trace --label-filter="$(XKS_LABEL_FILTER)" --timeout 60m -r ./test/openshift/e2e/ginkgo/parallel
 
 ##@ Build
 

--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,16 @@ e2e-tests-sequential:
 e2e-tests-parallel:
 	CI=prow make e2e-tests-parallel-ginkgo
 
+.PHONY: e2e-xks-tests-sequential-ginkgo
+e2e-xks-tests-sequential-ginkgo: ginkgo ## Runs Ginkgo e2e sequential tests
+	@echo "Running GitOps Operator sequential Ginkgo E2E tests..."
+	$(GINKGO_CLI) -v --trace --label-filter="!notOnXKS" --timeout 240m -r ./test/openshift/e2e/ginkgo/sequential
+
+.PHONY: e2e-xks-tests-parallel-ginkgo ## Runs Ginkgo e2e parallel tests, (Defaults to 5 runs at a time)
+e2e-xks-tests-parallel-ginkgo: ginkgo
+	@echo "Running GitOps Operator parallel Ginkgo E2E tests..."
+	$(GINKGO_CLI) -p -v -procs=5 --trace --label-filter="!notOnXKS" --timeout 60m -r ./test/openshift/e2e/ginkgo/parallel
+
 ##@ Build
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,12 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# GINKGO_VERSION is the version of ginkgo to use.
+# Pick ginkgo version from go.mod file.
+# Update this command when ginkgo version is updated in go.mod file. 
+# example: go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v3
+GINKGO_VERSION := $(shell go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)
+
 .PHONY: all
 all: build
 
@@ -247,7 +253,7 @@ kustomize: ## Download kustomize locally if necessary.
 GINKGO_CLI = $(shell pwd)/bin/ginkgo
 .PHONY: ginkgo
 ginkgo: ## Download ginkgo locally if necessary.
-	$(call go-get-tool,$(GINKGO_CLI),github.com/onsi/ginkgo/v2/ginkgo@v2.29.0)
+	$(call go-get-tool,$(GINKGO_CLI),github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION))
 
 
 # go-get-tool will 'go install' any package $2 and install it to $1.

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ SHELL = /usr/bin/env bash -o pipefail
 GINKGO_VERSION := $(shell go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)
 
 # XKS_LABEL_FILTER is the label filter for XKS tests.
-XKS_LABEL_FILTER ?= "!openshfit"
+XKS_LABEL_FILTER ?= "!openshift"
 
 .PHONY: all
 all: build
@@ -184,12 +184,12 @@ e2e-tests-parallel:
 .PHONY: e2e-xks-tests-sequential-ginkgo
 e2e-xks-tests-sequential-ginkgo: ginkgo ## Runs Ginkgo e2e sequential tests
 	@echo "Running GitOps Operator sequential Ginkgo E2E tests..."
-	$(GINKGO_CLI) -v --trace --label-filter="$(XKS_LABEL_FILTER)" --timeout 240m -r ./test/openshift/e2e/ginkgo/sequential
+	$(GINKGO_CLI) -v --trace --label-filter=$(XKS_LABEL_FILTER) --timeout 240m -r ./test/openshift/e2e/ginkgo/sequential 
 
 .PHONY: e2e-xks-tests-parallel-ginkgo ## Runs Ginkgo e2e parallel tests, (Defaults to 5 runs at a time)
 e2e-xks-tests-parallel-ginkgo: ginkgo
 	@echo "Running GitOps Operator parallel Ginkgo E2E tests..."
-	$(GINKGO_CLI) -p -v -procs=5 --trace --label-filter="$(XKS_LABEL_FILTER)" --timeout 60m -r ./test/openshift/e2e/ginkgo/parallel
+	$(GINKGO_CLI) -p -v -procs=5 --trace --label-filter=$(XKS_LABEL_FILTER) --timeout 60m -r ./test/openshift/e2e/ginkgo/parallel
 
 ##@ Build
 

--- a/test/e2e/argocd_route_test.go
+++ b/test/e2e/argocd_route_test.go
@@ -33,15 +33,15 @@ var _ = Describe("Argo CD ConsoleLink controller", func() {
 		route := &routev1.Route{}
 		consoleLink := &console.ConsoleLink{}
 
-		It("Argocd route is present", Label("notOnXKS"), func() {
+		It("Argocd route is present", Label("openshfit"), func() {
 			checkIfPresent(types.NamespacedName{Name: argoCDRouteName, Namespace: argoCDNamespace}, route)
 		})
 
-		It("ConsoleLink is created", Label("notOnXKS"), func() {
+		It("ConsoleLink is created", Label("openshfit"), func() {
 			checkIfPresent(types.NamespacedName{Name: consoleLinkName}, consoleLink)
 		})
 
-		It("ConsoleLink and argocd route should match", Label("notOnXKS"), func() {
+		It("ConsoleLink and argocd route should match", Label("openshfit"), func() {
 			Eventually(func() error {
 				err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: consoleLinkName}, consoleLink)
 				if err != nil {

--- a/test/e2e/argocd_route_test.go
+++ b/test/e2e/argocd_route_test.go
@@ -33,15 +33,15 @@ var _ = Describe("Argo CD ConsoleLink controller", func() {
 		route := &routev1.Route{}
 		consoleLink := &console.ConsoleLink{}
 
-		It("Argocd route is present", func() {
+		It("Argocd route is present", Label("openshift"), func() {
 			checkIfPresent(types.NamespacedName{Name: argoCDRouteName, Namespace: argoCDNamespace}, route)
 		})
 
-		It("ConsoleLink is created", func() {
+		It("ConsoleLink is created", Label("openshift"), func() {
 			checkIfPresent(types.NamespacedName{Name: consoleLinkName}, consoleLink)
 		})
 
-		It("ConsoleLink and argocd route should match", func() {
+		It("ConsoleLink and argocd route should match", Label("openshift"), func() {
 			Eventually(func() error {
 				err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: consoleLinkName}, consoleLink)
 				if err != nil {

--- a/test/e2e/argocd_route_test.go
+++ b/test/e2e/argocd_route_test.go
@@ -33,15 +33,15 @@ var _ = Describe("Argo CD ConsoleLink controller", func() {
 		route := &routev1.Route{}
 		consoleLink := &console.ConsoleLink{}
 
-		It("Argocd route is present", Label("openshift"), func() {
+		It("Argocd route is present", Label("notOnXKS"), func() {
 			checkIfPresent(types.NamespacedName{Name: argoCDRouteName, Namespace: argoCDNamespace}, route)
 		})
 
-		It("ConsoleLink is created", Label("openshift"), func() {
+		It("ConsoleLink is created", Label("notOnXKS"), func() {
 			checkIfPresent(types.NamespacedName{Name: consoleLinkName}, consoleLink)
 		})
 
-		It("ConsoleLink and argocd route should match", Label("openshift"), func() {
+		It("ConsoleLink and argocd route should match", Label("notOnXKS"), func() {
 			Eventually(func() error {
 				err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: consoleLinkName}, consoleLink)
 				if err != nil {

--- a/test/e2e/argocd_route_test.go
+++ b/test/e2e/argocd_route_test.go
@@ -33,15 +33,15 @@ var _ = Describe("Argo CD ConsoleLink controller", func() {
 		route := &routev1.Route{}
 		consoleLink := &console.ConsoleLink{}
 
-		It("Argocd route is present", Label("openshfit"), func() {
+		It("Argocd route is present", Label("openshift"), func() {
 			checkIfPresent(types.NamespacedName{Name: argoCDRouteName, Namespace: argoCDNamespace}, route)
 		})
 
-		It("ConsoleLink is created", Label("openshfit"), func() {
+		It("ConsoleLink is created", Label("openshift"), func() {
 			checkIfPresent(types.NamespacedName{Name: consoleLinkName}, consoleLink)
 		})
 
-		It("ConsoleLink and argocd route should match", Label("openshfit"), func() {
+		It("ConsoleLink and argocd route should match", Label("openshift"), func() {
 			Eventually(func() error {
 				err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: consoleLinkName}, consoleLink)
 				if err != nil {

--- a/test/kind-config.yaml
+++ b/test/kind-config.yaml
@@ -1,0 +1,6 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker

--- a/test/kind-config.yaml
+++ b/test/kind-config.yaml
@@ -2,5 +2,10 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          taints: []
   - role: worker
   - role: worker

--- a/test/openshift/e2e/README.md
+++ b/test/openshift/e2e/README.md
@@ -94,6 +94,56 @@ SKIP_HA_TESTS=true LOCAL_RUN=true  make e2e-tests-sequential-ginkgo
 
 
 
+## Test Labels
+
+Ginkgo [labels](https://onsi.github.io/ginkgo/#spec-labels) are used to categorize tests that are only supported on specific platforms or configurations. Labels allow the CI system to filter tests using `--label-filter` at runtime.
+
+**Important**: Labels should only be applied to tests that are restricted to a specific platform or configuration. Do NOT add labels to generic tests that can run on any Kubernetes cluster (OpenShift, KinD, EKS, etc.). If a test works everywhere, it should remain unlabelled.
+
+### Available labels
+
+| Label | Meaning | When to use |
+|-------|---------|-------------|
+| `openshfit` | Test requires OpenShift-specific features (Routes, ConsoleLinks, OLM Subscriptions, SCCs, etc.) and cannot run on vanilla Kubernetes (KinD, EKS, GKE, AKS). | Add when the test depends on OpenShift APIs or resources not available on non-OCP clusters. |
+| `HA` | Test requires a cluster with at least 3 worker nodes for HA (High Availability) validation. | Add when the test creates HA Redis StatefulSets or validates pod anti-affinity across nodes. |
+| `conversionWebhook` | Test requires the ArgoCD v1alpha1 ↔ v1beta1 conversion webhook to be running. | Add when the test exercises CRD conversion between API versions. |
+
+### How labels are used in CI
+
+- **OpenShift CI**: Runs all tests (no label filter), so all labelled and unlabelled tests execute.
+- **xKS/KinD CI** (`make e2e-xks-tests-sequential-ginkgo` / `make e2e-xks-tests-parallel-ginkgo`): Uses `--label-filter="!openshfit"` to exclude OpenShift-only tests. The `XKS_LABEL_FILTER` env var can further customize filtering (e.g., `XKS_LABEL_FILTER="!openshfit && !HA"`).
+
+### How to apply a label
+
+Add the `Label(...)` decorator to `It`, `Context`, or `Describe` nodes:
+
+```go
+// Single label — test requires OpenShift
+It("verifies ConsoleLink is created for ArgoCD route", Label("openshfit"), func() {
+    // ...
+})
+
+// Multiple labels — test requires OpenShift AND conversion webhook
+It("verifies v1beta1 to v1alpha1 conversion", Label("conversionWebhook", "openshfit"), func() {
+    // ...
+})
+
+// Label on Context — all specs inside inherit the label
+Context("1-120_repo_server_system_ca_trust", Label("openshfit"), func() {
+    It("ensures that missing Secret aborts startup", func() {
+        // ...
+    })
+})
+```
+
+### Guidelines
+
+- If your test uses OpenShift-specific resources (Routes, ConsoleLinks, SCCs, Subscriptions, CSVs, monitoring via prometheus-operator CRDs that are only present on OCP, etc.), add `Label("openshfit")`.
+- If your test requires 3+ nodes for HA validation, add `Label("HA")`.
+- If your test works on any conformant Kubernetes cluster, do NOT add any label.
+- When in doubt, leave the test unlabelled — it will run everywhere, which provides broader coverage.
+
+
 ## Test Code
 
 gitops-operator E2E tests are defined within `test/openshift/e2e/ginkgo`.

--- a/test/openshift/e2e/README.md
+++ b/test/openshift/e2e/README.md
@@ -106,7 +106,6 @@ Ginkgo [labels](https://onsi.github.io/ginkgo/#spec-labels) are used to categori
 |-------|---------|-------------|
 | `openshfit` | Test requires OpenShift-specific features (Routes, ConsoleLinks, OLM Subscriptions, SCCs, etc.) and cannot run on vanilla Kubernetes (KinD, EKS, GKE, AKS). | Add when the test depends on OpenShift APIs or resources not available on non-OCP clusters. |
 | `HA` | Test requires a cluster with at least 3 worker nodes for HA (High Availability) validation. | Add when the test creates HA Redis StatefulSets or validates pod anti-affinity across nodes. |
-| `conversionWebhook` | Test requires the ArgoCD v1alpha1 ↔ v1beta1 conversion webhook to be running. | Add when the test exercises CRD conversion between API versions. |
 
 ### How labels are used in CI
 
@@ -119,17 +118,12 @@ Add the `Label(...)` decorator to `It`, `Context`, or `Describe` nodes:
 
 ```go
 // Single label — test requires OpenShift
-It("verifies ConsoleLink is created for ArgoCD route", Label("openshfit"), func() {
-    // ...
-})
-
-// Multiple labels — test requires OpenShift AND conversion webhook
-It("verifies v1beta1 to v1alpha1 conversion", Label("conversionWebhook", "openshfit"), func() {
+It("verifies ConsoleLink is created for ArgoCD route", Label("openshift"), func() {
     // ...
 })
 
 // Label on Context — all specs inside inherit the label
-Context("1-120_repo_server_system_ca_trust", Label("openshfit"), func() {
+Context("1-120_repo_server_system_ca_trust", Label("openshift"), func() {
     It("ensures that missing Secret aborts startup", func() {
         // ...
     })
@@ -138,7 +132,7 @@ Context("1-120_repo_server_system_ca_trust", Label("openshfit"), func() {
 
 ### Guidelines
 
-- If your test uses OpenShift-specific resources (Routes, ConsoleLinks, SCCs, Subscriptions, CSVs, monitoring via prometheus-operator CRDs that are only present on OCP, etc.), add `Label("openshfit")`.
+- If your test uses OpenShift-specific resources (Routes, ConsoleLinks, SCCs, Subscriptions, CSVs, monitoring via prometheus-operator CRDs that are only present on OCP, etc.), add `Label("openshift")`.
 - If your test requires 3+ nodes for HA validation, add `Label("HA")`.
 - If your test works on any conformant Kubernetes cluster, do NOT add any label.
 - When in doubt, leave the test unlabelled — it will run everywhere, which provides broader coverage.

--- a/test/openshift/e2e/ginkgo/fixture/fixture.go
+++ b/test/openshift/e2e/ginkgo/fixture/fixture.go
@@ -109,6 +109,9 @@ func EnsureSequentialCleanSlateWithError() error {
 		return err
 	}
 
+	// Clean up old cluster-scoped role from 1-034
+	_ = k8sClient.Delete(ctx, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "custom-argocd-role"}})
+
 	// don't wait for openshift-gitops ArgoCD to exist, if it is on xKS cluster
 	// wait for openshift-gitops ArgoCD to exist, if it doesn't already
 	if RunningOnOpenShift() {
@@ -170,9 +173,6 @@ func EnsureSequentialCleanSlateWithError() error {
 		}); err != nil {
 			return err
 		}
-
-		// Clean up old cluster-scoped role from 1-034
-		_ = k8sClient.Delete(ctx, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "custom-argocd-role"}})
 
 		// Delete all existing RolloutManagers in openshift-gitops Namespace
 		var rolloutManagerList rolloutmanagerv1alpha1.RolloutManagerList

--- a/test/openshift/e2e/ginkgo/fixture/fixture.go
+++ b/test/openshift/e2e/ginkgo/fixture/fixture.go
@@ -60,14 +60,16 @@ func EnsureParallelCleanSlate() {
 
 	// Finally, wait for default openshift-gitops instance to be ready
 	// - Parallel tests should not write to any resources in 'openshift-gitops' namespace (sequential only), but they are allowed to read from them.
-	defaultOpenShiftGitOpsArgoCD := &argov1beta1api.ArgoCD{
-		ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops", Namespace: "openshift-gitops"},
+	// default instance only runs on openshift clusters
+	if RunningOnOpenShift() {
+		defaultOpenShiftGitOpsArgoCD := &argov1beta1api.ArgoCD{
+			ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops", Namespace: "openshift-gitops"},
+		}
+		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(defaultOpenShiftGitOpsArgoCD), defaultOpenShiftGitOpsArgoCD)
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(defaultOpenShiftGitOpsArgoCD, "5m", "5s").Should(argocd.BeAvailableWithCustomSleepTime(3 * time.Second))
 	}
-	err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(defaultOpenShiftGitOpsArgoCD), defaultOpenShiftGitOpsArgoCD)
-	Expect(err).ToNot(HaveOccurred())
-
-	Eventually(defaultOpenShiftGitOpsArgoCD, "5m", "5s").Should(argocd.BeAvailableWithCustomSleepTime(3 * time.Second))
-
 	// Unlike sequential clean slate, parallel clean slate cannot assume that there are no other tests running. This limits our ability to clean up old test artifacts.
 }
 
@@ -107,101 +109,104 @@ func EnsureSequentialCleanSlateWithError() error {
 		return err
 	}
 
+	// don't wait for openshift-gitops ArgoCD to exist, if it is on xKS cluster
 	// wait for openshift-gitops ArgoCD to exist, if it doesn't already
-	defaultOpenShiftGitOpsArgoCD := &argov1beta1api.ArgoCD{
-		ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops", Namespace: "openshift-gitops"},
-	}
-	Eventually(defaultOpenShiftGitOpsArgoCD, "3m", "5s").Should(k8s.ExistByName())
-
-	// Ensure that default state of ArgoCD CR in openshift-gitops is restored
-	if err := updateWithoutConflict(defaultOpenShiftGitOpsArgoCD, func(obj client.Object) {
-		argocdObj, ok := obj.(*argov1beta1api.ArgoCD)
-		Expect(ok).To(BeTrue())
-
-		// HA should be disabled by default
-		argocdObj.Spec.HA.Enabled = false
-
-		// .spec.monitoring.disableMetrics should be nil by default
-		argocdObj.Spec.Monitoring.DisableMetrics = nil
-
-		// Ensure that api server route has not been disabled, nor exposed via different settings
-		argocdObj.Spec.Server.Route = argov1beta1api.ArgoCDRouteSpec{
-			Enabled: true,
-			TLS:     nil,
-			// TLS: &routev1.TLSConfig{
-			// 	Termination:                   routev1.TLSTerminationReencrypt,
-			// 	InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-			// },
+	if RunningOnOpenShift() {
+		defaultOpenShiftGitOpsArgoCD := &argov1beta1api.ArgoCD{
+			ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops", Namespace: "openshift-gitops"},
 		}
+		Eventually(defaultOpenShiftGitOpsArgoCD, "3m", "5s").Should(k8s.ExistByName())
 
-		// Reset app controller processors to default
-		argocdObj.Spec.Controller.Processors = argov1beta1api.ArgoCDApplicationControllerProcessorsSpec{}
+		// Ensure that default state of ArgoCD CR in openshift-gitops is restored
+		if err := updateWithoutConflict(defaultOpenShiftGitOpsArgoCD, func(obj client.Object) {
+			argocdObj, ok := obj.(*argov1beta1api.ArgoCD)
+			Expect(ok).To(BeTrue())
 
-		// Reset repo server replicas to default
-		argocdObj.Spec.Repo.Replicas = nil
+			// HA should be disabled by default
+			argocdObj.Spec.HA.Enabled = false
 
-		// Reset source namespaces
-		argocdObj.Spec.SourceNamespaces = nil
-		argocdObj.Spec.ApplicationSet.SourceNamespaces = nil
+			// .spec.monitoring.disableMetrics should be nil by default
+			argocdObj.Spec.Monitoring.DisableMetrics = nil
 
-	}); err != nil {
-		return err
-	}
+			// Ensure that api server route has not been disabled, nor exposed via different settings
+			argocdObj.Spec.Server.Route = argov1beta1api.ArgoCDRouteSpec{
+				Enabled: true,
+				TLS:     nil,
+				// TLS: &routev1.TLSConfig{
+				// 	Termination:                   routev1.TLSTerminationReencrypt,
+				// 	InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+				// },
+			}
 
-	gitopsService := &gitopsoperatorv1alpha1.GitopsService{
-		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-	}
-	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(gitopsService), gitopsService); err != nil {
-		return err
-	}
+			// Reset app controller processors to default
+			argocdObj.Spec.Controller.Processors = argov1beta1api.ArgoCDApplicationControllerProcessorsSpec{}
 
-	// Ensure that run on infra is disabled: some tests will enable it
-	if err := updateWithoutConflict(gitopsService, func(obj client.Object) {
-		goObj, ok := obj.(*gitopsoperatorv1alpha1.GitopsService)
-		Expect(ok).To(BeTrue())
+			// Reset repo server replicas to default
+			argocdObj.Spec.Repo.Replicas = nil
 
-		goObj.Spec.NodeSelector = nil
-		goObj.Spec.RunOnInfra = false
-		goObj.Spec.Tolerations = nil
-	}); err != nil {
-		return err
-	}
+			// Reset source namespaces
+			argocdObj.Spec.SourceNamespaces = nil
+			argocdObj.Spec.ApplicationSet.SourceNamespaces = nil
 
-	// Clean up old cluster-scoped role from 1-034
-	_ = k8sClient.Delete(ctx, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "custom-argocd-role"}})
-
-	// Delete all existing RolloutManagers in openshift-gitops Namespace
-	var rolloutManagerList rolloutmanagerv1alpha1.RolloutManagerList
-	if err := k8sClient.List(ctx, &rolloutManagerList, client.InNamespace("openshift-gitops")); err != nil {
-		return err
-	}
-	for _, rm := range rolloutManagerList.Items {
-		if err := k8sClient.Delete(ctx, &rm); err != nil {
+		}); err != nil {
 			return err
 		}
-	}
 
-	// Delete 'restricted-dropcaps' which is created by at least one test
-	scc := &securityv1.SecurityContextConstraints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "restricted-dropcaps",
-		},
-	}
-	if err := k8sClient.Delete(ctx, scc); err != nil {
-		if !apierr.IsNotFound(err) {
+		gitopsService := &gitopsoperatorv1alpha1.GitopsService{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		}
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(gitopsService), gitopsService); err != nil {
 			return err
 		}
-		// Otherwise, expected error if it doesn't exist.
-	}
 
-	// Finally, wait for default openshift-gitops instance to be ready.
-	failure := InterceptGomegaFailure(func() {
-		Eventually(defaultOpenShiftGitOpsArgoCD, "5m", "5s").Should(argocd.BeAvailable())
-	})
-	// Output debug information on argo startup failure
-	if failure != nil {
-		OutputDebug(defaultOpenShiftGitOpsArgoCD.Namespace)
-		Fail(failure.Error())
+		// Ensure that run on infra is disabled: some tests will enable it
+		if err := updateWithoutConflict(gitopsService, func(obj client.Object) {
+			goObj, ok := obj.(*gitopsoperatorv1alpha1.GitopsService)
+			Expect(ok).To(BeTrue())
+
+			goObj.Spec.NodeSelector = nil
+			goObj.Spec.RunOnInfra = false
+			goObj.Spec.Tolerations = nil
+		}); err != nil {
+			return err
+		}
+
+		// Clean up old cluster-scoped role from 1-034
+		_ = k8sClient.Delete(ctx, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "custom-argocd-role"}})
+
+		// Delete all existing RolloutManagers in openshift-gitops Namespace
+		var rolloutManagerList rolloutmanagerv1alpha1.RolloutManagerList
+		if err := k8sClient.List(ctx, &rolloutManagerList, client.InNamespace("openshift-gitops")); err != nil {
+			return err
+		}
+		for _, rm := range rolloutManagerList.Items {
+			if err := k8sClient.Delete(ctx, &rm); err != nil {
+				return err
+			}
+		}
+
+		// Delete 'restricted-dropcaps' which is created by at least one test
+		scc := &securityv1.SecurityContextConstraints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "restricted-dropcaps",
+			},
+		}
+		if err := k8sClient.Delete(ctx, scc); err != nil {
+			if !apierr.IsNotFound(err) {
+				return err
+			}
+			// Otherwise, expected error if it doesn't exist.
+		}
+
+		// Finally, wait for default openshift-gitops instance to be ready.
+		failure := InterceptGomegaFailure(func() {
+			Eventually(defaultOpenShiftGitOpsArgoCD, "5m", "5s").Should(argocd.BeAvailable())
+		})
+		// Output debug information on argo startup failure
+		if failure != nil {
+			OutputDebug(defaultOpenShiftGitOpsArgoCD.Namespace)
+			Fail(failure.Error())
+		}
 	}
 	return nil
 }
@@ -986,6 +991,22 @@ func RunningOnOpenShift() bool {
 		}
 	}
 	return openshiftAPIsFound > 5 // I picked 5 as an arbitrary number, could also just be 1
+}
+
+// IsOperatorRunningOnOLM returns true if the operator is running on OLM, false otherwise.
+func IsOperatorRunningOnOLM() bool {
+	k8sClient, _ := utils.GetE2ETestKubeClient()
+
+	crdList := crdv1.CustomResourceDefinitionList{}
+	Expect(k8sClient.List(context.Background(), &crdList)).To(Succeed())
+
+	olmAPIsFound := 0
+	for _, crd := range crdList.Items {
+		if strings.Contains(crd.Spec.Group, "operators.coreos.com") {
+			olmAPIsFound++
+		}
+	}
+	return olmAPIsFound > 0
 }
 
 //nolint:unused

--- a/test/openshift/e2e/ginkgo/fixture/fixture.go
+++ b/test/openshift/e2e/ginkgo/fixture/fixture.go
@@ -994,6 +994,8 @@ func RunningOnOpenShift() bool {
 }
 
 // IsOperatorRunningOnOLM returns true if the operator is running on OLM, false otherwise.
+// TODO: Update to check the actual installation method by verifying whether a gitops Subscription is present,
+// rather than just checking for OLM CRDs.
 func IsOperatorRunningOnOLM() bool {
 	k8sClient, _ := utils.GetE2ETestKubeClient()
 

--- a/test/openshift/e2e/ginkgo/parallel/1-001_alpha_to_beta_dex_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-001_alpha_to_beta_dex_conversion_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("Ensure dex spec field can be converted between ArgoCD v1alpha1 and v1beta1", Label("notOnXKS"), Label("conversionWebhook"), func() {
+		It("Ensure dex spec field can be converted between ArgoCD v1alpha1 and v1beta1", Label("openshfit"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the cluster, which is not the case for a local run")

--- a/test/openshift/e2e/ginkgo/parallel/1-001_alpha_to_beta_dex_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-001_alpha_to_beta_dex_conversion_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("Ensure dex spec field can be converted between ArgoCD v1alpha1 and v1beta1", func() {
+		It("Ensure dex spec field can be converted between ArgoCD v1alpha1 and v1beta1", Label("openshift"), Label("conversionWebhook"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the cluster, which is not the case for a local run")

--- a/test/openshift/e2e/ginkgo/parallel/1-001_alpha_to_beta_dex_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-001_alpha_to_beta_dex_conversion_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("Ensure dex spec field can be converted between ArgoCD v1alpha1 and v1beta1", Label("openshift"), Label("conversionWebhook"), func() {
+		It("Ensure dex spec field can be converted between ArgoCD v1alpha1 and v1beta1", Label("notOnXKS"), Label("conversionWebhook"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the cluster, which is not the case for a local run")

--- a/test/openshift/e2e/ginkgo/parallel/1-001_alpha_to_beta_dex_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-001_alpha_to_beta_dex_conversion_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("Ensure dex spec field can be converted between ArgoCD v1alpha1 and v1beta1", Label("openshfit"), func() {
+		It("Ensure dex spec field can be converted between ArgoCD v1alpha1 and v1beta1", Label("openshift"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the cluster, which is not the case for a local run")

--- a/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("conversionWebhook", "notOnXKS"), func() {
+		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("openshfit"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the openshift cluster, which is not the case for a local or on xKS cluster")

--- a/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", func() {
+		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("conversionWebhook"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the cluster, which is not the case for a local run")

--- a/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
@@ -48,10 +48,10 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("conversionWebhook"), func() {
+		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("conversionWebhook", "openshift"), func() {
 
 			if fixture.EnvLocalRun() {
-				Skip("Conversion via webhook requires the operator to be running on the cluster, which is not the case for a local run")
+				Skip("Conversion via webhook requires the operator to be running on the openshift cluster, which is not the case for a local or on xKS cluster")
 				return
 			}
 

--- a/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("conversionWebhook", "openshift"), func() {
+		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("conversionWebhook", "notOnXKS"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the openshift cluster, which is not the case for a local or on xKS cluster")

--- a/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", func() {
+		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("conversionWebhook"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the cluster, which is not the case for a local run")

--- a/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("conversionWebhook", "notOnXKS"), func() {
+		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("openshfit"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the openshift cluster, which is not the case for a local or on xKS cluster")

--- a/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("openshfit"), func() {
+		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("openshift"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the openshift cluster, which is not the case for a local or on xKS cluster")

--- a/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("openshfit"), func() {
+		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("openshift"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the openshift cluster, which is not the case for a local or on xKS cluster")

--- a/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("conversionWebhook", "openshift"), func() {
+		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("conversionWebhook", "notOnXKS"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the openshift cluster, which is not the case for a local or on xKS cluster")

--- a/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-003_alpha_to_beta_sso_conflict_conversion_test.go
@@ -47,10 +47,10 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("conversionWebhook"), func() {
+		It("verifies expected behaviour of ArgoCD CR when dex and keycloak are both specified in v1alpha1 API", Label("conversionWebhook", "openshift"), func() {
 
 			if fixture.EnvLocalRun() {
-				Skip("Conversion via webhook requires the operator to be running on the cluster, which is not the case for a local run")
+				Skip("Conversion via webhook requires the operator to be running on the openshift cluster, which is not the case for a local or on xKS cluster")
 				return
 			}
 

--- a/test/openshift/e2e/ginkgo/parallel/1-003_validate_console_link_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-003_validate_console_link_test.go
@@ -17,7 +17,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifies ConsoleLink exists and has expected content", Label("notOnXKS"), func() {
+		It("verifies ConsoleLink exists and has expected content", Label("openshfit"), func() {
 
 			consoleLink := &consolev1.ConsoleLink{ObjectMeta: metav1.ObjectMeta{
 				Name: "argocd",

--- a/test/openshift/e2e/ginkgo/parallel/1-003_validate_console_link_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-003_validate_console_link_test.go
@@ -17,7 +17,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifies ConsoleLink exists and has expected content", Label("openshift"), func() {
+		It("verifies ConsoleLink exists and has expected content", Label("notOnXKS"), func() {
 
 			consoleLink := &consolev1.ConsoleLink{ObjectMeta: metav1.ObjectMeta{
 				Name: "argocd",

--- a/test/openshift/e2e/ginkgo/parallel/1-003_validate_console_link_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-003_validate_console_link_test.go
@@ -17,7 +17,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifies ConsoleLink exists and has expected content", func() {
+		It("verifies ConsoleLink exists and has expected content", Label("openshift"), func() {
 
 			consoleLink := &consolev1.ConsoleLink{ObjectMeta: metav1.ObjectMeta{
 				Name: "argocd",
@@ -25,8 +25,6 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			Eventually(consoleLink).Should(k8sFixture.ExistByName())
 			Expect(string(consoleLink.Spec.Location)).To(Equal("ApplicationMenu"))
 			Expect(consoleLink.Spec.Text).To(Equal("Cluster Argo CD"))
-
 		})
-
 	})
 })

--- a/test/openshift/e2e/ginkgo/parallel/1-003_validate_console_link_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-003_validate_console_link_test.go
@@ -17,7 +17,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifies ConsoleLink exists and has expected content", Label("openshfit"), func() {
+		It("verifies ConsoleLink exists and has expected content", Label("openshift"), func() {
 
 			consoleLink := &consolev1.ConsoleLink{ObjectMeta: metav1.ObjectMeta{
 				Name: "argocd",

--- a/test/openshift/e2e/ginkgo/parallel/1-004_beta_to_alpha_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-004_beta_to_alpha_conversion_test.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies v1beta1 ArgoCD CR containing Dex SSO values can be converted to v1alpha1", Label("conversionWebhook", "notOnXKS"), func() {
+		It("verifies v1beta1 ArgoCD CR containing Dex SSO values can be converted to v1alpha1", Label("openshfit"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the cluster, which is not the case for a local run")

--- a/test/openshift/e2e/ginkgo/parallel/1-004_beta_to_alpha_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-004_beta_to_alpha_conversion_test.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies v1beta1 ArgoCD CR containing Dex SSO values can be converted to v1alpha1", Label("conversionWebhook"), func() {
+		It("verifies v1beta1 ArgoCD CR containing Dex SSO values can be converted to v1alpha1", Label("conversionWebhook", "openshift"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the cluster, which is not the case for a local run")

--- a/test/openshift/e2e/ginkgo/parallel/1-004_beta_to_alpha_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-004_beta_to_alpha_conversion_test.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies v1beta1 ArgoCD CR containing Dex SSO values can be converted to v1alpha1", func() {
+		It("verifies v1beta1 ArgoCD CR containing Dex SSO values can be converted to v1alpha1", Label("conversionWebhook"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the cluster, which is not the case for a local run")

--- a/test/openshift/e2e/ginkgo/parallel/1-004_beta_to_alpha_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-004_beta_to_alpha_conversion_test.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies v1beta1 ArgoCD CR containing Dex SSO values can be converted to v1alpha1", Label("conversionWebhook", "openshift"), func() {
+		It("verifies v1beta1 ArgoCD CR containing Dex SSO values can be converted to v1alpha1", Label("conversionWebhook", "notOnXKS"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the cluster, which is not the case for a local run")

--- a/test/openshift/e2e/ginkgo/parallel/1-004_beta_to_alpha_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-004_beta_to_alpha_conversion_test.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies v1beta1 ArgoCD CR containing Dex SSO values can be converted to v1alpha1", Label("openshfit"), func() {
+		It("verifies v1beta1 ArgoCD CR containing Dex SSO values can be converted to v1alpha1", Label("openshift"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("Conversion via webhook requires the operator to be running on the cluster, which is not the case for a local run")

--- a/test/openshift/e2e/ginkgo/parallel/1-005_validate_metrics_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-005_validate_metrics_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifies that default ServiceMonitors exist in openshift-gitops and PrometheusRule ArgoCDSyncAlert exists", Label("notOnXKS"), func() {
+		It("verifies that default ServiceMonitors exist in openshift-gitops and PrometheusRule ArgoCDSyncAlert exists", Label("openshfit"), func() {
 
 			By("verifying openshift-gitops ServiceMonitor exists and has expected values")
 			openshiftGitOpsSM := &monitoringv1.ServiceMonitor{

--- a/test/openshift/e2e/ginkgo/parallel/1-005_validate_metrics_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-005_validate_metrics_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifies that default ServiceMonitors exist in openshift-gitops and PrometheusRule ArgoCDSyncAlert exists", Label("openshift"), func() {
+		It("verifies that default ServiceMonitors exist in openshift-gitops and PrometheusRule ArgoCDSyncAlert exists", Label("notOnXKS"), func() {
 
 			By("verifying openshift-gitops ServiceMonitor exists and has expected values")
 			openshiftGitOpsSM := &monitoringv1.ServiceMonitor{

--- a/test/openshift/e2e/ginkgo/parallel/1-005_validate_metrics_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-005_validate_metrics_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifies that default ServiceMonitors exist in openshift-gitops and PrometheusRule ArgoCDSyncAlert exists", func() {
+		It("verifies that default ServiceMonitors exist in openshift-gitops and PrometheusRule ArgoCDSyncAlert exists", Label("openshift"), func() {
 
 			By("verifying openshift-gitops ServiceMonitor exists and has expected values")
 			openshiftGitOpsSM := &monitoringv1.ServiceMonitor{

--- a/test/openshift/e2e/ginkgo/parallel/1-005_validate_metrics_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-005_validate_metrics_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifies that default ServiceMonitors exist in openshift-gitops and PrometheusRule ArgoCDSyncAlert exists", Label("openshfit"), func() {
+		It("verifies that default ServiceMonitors exist in openshift-gitops and PrometheusRule ArgoCDSyncAlert exists", Label("openshift"), func() {
 
 			By("verifying openshift-gitops ServiceMonitor exists and has expected values")
 			openshiftGitOpsSM := &monitoringv1.ServiceMonitor{

--- a/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that certificates can be confirmed on server and webhook Routes", Label("notOnXKS"), func() {
+		It("ensures that certificates can be confirmed on server and webhook Routes", Label("openshfit"), func() {
 
 			fixture.EnsureRunningOnOpenShift()
 

--- a/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that certificates can be confirmed on server and webhook Routes", func() {
+		It("ensures that certificates can be confirmed on server and webhook Routes", Label("openshift"), func() {
 
 			fixture.EnsureRunningOnOpenShift()
 

--- a/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that certificates can be confirmed on server and webhook Routes", Label("openshift"), func() {
+		It("ensures that certificates can be confirmed on server and webhook Routes", Label("notOnXKS"), func() {
 
 			fixture.EnsureRunningOnOpenShift()
 

--- a/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that certificates can be confirmed on server and webhook Routes", Label("openshfit"), func() {
+		It("ensures that certificates can be confirmed on server and webhook Routes", Label("openshift"), func() {
 
 			fixture.EnsureRunningOnOpenShift()
 

--- a/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that certificates can be confirmed on server and webhook Routes", func() {
+		It("ensures that certificates can be confirmed on server and webhook Routes", Label("openshift"), func() {
 
 			fixture.EnsureRunningOnOpenShift()
 

--- a/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that certificates can be confirmed on server and webhook Routes", Label("notOnXKS"), func() {
+		It("ensures that certificates can be confirmed on server and webhook Routes", Label("openshfit"), func() {
 
 			fixture.EnsureRunningOnOpenShift()
 

--- a/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that certificates can be confirmed on server and webhook Routes", Label("openshift"), func() {
+		It("ensures that certificates can be confirmed on server and webhook Routes", Label("notOnXKS"), func() {
 
 			fixture.EnsureRunningOnOpenShift()
 

--- a/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-005_validate_route_tls_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that certificates can be confirmed on server and webhook Routes", Label("openshfit"), func() {
+		It("ensures that certificates can be confirmed on server and webhook Routes", Label("openshift"), func() {
 
 			fixture.EnsureRunningOnOpenShift()
 

--- a/test/openshift/e2e/ginkgo/parallel/1-023_validate_repo_server_tls_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-023_validate_repo_server_tls_test.go
@@ -59,7 +59,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.OutputDebugOnFail(nsTest_1_23_custom)
 		})
 
-		It("verifying ArgoCD .spec.repo AutoTLS and verifyTLS work as expected", Label("notOnXKS"), func() {
+		It("verifying ArgoCD .spec.repo AutoTLS and verifyTLS work as expected", Label("openshfit"), func() {
 
 			By("creating a namespace scoped Argo instance with AutoTLS set to 'openshift'")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-023_validate_repo_server_tls_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-023_validate_repo_server_tls_test.go
@@ -59,7 +59,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.OutputDebugOnFail(nsTest_1_23_custom)
 		})
 
-		It("verifying ArgoCD .spec.repo AutoTLS and verifyTLS work as expected", func() {
+		It("verifying ArgoCD .spec.repo AutoTLS and verifyTLS work as expected", Label("openshift"), func() {
 
 			By("creating a namespace scoped Argo instance with AutoTLS set to 'openshift'")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-023_validate_repo_server_tls_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-023_validate_repo_server_tls_test.go
@@ -59,7 +59,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.OutputDebugOnFail(nsTest_1_23_custom)
 		})
 
-		It("verifying ArgoCD .spec.repo AutoTLS and verifyTLS work as expected", Label("openshift"), func() {
+		It("verifying ArgoCD .spec.repo AutoTLS and verifyTLS work as expected", Label("notOnXKS"), func() {
 
 			By("creating a namespace scoped Argo instance with AutoTLS set to 'openshift'")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-023_validate_repo_server_tls_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-023_validate_repo_server_tls_test.go
@@ -59,7 +59,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.OutputDebugOnFail(nsTest_1_23_custom)
 		})
 
-		It("verifying ArgoCD .spec.repo AutoTLS and verifyTLS work as expected", Label("openshfit"), func() {
+		It("verifying ArgoCD .spec.repo AutoTLS and verifyTLS work as expected", Label("openshift"), func() {
 
 			By("creating a namespace scoped Argo instance with AutoTLS set to 'openshift'")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
@@ -55,7 +55,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", Label("notOnXKS"), func() {
+		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", Label("openshfit"), func() {
 
 			By("creating namespace-scoped Argo CD instance with rencrypt Route")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
@@ -55,7 +55,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", Label("openshift"), func() {
+		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", Label("notOnXKS"), func() {
 
 			By("creating namespace-scoped Argo CD instance with rencrypt Route")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
@@ -55,7 +55,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", func() {
+		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", Label("openshift"), func() {
 
 			By("creating namespace-scoped Argo CD instance with rencrypt Route")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
@@ -54,7 +54,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", Label("notOnXKS"), func() {
+		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", Label("openshfit"), func() {
 
 			By("creating namespace-scoped Argo CD instance with rencrypt Route")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
@@ -54,7 +54,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", Label("openshfit"), func() {
+		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", Label("openshift"), func() {
 
 			By("creating namespace-scoped Argo CD instance with rencrypt Route")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
@@ -54,7 +54,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", func() {
+		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", Label("openshift"), func() {
 
 			By("creating namespace-scoped Argo CD instance with rencrypt Route")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
@@ -55,7 +55,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", Label("openshfit"), func() {
+		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", Label("openshift"), func() {
 
 			By("creating namespace-scoped Argo CD instance with rencrypt Route")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
@@ -54,7 +54,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", Label("openshift"), func() {
+		It("verifies Argo CD Server's Route can be enabled with TLSTerminationReencrypt", Label("notOnXKS"), func() {
 
 			By("creating namespace-scoped Argo CD instance with rencrypt Route")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-031_validate_toolchain_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-031_validate_toolchain_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
@@ -53,14 +54,14 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 		})
 
 		// getPodName waits for there to exist a running pod with name 'name' in openshift-gitops
-		getPodName := func(name string) (string, error) {
+		getPodName := func(namespace, name string) (string, error) {
 
 			var podName string
 
 			if err := wait.PollUntilContextTimeout(context.Background(), time.Second*5, time.Minute*2, true, func(ctx context.Context) (done bool, err error) {
 
 				var podList corev1.PodList
-				if err := k8sClient.List(ctx, &podList, client.InNamespace("openshift-gitops")); err != nil {
+				if err := k8sClient.List(ctx, &podList, client.InNamespace(namespace)); err != nil {
 					GinkgoWriter.Println(err)
 					return false, nil
 				}
@@ -82,7 +83,25 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			return podName, nil
 		}
 
-		It("verifies that toolchain versions have the expected values", func() {
+		FIt("verifies that toolchain versions have the expected values", func() {
+
+			// create a new namespace
+			ns, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("test-1-031-toolchain")
+			defer cleanupFunc()
+
+			//create a new argocd instance
+			argocdInstance := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "openshift-gitops",
+					Namespace: ns.Name,
+				},
+				Spec: argov1beta1api.ArgoCDSpec{
+					SSO: &argov1beta1api.ArgoCDSSOSpec{
+						Provider: "dex",
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), argocdInstance)).To(Succeed())
 
 			// These variables need to be maintained according to the component matrix: https://spaces.redhat.com/display/GITOPS/GitOps+Component+Matrix
 			expected_kustomizeVersion := "v5.8.1"
@@ -105,25 +124,25 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			By("locating pods containing toolchain in openshift-gitops")
 
-			gitops_server_pod, err := getPodName("openshift-gitops-server")
+			gitops_server_pod, err := getPodName(ns.Name, "openshift-gitops-server")
 			Expect(err).ToNot(HaveOccurred())
-			dex_pod, err := getPodName("openshift-gitops-dex-server")
+			dex_pod, err := getPodName(ns.Name, "openshift-gitops-dex-server")
 			Expect(err).ToNot(HaveOccurred())
-			redis_pod, err := getPodName("openshift-gitops-redis")
+			redis_pod, err := getPodName(ns.Name, "openshift-gitops-redis")
 			Expect(err).ToNot(HaveOccurred())
 
-			serverRoute := &routev1.Route{ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops-server", Namespace: "openshift-gitops"}}
+			serverRoute := &routev1.Route{ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops-server", Namespace: ns.Name}}
 			Eventually(serverRoute).Should(k8sFixture.ExistByName())
 
 			By("extracting the kustomize version from container")
 
-			kustomizeVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n openshift-gitops exec "+gitops_server_pod+" -- kustomize version")
+			kustomizeVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n"+ns.Name+" exec "+gitops_server_pod+" -- kustomize version")
 
 			Expect(err).NotTo(HaveOccurred())
 			kustomizeVersion = strings.TrimSpace(kustomizeVersion)
 
 			By("extracting the helm version from container")
-			helmVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n openshift-gitops exec "+gitops_server_pod+" -- helm version")
+			helmVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n"+ns.Name+" exec "+gitops_server_pod+" -- helm version")
 			Expect(err).NotTo(HaveOccurred())
 
 			// output format:
@@ -136,14 +155,14 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			// After: v3.15.4
 
 			By("extracting the argo cd server version from container")
-			argocdVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n openshift-gitops exec "+gitops_server_pod+" -- argocd version --short --server "+serverRoute.Spec.Host+" --insecure | grep 'argocd-server'")
+			argocdVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n"+ns.Name+" exec "+gitops_server_pod+" -- argocd version --short --server "+serverRoute.Spec.Host+" --insecure | grep 'argocd-server'")
 			argocdVersion = strings.ReplaceAll(argocdVersion, "+unknown", "")
 			// output format:
 			// argocd-server: v2.13.1+af54ef8
 			Expect(err).NotTo(HaveOccurred())
 
 			By("extracting the dex version from container")
-			dexVersionOutput, err := osFixture.ExecCommand("bash", "-c", "oc -n openshift-gitops exec "+dex_pod+" -- dex version")
+			dexVersionOutput, err := osFixture.ExecCommand("bash", "-c", "oc -n"+ns.Name+" exec "+dex_pod+" -- dex version")
 			Expect(err).ToNot(HaveOccurred())
 			// Output format:
 			// Defaulted container "dex" out of: dex, copyutil (init)
@@ -164,7 +183,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			Expect(dexVersion).ToNot(BeEmpty())
 
 			By("extracting the redis version from container")
-			redisVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n openshift-gitops exec "+redis_pod+" -- redis-server -v")
+			redisVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n"+ns.Name+" exec "+redis_pod+" -- redis-server -v")
 			// output format: Redis server v=6.2.7 sha=00000000:0 malloc=jemalloc-5.1.0 bits=64 build=5d88ce217879027a
 			redisVersion = redisVersion[strings.Index(redisVersion, "v=")+2:]
 			// After: v=6.2.7 (...)

--- a/test/openshift/e2e/ginkgo/parallel/1-031_validate_toolchain_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-031_validate_toolchain_test.go
@@ -83,7 +83,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			return podName, nil
 		}
 
-		FIt("verifies that toolchain versions have the expected values", func() {
+		It("verifies that toolchain versions have the expected values", func() {
 
 			// create a new namespace
 			ns, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("test-1-031-toolchain")

--- a/test/openshift/e2e/ginkgo/parallel/1-031_validate_toolchain_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-031_validate_toolchain_test.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
@@ -54,14 +53,14 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 		})
 
 		// getPodName waits for there to exist a running pod with name 'name' in openshift-gitops
-		getPodName := func(namespace, name string) (string, error) {
+		getPodName := func(name string) (string, error) {
 
 			var podName string
 
 			if err := wait.PollUntilContextTimeout(context.Background(), time.Second*5, time.Minute*2, true, func(ctx context.Context) (done bool, err error) {
 
 				var podList corev1.PodList
-				if err := k8sClient.List(ctx, &podList, client.InNamespace(namespace)); err != nil {
+				if err := k8sClient.List(ctx, &podList, client.InNamespace("openshift-gitops")); err != nil {
 					GinkgoWriter.Println(err)
 					return false, nil
 				}
@@ -85,24 +84,6 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 		It("verifies that toolchain versions have the expected values", Label("openshift"), func() {
 
-			// create a new namespace
-			ns, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("test-1-031-toolchain")
-			defer cleanupFunc()
-
-			//create a new argocd instance
-			argocdInstance := &argov1beta1api.ArgoCD{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "openshift-gitops",
-					Namespace: ns.Name,
-				},
-				Spec: argov1beta1api.ArgoCDSpec{
-					SSO: &argov1beta1api.ArgoCDSSOSpec{
-						Provider: "dex",
-					},
-				},
-			}
-			Expect(k8sClient.Create(context.Background(), argocdInstance)).To(Succeed())
-
 			// These variables need to be maintained according to the component matrix: https://spaces.redhat.com/display/GITOPS/GitOps+Component+Matrix
 			expected_kustomizeVersion := "v5.8.1"
 			expected_helmVersion := "v3.19.4"
@@ -124,25 +105,25 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			By("locating pods containing toolchain in openshift-gitops")
 
-			gitops_server_pod, err := getPodName(ns.Name, "openshift-gitops-server")
+			gitops_server_pod, err := getPodName("openshift-gitops-server")
 			Expect(err).ToNot(HaveOccurred())
-			dex_pod, err := getPodName(ns.Name, "openshift-gitops-dex-server")
+			dex_pod, err := getPodName("openshift-gitops-dex-server")
 			Expect(err).ToNot(HaveOccurred())
-			redis_pod, err := getPodName(ns.Name, "openshift-gitops-redis")
+			redis_pod, err := getPodName("openshift-gitops-redis")
 			Expect(err).ToNot(HaveOccurred())
 
-			serverRoute := &routev1.Route{ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops-server", Namespace: ns.Name}}
+			serverRoute := &routev1.Route{ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops-server", Namespace: "openshift-gitops"}}
 			Eventually(serverRoute).Should(k8sFixture.ExistByName())
 
 			By("extracting the kustomize version from container")
 
-			kustomizeVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n"+ns.Name+" exec "+gitops_server_pod+" -- kustomize version")
+			kustomizeVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n openshift-gitops exec "+gitops_server_pod+" -- kustomize version")
 
 			Expect(err).NotTo(HaveOccurred())
 			kustomizeVersion = strings.TrimSpace(kustomizeVersion)
 
 			By("extracting the helm version from container")
-			helmVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n"+ns.Name+" exec "+gitops_server_pod+" -- helm version")
+			helmVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n openshift-gitops exec "+gitops_server_pod+" -- helm version")
 			Expect(err).NotTo(HaveOccurred())
 
 			// output format:
@@ -155,14 +136,14 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			// After: v3.15.4
 
 			By("extracting the argo cd server version from container")
-			argocdVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n"+ns.Name+" exec "+gitops_server_pod+" -- argocd version --short --server "+serverRoute.Spec.Host+" --insecure | grep 'argocd-server'")
+			argocdVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n openshift-gitops exec "+gitops_server_pod+" -- argocd version --short --server "+serverRoute.Spec.Host+" --insecure | grep 'argocd-server'")
 			argocdVersion = strings.ReplaceAll(argocdVersion, "+unknown", "")
 			// output format:
 			// argocd-server: v2.13.1+af54ef8
 			Expect(err).NotTo(HaveOccurred())
 
 			By("extracting the dex version from container")
-			dexVersionOutput, err := osFixture.ExecCommand("bash", "-c", "oc -n"+ns.Name+" exec "+dex_pod+" -- dex version")
+			dexVersionOutput, err := osFixture.ExecCommand("bash", "-c", "oc -n openshift-gitops exec "+dex_pod+" -- dex version")
 			Expect(err).ToNot(HaveOccurred())
 			// Output format:
 			// Defaulted container "dex" out of: dex, copyutil (init)
@@ -183,7 +164,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			Expect(dexVersion).ToNot(BeEmpty())
 
 			By("extracting the redis version from container")
-			redisVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n"+ns.Name+" exec "+redis_pod+" -- redis-server -v")
+			redisVersion, err := osFixture.ExecCommand("bash", "-c", "oc -n openshift-gitops exec "+redis_pod+" -- redis-server -v")
 			// output format: Redis server v=6.2.7 sha=00000000:0 malloc=jemalloc-5.1.0 bits=64 build=5d88ce217879027a
 			redisVersion = redisVersion[strings.Index(redisVersion, "v=")+2:]
 			// After: v=6.2.7 (...)

--- a/test/openshift/e2e/ginkgo/parallel/1-031_validate_toolchain_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-031_validate_toolchain_test.go
@@ -83,7 +83,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			return podName, nil
 		}
 
-		It("verifies that toolchain versions have the expected values", func() {
+		It("verifies that toolchain versions have the expected values", Label("openshift"), func() {
 
 			// create a new namespace
 			ns, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("test-1-031-toolchain")

--- a/test/openshift/e2e/ginkgo/parallel/1-038_validate_productized_images_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-038_validate_productized_images_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
 			ctx = context.Background()
 		})
-
+		// TODO: check if this can be ported for xKS testing
 		It("validates that Argo CD components are based on registry.redhat.io images", func() {
 
 			if fixture.EnvNonOLM() {

--- a/test/openshift/e2e/ginkgo/parallel/1-041_validate_argocd_sync_alert_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-041_validate_argocd_sync_alert_test.go
@@ -20,7 +20,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifying PrometheusRule gitops-operator-argocd-alerts exists and has expected values", Label("notOnXKS"), func() {
+		It("verifying PrometheusRule gitops-operator-argocd-alerts exists and has expected values", Label("openshfit"), func() {
 
 			By("checking OpenShift GitOps ArgoCD instance is available")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-041_validate_argocd_sync_alert_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-041_validate_argocd_sync_alert_test.go
@@ -20,7 +20,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifying PrometheusRule gitops-operator-argocd-alerts exists and has expected values", func() {
+		It("verifying PrometheusRule gitops-operator-argocd-alerts exists and has expected values", Label("openshift"), func() {
 
 			By("checking OpenShift GitOps ArgoCD instance is available")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-041_validate_argocd_sync_alert_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-041_validate_argocd_sync_alert_test.go
@@ -20,7 +20,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifying PrometheusRule gitops-operator-argocd-alerts exists and has expected values", Label("openshift"), func() {
+		It("verifying PrometheusRule gitops-operator-argocd-alerts exists and has expected values", Label("notOnXKS"), func() {
 
 			By("checking OpenShift GitOps ArgoCD instance is available")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-041_validate_argocd_sync_alert_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-041_validate_argocd_sync_alert_test.go
@@ -20,7 +20,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifying PrometheusRule gitops-operator-argocd-alerts exists and has expected values", Label("openshfit"), func() {
+		It("verifying PrometheusRule gitops-operator-argocd-alerts exists and has expected values", Label("openshift"), func() {
 
 			By("checking OpenShift GitOps ArgoCD instance is available")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-042_validate_status_host_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-042_validate_status_host_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that .status.host of ArgoCD matches .spec.host of Route, and status is updated when Route is removed", Label("notOnXKS"), func() {
+		It("verifies that .status.host of ArgoCD matches .spec.host of Route, and status is updated when Route is removed", Label("openshfit"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-042_validate_status_host_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-042_validate_status_host_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that .status.host of ArgoCD matches .spec.host of Route, and status is updated when Route is removed", func() {
+		It("verifies that .status.host of ArgoCD matches .spec.host of Route, and status is updated when Route is removed", Label("openshift"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-042_validate_status_host_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-042_validate_status_host_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that .status.host of ArgoCD matches .spec.host of Route, and status is updated when Route is removed", Label("openshift"), func() {
+		It("verifies that .status.host of ArgoCD matches .spec.host of Route, and status is updated when Route is removed", Label("notOnXKS"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-042_validate_status_host_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-042_validate_status_host_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that .status.host of ArgoCD matches .spec.host of Route, and status is updated when Route is removed", Label("openshfit"), func() {
+		It("verifies that .status.host of ArgoCD matches .spec.host of Route, and status is updated when Route is removed", Label("openshift"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-050_validate_sso_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-050_validate_sso_test.go
@@ -67,7 +67,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				cleanupFunc()
 			}
 		})
-		It("ensures the conditions in status when external Authentication is enabled on clusters; above 4.20 by default in openshift is enabled", Label("notOnXKS"), func() {
+		It("ensures the conditions in status when external Authentication is enabled on clusters; above 4.20 by default in openshift is enabled", Label("openshfit"), func() {
 			By("creating simple namespace-scoped Argo CD instance")
 			ocVersion := getOCPVersion()
 			Expect(ocVersion).ToNot(BeEmpty())

--- a/test/openshift/e2e/ginkgo/parallel/1-050_validate_sso_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-050_validate_sso_test.go
@@ -67,7 +67,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				cleanupFunc()
 			}
 		})
-		It("ensures the conditions in status when external Authentication is enabled on clusters; above 4.20 by default in openshit is enabled", func() {
+		It("ensures the conditions in status when external Authentication is enabled on clusters; above 4.20 by default in openshift is enabled", Label("openshift"), func() {
 			By("creating simple namespace-scoped Argo CD instance")
 			ocVersion := getOCPVersion()
 			Expect(ocVersion).ToNot(BeEmpty())

--- a/test/openshift/e2e/ginkgo/parallel/1-050_validate_sso_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-050_validate_sso_test.go
@@ -67,7 +67,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				cleanupFunc()
 			}
 		})
-		It("ensures the conditions in status when external Authentication is enabled on clusters; above 4.20 by default in openshift is enabled", Label("openshift"), func() {
+		It("ensures the conditions in status when external Authentication is enabled on clusters; above 4.20 by default in openshift is enabled", Label("notOnXKS"), func() {
 			By("creating simple namespace-scoped Argo CD instance")
 			ocVersion := getOCPVersion()
 			Expect(ocVersion).ToNot(BeEmpty())

--- a/test/openshift/e2e/ginkgo/parallel/1-050_validate_sso_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-050_validate_sso_test.go
@@ -67,7 +67,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				cleanupFunc()
 			}
 		})
-		It("ensures the conditions in status when external Authentication is enabled on clusters; above 4.20 by default in openshift is enabled", Label("openshfit"), func() {
+		It("ensures the conditions in status when external Authentication is enabled on clusters; above 4.20 by default in openshift is enabled", Label("openshift"), func() {
 			By("creating simple namespace-scoped Argo CD instance")
 			ocVersion := getOCPVersion()
 			Expect(ocVersion).ToNot(BeEmpty())
@@ -121,6 +121,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 		})
 
+		// openshiftOAuth is not supported in xKS
 		It("ensures Dex/Keycloak SSO can be enabled and disabled on a namespace-scoped Argo CD instance", func() {
 
 			ns, cleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-051-validate_csv_permissions_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-051-validate_csv_permissions_test.go
@@ -34,6 +34,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 		})
 
+		// TODO: check if this can be ported for xKS testing
 		It("verifies operator can delete resourcequotas", func() {
 
 			if fixture.EnvNonOLM() {

--- a/test/openshift/e2e/ginkgo/parallel/1-053_validate_cluster_admin_rbac_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-053_validate_cluster_admin_rbac_test.go
@@ -35,7 +35,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("validates that openshift-gitops instance has expected .spec.RBAC.policy values", Label("notOnXKS"), func() {
+		It("validates that openshift-gitops instance has expected .spec.RBAC.policy values", Label("openshfit"), func() {
 
 			argoCD := &argov1beta1api.ArgoCD{
 				ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops", Namespace: "openshift-gitops"},

--- a/test/openshift/e2e/ginkgo/parallel/1-053_validate_cluster_admin_rbac_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-053_validate_cluster_admin_rbac_test.go
@@ -35,7 +35,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("validates that openshift-gitops instance has expected .spec.RBAC.policy values", func() {
+		It("validates that openshift-gitops instance has expected .spec.RBAC.policy values", Label("openshift"), func() {
 
 			argoCD := &argov1beta1api.ArgoCD{
 				ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops", Namespace: "openshift-gitops"},

--- a/test/openshift/e2e/ginkgo/parallel/1-053_validate_cluster_admin_rbac_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-053_validate_cluster_admin_rbac_test.go
@@ -35,7 +35,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("validates that openshift-gitops instance has expected .spec.RBAC.policy values", Label("openshift"), func() {
+		It("validates that openshift-gitops instance has expected .spec.RBAC.policy values", Label("notOnXKS"), func() {
 
 			argoCD := &argov1beta1api.ArgoCD{
 				ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops", Namespace: "openshift-gitops"},

--- a/test/openshift/e2e/ginkgo/parallel/1-053_validate_cluster_admin_rbac_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-053_validate_cluster_admin_rbac_test.go
@@ -35,7 +35,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("validates that openshift-gitops instance has expected .spec.RBAC.policy values", Label("openshfit"), func() {
+		It("validates that openshift-gitops instance has expected .spec.RBAC.policy values", Label("openshift"), func() {
 
 			argoCD := &argov1beta1api.ArgoCD{
 				ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops", Namespace: "openshift-gitops"},

--- a/test/openshift/e2e/ginkgo/parallel/1-054_validate_deploymentconfig_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-054_validate_deploymentconfig_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies a DeploymentConfig can be deployed by Argo CD", Label("notOnXKS"), func() {
+		It("verifies a DeploymentConfig can be deployed by Argo CD", Label("openshfit"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-054_validate_deploymentconfig_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-054_validate_deploymentconfig_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies a DeploymentConfig can be deployed by Argo CD", func() {
+		It("verifies a DeploymentConfig can be deployed by Argo CD", Label("openshift"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-054_validate_deploymentconfig_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-054_validate_deploymentconfig_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies a DeploymentConfig can be deployed by Argo CD", Label("openshift"), func() {
+		It("verifies a DeploymentConfig can be deployed by Argo CD", Label("notOnXKS"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-054_validate_deploymentconfig_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-054_validate_deploymentconfig_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies a DeploymentConfig can be deployed by Argo CD", Label("openshfit"), func() {
+		It("verifies a DeploymentConfig can be deployed by Argo CD", Label("openshift"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-055_drop_resource_customizations_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-055_drop_resource_customizations_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that resource customization is dropped in conversion from ArgoCD v1alpha1 to v1beta1", Label("notOnXKS"), func() {
+		It("verifies that resource customization is dropped in conversion from ArgoCD v1alpha1 to v1beta1", Label("openshfit"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance via v1alpha1 API, with resourcecustomization and resourcehealthcheck")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-055_drop_resource_customizations_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-055_drop_resource_customizations_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that resource customization is dropped in conversion from ArgoCD v1alpha1 to v1beta1", Label("openshift"), func() {
+		It("verifies that resource customization is dropped in conversion from ArgoCD v1alpha1 to v1beta1", Label("notOnXKS"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance via v1alpha1 API, with resourcecustomization and resourcehealthcheck")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-055_drop_resource_customizations_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-055_drop_resource_customizations_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that resource customization is dropped in conversion from ArgoCD v1alpha1 to v1beta1", func() {
+		It("verifies that resource customization is dropped in conversion from ArgoCD v1alpha1 to v1beta1", Label("openshift"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance via v1alpha1 API, with resourcecustomization and resourcehealthcheck")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-055_drop_resource_customizations_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-055_drop_resource_customizations_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that resource customization is dropped in conversion from ArgoCD v1alpha1 to v1beta1", Label("openshfit"), func() {
+		It("verifies that resource customization is dropped in conversion from ArgoCD v1alpha1 to v1beta1", Label("openshift"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance via v1alpha1 API, with resourcecustomization and resourcehealthcheck")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-063_validate_dex_liveness_probe_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-063_validate_dex_liveness_probe_test.go
@@ -31,7 +31,7 @@ import (
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 	// TODO: make it XKS compatible
-	Context("1-063_validate_dex_liveness_probe_test", Label("notOnXKS"), Label("dex"), func() {
+	Context("1-063_validate_dex_liveness_probe_test", Label("openshfit"), Label("dex"), func() {
 
 		var (
 			k8sClient client.Client

--- a/test/openshift/e2e/ginkgo/parallel/1-063_validate_dex_liveness_probe_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-063_validate_dex_liveness_probe_test.go
@@ -31,7 +31,7 @@ import (
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 	// TODO: make it XKS compatible
-	Context("1-063_validate_dex_liveness_probe_test", Label("openshift"), Label("dex"), func() {
+	Context("1-063_validate_dex_liveness_probe_test", Label("notOnXKS"), Label("dex"), func() {
 
 		var (
 			k8sClient client.Client

--- a/test/openshift/e2e/ginkgo/parallel/1-063_validate_dex_liveness_probe_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-063_validate_dex_liveness_probe_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
-
-	Context("1-063_validate_dex_liveness_probe_test", func() {
+	// TODO: make it XKS compatible
+	Context("1-063_validate_dex_liveness_probe_test", Label("openshift"), Label("dex"), func() {
 
 		var (
 			k8sClient client.Client

--- a/test/openshift/e2e/ginkgo/parallel/1-063_validate_dex_liveness_probe_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-063_validate_dex_liveness_probe_test.go
@@ -31,7 +31,7 @@ import (
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 	// TODO: make it XKS compatible
-	Context("1-063_validate_dex_liveness_probe_test", Label("openshift"), Label("dex"), func() {
+	Context("1-063_validate_dex_liveness_probe_test", Label("openshift"), func() {
 
 		var (
 			k8sClient client.Client

--- a/test/openshift/e2e/ginkgo/parallel/1-063_validate_dex_liveness_probe_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-063_validate_dex_liveness_probe_test.go
@@ -31,7 +31,7 @@ import (
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 	// TODO: make it XKS compatible
-	Context("1-063_validate_dex_liveness_probe_test", Label("openshfit"), Label("dex"), func() {
+	Context("1-063_validate_dex_liveness_probe_test", Label("openshift"), Label("dex"), func() {
 
 		var (
 			k8sClient client.Client

--- a/test/openshift/e2e/ginkgo/parallel/1-064_validate_security_contexts_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-064_validate_security_contexts_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		FIt("verifies that various Argo CD component workloads have expected security context", func() {
+		It("verifies that various Argo CD component workloads have expected security context", func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-064_validate_security_contexts_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-064_validate_security_contexts_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that various Argo CD component workloads have expected security context", func() {
+		FIt("verifies that various Argo CD component workloads have expected security context", func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
@@ -73,24 +73,28 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 					Notifications: argov1beta1api.ArgoCDNotifications{
 						Enabled: true,
 					},
-					SSO: &argov1beta1api.ArgoCDSSOSpec{
-						Provider: argov1beta1api.SSOProviderTypeDex,
-						Dex: &argov1beta1api.ArgoCDDexSpec{
-							OpenShiftOAuth: true,
-							Resources: &corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("500m"),
-									corev1.ResourceMemory: resource.MustParse("256Mi"),
-								},
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("250m"),
-									corev1.ResourceMemory: resource.MustParse("128Mi"),
-								},
+				},
+			}
+
+			if fixture.RunningOnOpenShift() {
+				argoCD.Spec.SSO = &argov1beta1api.ArgoCDSSOSpec{
+					Provider: argov1beta1api.SSOProviderTypeDex,
+					Dex: &argov1beta1api.ArgoCDDexSpec{
+						OpenShiftOAuth: true,
+						Resources: &corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
+							},
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("250m"),
+								corev1.ResourceMemory: resource.MustParse("128Mi"),
 							},
 						},
 					},
-				},
+				}
 			}
+
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 
 			By("waiting for ArgoCD CR to be reconciled and the instance to be ready")
@@ -98,7 +102,10 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			By("verifying that each Argo CD deployment has expected security context")
 
-			deployments := []string{"argocd-applicationset-controller", "argocd-dex-server", "argocd-notifications-controller", "argocd-redis", "argocd-repo-server", "argocd-server"}
+			deployments := []string{"argocd-applicationset-controller", "argocd-notifications-controller", "argocd-redis", "argocd-repo-server", "argocd-server"}
+			if fixture.RunningOnOpenShift() {
+				deployments = []string{"argocd-applicationset-controller", "argocd-dex-server", "argocd-notifications-controller", "argocd-redis", "argocd-repo-server", "argocd-server"}
+			}
 			for _, deployment := range deployments {
 
 				depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: deployment, Namespace: ns.Name}}

--- a/test/openshift/e2e/ginkgo/parallel/1-064_validate_security_contexts_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-064_validate_security_contexts_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that various Argo CD component workloads have expected security context", func() {
+		FIt("verifies that various Argo CD component workloads have expected security context", func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
@@ -74,24 +74,28 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 					Notifications: argov1beta1api.ArgoCDNotifications{
 						Enabled: true,
 					},
-					SSO: &argov1beta1api.ArgoCDSSOSpec{
-						Provider: argov1beta1api.SSOProviderTypeDex,
-						Dex: &argov1beta1api.ArgoCDDexSpec{
-							OpenShiftOAuth: true,
-							Resources: &corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("500m"),
-									corev1.ResourceMemory: resource.MustParse("256Mi"),
-								},
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("250m"),
-									corev1.ResourceMemory: resource.MustParse("128Mi"),
-								},
+				},
+			}
+
+			if fixture.RunningOnOpenShift() {
+				argoCD.Spec.SSO = &argov1beta1api.ArgoCDSSOSpec{
+					Provider: argov1beta1api.SSOProviderTypeDex,
+					Dex: &argov1beta1api.ArgoCDDexSpec{
+						OpenShiftOAuth: true,
+						Resources: &corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
+							},
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("250m"),
+								corev1.ResourceMemory: resource.MustParse("128Mi"),
 							},
 						},
 					},
-				},
+				}
 			}
+
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 
 			By("waiting for ArgoCD CR to be reconciled and the instance to be ready")
@@ -99,7 +103,10 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			By("verifying that each Argo CD deployment has expected security context")
 
-			deployments := []string{"argocd-applicationset-controller", "argocd-dex-server", "argocd-notifications-controller", "argocd-redis", "argocd-repo-server", "argocd-server"}
+			deployments := []string{"argocd-applicationset-controller", "argocd-notifications-controller", "argocd-redis", "argocd-repo-server", "argocd-server"}
+			if fixture.RunningOnOpenShift() {
+				deployments = []string{"argocd-applicationset-controller", "argocd-dex-server", "argocd-notifications-controller", "argocd-redis", "argocd-repo-server", "argocd-server"}
+			}
 			for _, deployment := range deployments {
 
 				depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: deployment, Namespace: ns.Name}}

--- a/test/openshift/e2e/ginkgo/parallel/1-064_validate_security_contexts_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-064_validate_security_contexts_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		FIt("verifies that various Argo CD component workloads have expected security context", func() {
+		It("verifies that various Argo CD component workloads have expected security context", func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-065_validate_redis_ha_anti_affinity_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-065_validate_redis_ha_anti_affinity_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensuring that Redis HA StatefulSet has expected PodAffinity", func() {
+		It("ensuring that Redis HA StatefulSet has expected PodAffinity", Label("HA"), func() {
 
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/parallel/1-066_validate_redis_secure_comm_no_autotls_no_ha_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-066_validate_redis_secure_comm_no_autotls_no_ha_test.go
@@ -60,7 +60,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.OutputDebugOnFail(ns)
 		})
 
-		It("validates that Argo CD components correctly inherit 'argocd-operator-redis-tls' Secret once it is created", func() {
+		FIt("validates that Argo CD components correctly inherit 'argocd-operator-redis-tls' Secret once it is created", func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-066_validate_redis_secure_comm_no_autotls_no_ha_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-066_validate_redis_secure_comm_no_autotls_no_ha_test.go
@@ -60,7 +60,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.OutputDebugOnFail(ns)
 		})
 
-		FIt("validates that Argo CD components correctly inherit 'argocd-operator-redis-tls' Secret once it is created", func() {
+		It("validates that Argo CD components correctly inherit 'argocd-operator-redis-tls' Secret once it is created", func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-066_validate_redis_secure_comm_no_autotls_no_ha_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-066_validate_redis_secure_comm_no_autotls_no_ha_test.go
@@ -60,7 +60,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.OutputDebugOnFail(ns)
 		})
 
-		It("validates that Argo CD components correctly inherit 'argocd-operator-redis-tls' Secret once it is created", func() {
+		FIt("validates that Argo CD components correctly inherit 'argocd-operator-redis-tls' Secret once it is created", func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
@@ -143,10 +143,20 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			By("expecting redis-server to have desired container process command/arguments")
 
-			expectedString := "--save \"\" --appendonly no --aclfile /app/config/redis-auth/users.acl --tls-protocols TLSv1.2 --tls-ciphers TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 --tls-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 --tls-port 6379 --port 0 --tls-cert-file /app/config/redis/tls/tls.crt --tls-key-file /app/config/redis/tls/tls.key --tls-auth-clients no"
+			fqdnSuffix := ".svc.cluster.local.:"
+			if !fixture.RunningOnOpenShift() {
+				fqdnSuffix = ".svc.cluster.local:"
+			}
+
+			expectedString := "--save \"\" --appendonly no --aclfile /app/config/redis-auth/users.acl"
+
+			if fixture.RunningOnOpenShift() {
+				expectedString += " --tls-protocols TLSv1.2 --tls-ciphers TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 --tls-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+			}
+
+			expectedString += " --tls-port 6379 --port 0 --tls-cert-file /app/config/redis/tls/tls.crt --tls-key-file /app/config/redis/tls/tls.key --tls-auth-clients no"
 
 			if !fixture.IsUpstreamOperatorTests() {
-				// Downstream operator adds these arguments
 				expectedString = "redis-server --protected-mode no " + expectedString
 			}
 
@@ -157,21 +167,21 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			Eventually(repoServerDepl).Should(k8sFixture.ExistByName())
 
 			By("expecting repo-server to have desired container process command/arguments")
-			Expect(repoServerDepl).To(deplFixture.HaveContainerCommandSubstring("uid_entrypoint.sh argocd-repo-server --redis argocd-redis."+ns.Name+".svc.cluster.local.:6379 --redis-use-tls --redis-ca-certificate /app/config/reposerver/tls/redis/tls.crt --loglevel info --logformat text", 0),
+			Expect(repoServerDepl).To(deplFixture.HaveContainerCommandSubstring("uid_entrypoint.sh argocd-repo-server --redis argocd-redis."+ns.Name+fqdnSuffix+"6379 --redis-use-tls --redis-ca-certificate /app/config/reposerver/tls/redis/tls.crt --loglevel info --logformat text", 0),
 				"TLS .spec.template.spec.containers.command for argocd-repo-server deployment is wrong")
 
 			argocdServerDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "argocd-server", Namespace: ns.Name}}
 			Eventually(argocdServerDepl).Should(k8sFixture.ExistByName())
 
 			By("expecting argocd-server to have desired container process command/arguments")
-			Expect(argocdServerDepl).To(deplFixture.HaveContainerCommandSubstring("argocd-server --staticassets /shared/app --dex-server https://argocd-dex-server."+ns.Name+".svc.cluster.local.:5556 --repo-server argocd-repo-server."+ns.Name+".svc.cluster.local.:8081 --redis argocd-redis."+ns.Name+".svc.cluster.local.:6379 --redis-use-tls --redis-ca-certificate /app/config/server/tls/redis/tls.crt --loglevel info --logformat text", 0),
+			Expect(argocdServerDepl).To(deplFixture.HaveContainerCommandSubstring("argocd-server --staticassets /shared/app --dex-server https://argocd-dex-server."+ns.Name+fqdnSuffix+"5556 --repo-server argocd-repo-server."+ns.Name+fqdnSuffix+"8081 --redis argocd-redis."+ns.Name+fqdnSuffix+"6379 --redis-use-tls --redis-ca-certificate /app/config/server/tls/redis/tls.crt --loglevel info --logformat text", 0),
 				"TLS .spec.template.spec.containers.command for argocd-server deployment is wrong")
 
 			By("expecting application-controller to have desired container process command/arguments")
 			applicationControllerSS := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "argocd-application-controller", Namespace: ns.Name}}
 			Eventually(applicationControllerSS).Should(k8sFixture.ExistByName())
 
-			Expect(applicationControllerSS).To(statefulsetFixture.HaveContainerCommandSubstring("argocd-application-controller --operation-processors 10 --redis argocd-redis."+ns.Name+".svc.cluster.local.:6379 --redis-use-tls --redis-ca-certificate /app/config/controller/tls/redis/tls.crt --repo-server argocd-repo-server."+ns.Name+".svc.cluster.local.:8081 --status-processors 20 --kubectl-parallelism-limit 10 --loglevel info --logformat text", 0),
+			Expect(applicationControllerSS).To(statefulsetFixture.HaveContainerCommandSubstring("argocd-application-controller --operation-processors 10 --redis argocd-redis."+ns.Name+fqdnSuffix+"6379 --redis-use-tls --redis-ca-certificate /app/config/controller/tls/redis/tls.crt --repo-server argocd-repo-server."+ns.Name+fqdnSuffix+"8081 --status-processors 20 --kubectl-parallelism-limit 10 --loglevel info --logformat text", 0),
 				"TLS .spec.template.spec.containers.command for argocd-application-controller statefulsets is wrong")
 
 		})

--- a/test/openshift/e2e/ginkgo/parallel/1-066_validate_redis_secure_comm_no_autotls_no_ha_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-066_validate_redis_secure_comm_no_autotls_no_ha_test.go
@@ -144,9 +144,6 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			By("expecting redis-server to have desired container process command/arguments")
 
 			fqdnSuffix := ".svc.cluster.local.:"
-			if !fixture.RunningOnOpenShift() {
-				fqdnSuffix = ".svc.cluster.local:"
-			}
 
 			expectedString := "--save \"\" --appendonly no --aclfile /app/config/redis-auth/users.acl"
 
@@ -166,7 +163,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			repoServerDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "argocd-repo-server", Namespace: ns.Name}}
 			Eventually(repoServerDepl).Should(k8sFixture.ExistByName())
 
-			By("expecting repo-server to have desired container process command/arguments")
+			By("expecting repo-server to ha`ve desired container process command/arguments")
 			Expect(repoServerDepl).To(deplFixture.HaveContainerCommandSubstring("uid_entrypoint.sh argocd-repo-server --redis argocd-redis."+ns.Name+fqdnSuffix+"6379 --redis-use-tls --redis-ca-certificate /app/config/reposerver/tls/redis/tls.crt --loglevel info --logformat text", 0),
 				"TLS .spec.template.spec.containers.command for argocd-repo-server deployment is wrong")
 

--- a/test/openshift/e2e/ginkgo/parallel/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
@@ -61,7 +61,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.OutputDebugOnFail(ns)
 		})
 
-		It("ensures that redis HA can be enabled with tls with generated certificate", func() {
+		It("ensures that redis HA can be enabled with tls with generated certificate", Label("HA"), func() {
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)
 
@@ -218,7 +218,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				"TLS .spec.template.spec.containers.command for argocd-application-controller statefulsets is wrong")
 		})
 
-		It("verify redis HA credential distribution", func() {
+		It("verify redis HA credential distribution", Label("HA"), func() {
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)
 

--- a/test/openshift/e2e/ginkgo/parallel/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
@@ -61,7 +61,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.OutputDebugOnFail(ns)
 		})
 
-		FIt("ensures that redis HA can be enabled with tls with generated certificate", Label("HA"), func() {
+		It("ensures that redis HA can be enabled with tls with generated certificate", Label("HA"), func() {
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)
 
@@ -223,7 +223,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				"TLS .spec.template.spec.containers.command for argocd-application-controller statefulsets is wrong")
 		})
 
-		FIt("verify redis HA credential distribution", Label("HA"), func() {
+		It("verify redis HA credential distribution", Label("HA"), func() {
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)
 

--- a/test/openshift/e2e/ginkgo/parallel/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
@@ -197,9 +197,6 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			}
 
 			fqdnSuffix := ".svc.cluster.local.:"
-			if !fixture.RunningOnOpenShift() {
-				fqdnSuffix = ".svc.cluster.local:"
-			}
 
 			repoServerDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "argocd-repo-server", Namespace: ns.Name}}
 			Eventually(repoServerDepl, "2m", "5s").Should(k8sFixture.ExistByName(), "Repo server deployment did not exist within timeout")

--- a/test/openshift/e2e/ginkgo/parallel/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
@@ -61,7 +61,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.OutputDebugOnFail(ns)
 		})
 
-		It("ensures that redis HA can be enabled with tls with generated certificate", Label("HA"), func() {
+		FIt("ensures that redis HA can be enabled with tls with generated certificate", Label("HA"), func() {
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)
 
@@ -196,29 +196,34 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				Expect(sentinelConf).To(MatchRegexp(line))
 			}
 
+			fqdnSuffix := ".svc.cluster.local.:"
+			if !fixture.RunningOnOpenShift() {
+				fqdnSuffix = ".svc.cluster.local:"
+			}
+
 			repoServerDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "argocd-repo-server", Namespace: ns.Name}}
 			Eventually(repoServerDepl, "2m", "5s").Should(k8sFixture.ExistByName(), "Repo server deployment did not exist within timeout")
 
 			By("expecting repo-server to have desired container process command/arguments")
-			Expect(repoServerDepl).To(deplFixture.HaveContainerCommandSubstring("uid_entrypoint.sh argocd-repo-server --redis argocd-redis-ha-haproxy."+ns.Name+".svc.cluster.local.:6379 --redis-use-tls --redis-ca-certificate /app/config/reposerver/tls/redis/tls.crt --loglevel info --logformat text", 0),
+			Expect(repoServerDepl).To(deplFixture.HaveContainerCommandSubstring("uid_entrypoint.sh argocd-repo-server --redis argocd-redis-ha-haproxy."+ns.Name+fqdnSuffix+"6379 --redis-use-tls --redis-ca-certificate /app/config/reposerver/tls/redis/tls.crt --loglevel info --logformat text", 0),
 				"TLS .spec.template.spec.containers.command for argocd-repo-server deployment is wrong")
 
 			argocdServerDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "argocd-server", Namespace: ns.Name}}
 			Eventually(argocdServerDepl, "2m", "5s").Should(k8sFixture.ExistByName(), "ArgoCD server deployment did not exist within timeout")
 
 			By("expecting argocd-server to have desired container process command/arguments")
-			Expect(argocdServerDepl).To(deplFixture.HaveContainerCommandSubstring("argocd-server --staticassets /shared/app --dex-server https://argocd-dex-server."+ns.Name+".svc.cluster.local.:5556 --repo-server argocd-repo-server."+ns.Name+".svc.cluster.local.:8081 --redis argocd-redis-ha-haproxy."+ns.Name+".svc.cluster.local.:6379 --redis-use-tls --redis-ca-certificate /app/config/server/tls/redis/tls.crt --loglevel info --logformat text", 0),
+			Expect(argocdServerDepl).To(deplFixture.HaveContainerCommandSubstring("argocd-server --staticassets /shared/app --dex-server https://argocd-dex-server."+ns.Name+fqdnSuffix+"5556 --repo-server argocd-repo-server."+ns.Name+fqdnSuffix+"8081 --redis argocd-redis-ha-haproxy."+ns.Name+fqdnSuffix+"6379 --redis-use-tls --redis-ca-certificate /app/config/server/tls/redis/tls.crt --loglevel info --logformat text", 0),
 				"TLS .spec.template.spec.containers.command for argocd-server deployment is wrong")
 
 			By("expecting application-controller to have desired container process command/arguments")
 			applicationControllerSS := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "argocd-application-controller", Namespace: ns.Name}}
 			Eventually(applicationControllerSS, "2m", "5s").Should(k8sFixture.ExistByName(), "Application controller StatefulSet did not exist within timeout")
 
-			Expect(applicationControllerSS).To(statefulsetFixture.HaveContainerCommandSubstring("argocd-application-controller --operation-processors 10 --redis argocd-redis-ha-haproxy."+ns.Name+".svc.cluster.local.:6379 --redis-use-tls --redis-ca-certificate /app/config/controller/tls/redis/tls.crt --repo-server argocd-repo-server."+ns.Name+".svc.cluster.local.:8081 --status-processors 20 --kubectl-parallelism-limit 10 --loglevel info --logformat text", 0),
+			Expect(applicationControllerSS).To(statefulsetFixture.HaveContainerCommandSubstring("argocd-application-controller --operation-processors 10 --redis argocd-redis-ha-haproxy."+ns.Name+fqdnSuffix+"6379 --redis-use-tls --redis-ca-certificate /app/config/controller/tls/redis/tls.crt --repo-server argocd-repo-server."+ns.Name+fqdnSuffix+"8081 --status-processors 20 --kubectl-parallelism-limit 10 --loglevel info --logformat text", 0),
 				"TLS .spec.template.spec.containers.command for argocd-application-controller statefulsets is wrong")
 		})
 
-		It("verify redis HA credential distribution", Label("HA"), func() {
+		FIt("verify redis HA credential distribution", Label("HA"), func() {
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)
 

--- a/test/openshift/e2e/ginkgo/parallel/1-068_validate_redis_secure_comm_autols_no_ha_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-068_validate_redis_secure_comm_autols_no_ha_test.go
@@ -40,7 +40,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.OutputDebugOnFail(ns)
 		})
 
-		It("validates that the operator configures Redis using auto-gen TLS certificates when HA is disabled", func() {
+		It("validates that the operator configures Redis using auto-gen TLS certificates when HA is disabled", Label("openshift"), func() {
 
 			expectComponentsAreRunning := func() {
 				deploymentsShouldExist := []string{"argocd-redis", "argocd-server", "argocd-repo-server"}

--- a/test/openshift/e2e/ginkgo/parallel/1-069_validate_redis_secure_comm_autotls_ha_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-069_validate_redis_secure_comm_autotls_ha_test.go
@@ -58,7 +58,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.OutputDebugOnFail(ns)
 		})
 
-		It("verifying when HA is enabled that Argo CD starts successfully in HA mode, and that AutoTLS can be enabled", func() {
+		It("verifying when HA is enabled that Argo CD starts successfully in HA mode, and that AutoTLS can be enabled", Label("HA"), func() {
 
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/parallel/1-069_validate_redis_secure_comm_autotls_ha_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-069_validate_redis_secure_comm_autotls_ha_test.go
@@ -58,7 +58,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.OutputDebugOnFail(ns)
 		})
 
-		It("verifying when HA is enabled that Argo CD starts successfully in HA mode, and that AutoTLS can be enabled", Label("HA"), func() {
+		// autoTLS is not supported in xKS, only supported on openshift
+		It("verifying when HA is enabled that Argo CD starts successfully in HA mode, and that AutoTLS can be enabled", Label("openshift", "HA"), func() {
 
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/parallel/1-075_validate_dex_anyuid_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-075_validate_dex_anyuid_test.go
@@ -51,7 +51,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("validates that dex runs when serviceaccount has anyuid SCC", func() {
+		It("validates that dex runs when serviceaccount has anyuid SCC", Label("openshift"), func() {
 
 			By("creating an Argo CD instance with Dex OpenShift Auth enabled")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-081_validate_applicationset_deployment_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-081_validate_applicationset_deployment_test.go
@@ -37,7 +37,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifies that openshift-gitops Argo CD has applicationset controller workload and service with expected values", Label("notOnXKS"), func() {
+		It("verifies that openshift-gitops Argo CD has applicationset controller workload and service with expected values", Label("openshfit"), func() {
 
 			gitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/parallel/1-081_validate_applicationset_deployment_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-081_validate_applicationset_deployment_test.go
@@ -37,7 +37,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifies that openshift-gitops Argo CD has applicationset controller workload and service with expected values", func() {
+		It("verifies that openshift-gitops Argo CD has applicationset controller workload and service with expected values", Label("openshift"), func() {
 
 			gitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/parallel/1-081_validate_applicationset_deployment_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-081_validate_applicationset_deployment_test.go
@@ -37,7 +37,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifies that openshift-gitops Argo CD has applicationset controller workload and service with expected values", Label("openshift"), func() {
+		It("verifies that openshift-gitops Argo CD has applicationset controller workload and service with expected values", Label("notOnXKS"), func() {
 
 			gitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/parallel/1-081_validate_applicationset_deployment_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-081_validate_applicationset_deployment_test.go
@@ -37,7 +37,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verifies that openshift-gitops Argo CD has applicationset controller workload and service with expected values", Label("openshfit"), func() {
+		It("verifies that openshift-gitops Argo CD has applicationset controller workload and service with expected values", Label("openshift"), func() {
 
 			gitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/parallel/1-082_validate_node_placement_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-082_validate_node_placement_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that setting values in .spec.nodePlacement on Argo CD CR cause those values to be set on the Argo CD Deployment/StatefulSet workloads", Label("notOnXKS"), func() {
+		It("verifies that setting values in .spec.nodePlacement on Argo CD CR cause those values to be set on the Argo CD Deployment/StatefulSet workloads", Label("openshfit"), func() {
 
 			By("creating a basic Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-082_validate_node_placement_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-082_validate_node_placement_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that setting values in .spec.nodePlacement on Argo CD CR cause those values to be set on the Argo CD Deployment/StatefulSet workloads", func() {
+		It("verifies that setting values in .spec.nodePlacement on Argo CD CR cause those values to be set on the Argo CD Deployment/StatefulSet workloads", Label("openshift"), func() {
 
 			By("creating a basic Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-082_validate_node_placement_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-082_validate_node_placement_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that setting values in .spec.nodePlacement on Argo CD CR cause those values to be set on the Argo CD Deployment/StatefulSet workloads", Label("openshift"), func() {
+		It("verifies that setting values in .spec.nodePlacement on Argo CD CR cause those values to be set on the Argo CD Deployment/StatefulSet workloads", Label("notOnXKS"), func() {
 
 			By("creating a basic Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-082_validate_node_placement_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-082_validate_node_placement_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that setting values in .spec.nodePlacement on Argo CD CR cause those values to be set on the Argo CD Deployment/StatefulSet workloads", Label("openshfit"), func() {
+		It("verifies that setting values in .spec.nodePlacement on Argo CD CR cause those values to be set on the Argo CD Deployment/StatefulSet workloads", func() {
 
 			By("creating a basic Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-084_validate_status_host_ingress_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-084_validate_status_host_ingress_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that when Argo CD Server is exposed via an Ingress, that the ingress is created and ArgoCD CR has the correct status information", Label("notOnXKS"), func() {
+		It("ensures that when Argo CD Server is exposed via an Ingress, that the ingress is created and ArgoCD CR has the correct status information", Label("openshfit"), func() {
 
 			// This test supersedes '1-002_verify_hostname_with_ingress'
 

--- a/test/openshift/e2e/ginkgo/parallel/1-084_validate_status_host_ingress_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-084_validate_status_host_ingress_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that when Argo CD Server is exposed via an Ingress, that the ingress is created and ArgoCD CR has the correct status information", func() {
+		It("ensures that when Argo CD Server is exposed via an Ingress, that the ingress is created and ArgoCD CR has the correct status information", Label("openshift"), func() {
 
 			// This test supersedes '1-002_verify_hostname_with_ingress'
 

--- a/test/openshift/e2e/ginkgo/parallel/1-084_validate_status_host_ingress_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-084_validate_status_host_ingress_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that when Argo CD Server is exposed via an Ingress, that the ingress is created and ArgoCD CR has the correct status information", Label("openshift"), func() {
+		It("ensures that when Argo CD Server is exposed via an Ingress, that the ingress is created and ArgoCD CR has the correct status information", Label("notOnXKS"), func() {
 
 			// This test supersedes '1-002_verify_hostname_with_ingress'
 

--- a/test/openshift/e2e/ginkgo/parallel/1-084_validate_status_host_ingress_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-084_validate_status_host_ingress_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that when Argo CD Server is exposed via an Ingress, that the ingress is created and ArgoCD CR has the correct status information", Label("openshfit"), func() {
+		It("ensures that when Argo CD Server is exposed via an Ingress, that the ingress is created and ArgoCD CR has the correct status information", func() {
 
 			// This test supersedes '1-002_verify_hostname_with_ingress'
 

--- a/test/openshift/e2e/ginkgo/parallel/1-090_validate_permissions_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-090_validate_permissions_test.go
@@ -47,7 +47,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensure the GitOps Operator CSV has the correct cluster permissions and gitopsservices CRD has expected properties", func() {
+		// TODO: skipped on xKS, check if this can be ported for xKS testing
+		It("ensure the GitOps Operator CSV has the correct cluster permissions and gitopsservices CRD has expected properties", Label("openshift"), func() {
 
 			if fixture.EnvCI() {
 				Skip("AFAICT CSV does not exist when running E2E tests from gitops-operator repo")

--- a/test/openshift/e2e/ginkgo/parallel/1-095_validate_dex_clientsecret_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-095_validate_dex_clientsecret_test.go
@@ -72,7 +72,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that the Dex client secret is sourced from a short-lived TokenRequest token and is correctly set in argocd-secret", func() {
+		It("verifies that the Dex client secret is sourced from a short-lived TokenRequest token and is correctly set in argocd-secret", Label("openshift"), func() {
 
 			By("creating simple Argo CD instance with Dex and Openshift OAuth enabled")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-096-validate_home_env_argocd_controller_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-096-validate_home_env_argocd_controller_test.go
@@ -35,7 +35,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 		})
 
-		It("verifies openshift-gitops app controller StatefulSet container has expected HOME env var and redis-initial-pass volume mount", Label("notOnXKS"), func() {
+		It("verifies openshift-gitops app controller StatefulSet container has expected HOME env var and redis-initial-pass volume mount", Label("openshfit"), func() {
 
 			By("verifying openshift-gitops-application-controller StatefulSet has the expected value for HOME")
 			ss := &appsv1.StatefulSet{

--- a/test/openshift/e2e/ginkgo/parallel/1-096-validate_home_env_argocd_controller_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-096-validate_home_env_argocd_controller_test.go
@@ -35,7 +35,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 		})
 
-		It("verifies openshift-gitops app controller StatefulSet container has expected HOME env var and redis-initial-pass volume mount", func() {
+		It("verifies openshift-gitops app controller StatefulSet container has expected HOME env var and redis-initial-pass volume mount", Label("openshift"), func() {
 
 			By("verifying openshift-gitops-application-controller StatefulSet has the expected value for HOME")
 			ss := &appsv1.StatefulSet{

--- a/test/openshift/e2e/ginkgo/parallel/1-096-validate_home_env_argocd_controller_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-096-validate_home_env_argocd_controller_test.go
@@ -35,7 +35,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 		})
 
-		It("verifies openshift-gitops app controller StatefulSet container has expected HOME env var and redis-initial-pass volume mount", Label("openshift"), func() {
+		It("verifies openshift-gitops app controller StatefulSet container has expected HOME env var and redis-initial-pass volume mount", Label("notOnXKS"), func() {
 
 			By("verifying openshift-gitops-application-controller StatefulSet has the expected value for HOME")
 			ss := &appsv1.StatefulSet{

--- a/test/openshift/e2e/ginkgo/parallel/1-096-validate_home_env_argocd_controller_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-096-validate_home_env_argocd_controller_test.go
@@ -35,7 +35,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 		})
 
-		It("verifies openshift-gitops app controller StatefulSet container has expected HOME env var and redis-initial-pass volume mount", Label("openshfit"), func() {
+		It("verifies openshift-gitops app controller StatefulSet container has expected HOME env var and redis-initial-pass volume mount", Label("openshift"), func() {
 
 			By("verifying openshift-gitops-application-controller StatefulSet has the expected value for HOME")
 			ss := &appsv1.StatefulSet{

--- a/test/openshift/e2e/ginkgo/parallel/1-103_argocd_alpha_to_beta_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-103_argocd_alpha_to_beta_conversion_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that creation of a v1alpha1 ArgoCD CR with SSO fields will be translated into a v1beta1 ArgoCD CR via webhook", Label("notOnXKS"), func() {
+		It("ensures that creation of a v1alpha1 ArgoCD CR with SSO fields will be translated into a v1beta1 ArgoCD CR via webhook", Label("openshfit"), func() {
 			if fixture.EnvLocalRun() {
 				Skip("When LOCAL_RUN is set, the API upgrade webhook is not running, which is what this test tets. Thus this test should be skipped.")
 				return

--- a/test/openshift/e2e/ginkgo/parallel/1-103_argocd_alpha_to_beta_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-103_argocd_alpha_to_beta_conversion_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that creation of a v1alpha1 ArgoCD CR with SSO fields will be translated into a v1beta1 ArgoCD CR via webhook", func() {
+		It("ensures that creation of a v1alpha1 ArgoCD CR with SSO fields will be translated into a v1beta1 ArgoCD CR via webhook", Label("openshift"), func() {
 			if fixture.EnvLocalRun() {
 				Skip("When LOCAL_RUN is set, the API upgrade webhook is not running, which is what this test tets. Thus this test should be skipped.")
 				return

--- a/test/openshift/e2e/ginkgo/parallel/1-103_argocd_alpha_to_beta_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-103_argocd_alpha_to_beta_conversion_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that creation of a v1alpha1 ArgoCD CR with SSO fields will be translated into a v1beta1 ArgoCD CR via webhook", Label("openshift"), func() {
+		It("ensures that creation of a v1alpha1 ArgoCD CR with SSO fields will be translated into a v1beta1 ArgoCD CR via webhook", Label("notOnXKS"), func() {
 			if fixture.EnvLocalRun() {
 				Skip("When LOCAL_RUN is set, the API upgrade webhook is not running, which is what this test tets. Thus this test should be skipped.")
 				return

--- a/test/openshift/e2e/ginkgo/parallel/1-103_argocd_alpha_to_beta_conversion_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-103_argocd_alpha_to_beta_conversion_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that creation of a v1alpha1 ArgoCD CR with SSO fields will be translated into a v1beta1 ArgoCD CR via webhook", Label("openshfit"), func() {
+		It("ensures that creation of a v1alpha1 ArgoCD CR with SSO fields will be translated into a v1beta1 ArgoCD CR via webhook", Label("openshift"), func() {
 			if fixture.EnvLocalRun() {
 				Skip("When LOCAL_RUN is set, the API upgrade webhook is not running, which is what this test tets. Thus this test should be skipped.")
 				return

--- a/test/openshift/e2e/ginkgo/parallel/1-104_validate_prometheus_alert_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-104_validate_prometheus_alert_test.go
@@ -21,7 +21,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("verify that openshift gitops operator servicemonitor exists in openshift-gitops-operator namespace, and has the expected values", func() {
+		// TODO: currently skipped on xKS, update CI to install prometheus for tests to run
+		It("verify that openshift gitops operator servicemonitor exists in openshift-gitops-operator namespace, and has the expected values", Label("openshift"), func() {
 
 			if fixture.EnvLocalRun() || fixture.EnvNonOLM() {
 				Skip("this test requires the operator to installed via OLM to openshift-operators namespace")

--- a/test/openshift/e2e/ginkgo/parallel/1-109_validate_reencrypt_termination_policy_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-109_validate_reencrypt_termination_policy_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("ensure the openshift-gitops default argo cd server route has expected TLS  Config values: insecure redirect and reencrypt, and the route ingress is sucessfully admitted", Label("notOnXKS"), func() {
+		It("ensure the openshift-gitops default argo cd server route has expected TLS  Config values: insecure redirect and reencrypt, and the route ingress is sucessfully admitted", Label("openshfit"), func() {
 
 			By("ensuring that default openshift-gitops has expecter route settings and an admitted ingress")
 			openshiftGitOpsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/parallel/1-109_validate_reencrypt_termination_policy_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-109_validate_reencrypt_termination_policy_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("ensure the openshift-gitops default argo cd server route has expected TLS  Config values: insecure redirect and reencrypt, and the route ingress is sucessfully admitted", Label("openshift"), func() {
+		It("ensure the openshift-gitops default argo cd server route has expected TLS  Config values: insecure redirect and reencrypt, and the route ingress is sucessfully admitted", Label("notOnXKS"), func() {
 
 			By("ensuring that default openshift-gitops has expecter route settings and an admitted ingress")
 			openshiftGitOpsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/parallel/1-109_validate_reencrypt_termination_policy_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-109_validate_reencrypt_termination_policy_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("ensure the openshift-gitops default argo cd server route has expected TLS  Config values: insecure redirect and reencrypt, and the route ingress is sucessfully admitted", func() {
+		It("ensure the openshift-gitops default argo cd server route has expected TLS  Config values: insecure redirect and reencrypt, and the route ingress is sucessfully admitted", Label("openshift"), func() {
 
 			By("ensuring that default openshift-gitops has expecter route settings and an admitted ingress")
 			openshiftGitOpsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/parallel/1-109_validate_reencrypt_termination_policy_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-109_validate_reencrypt_termination_policy_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureParallelCleanSlate()
 		})
 
-		It("ensure the openshift-gitops default argo cd server route has expected TLS  Config values: insecure redirect and reencrypt, and the route ingress is sucessfully admitted", Label("openshfit"), func() {
+		It("ensure the openshift-gitops default argo cd server route has expected TLS  Config values: insecure redirect and reencrypt, and the route ingress is sucessfully admitted", Label("openshift"), func() {
 
 			By("ensuring that default openshift-gitops has expecter route settings and an admitted ingress")
 			openshiftGitOpsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/parallel/1-118_validate_redis_ssc_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-118_validate_redis_ssc_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 		})
 
-		It("verifies that HA pods have expected SSC", func() {
+		It("verifies that HA pods have expected SSC", Label("openshift"), func() {
 
 			fixture.EnsureRunningOnOpenShift() // SSC requires OpenShift
 

--- a/test/openshift/e2e/ginkgo/parallel/1-121_validate_custom_labels_rollouts.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-121_validate_custom_labels_rollouts.go
@@ -46,7 +46,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that custom labels set by the operator are added to Argo Rollouts resources", func() {
+		FIt("ensures that custom labels set by the operator are added to Argo Rollouts resources", func() {
 
 			By("creating namespace-scoped RolloutManager instance")
 			rolloutManager := &rolloutmanagerv1alpha1.RolloutManager{

--- a/test/openshift/e2e/ginkgo/parallel/1-121_validate_custom_labels_rollouts.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-121_validate_custom_labels_rollouts.go
@@ -46,7 +46,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		FIt("ensures that custom labels set by the operator are added to Argo Rollouts resources", func() {
+		It("ensures that custom labels set by the operator are added to Argo Rollouts resources", func() {
 
 			By("creating namespace-scoped RolloutManager instance")
 			rolloutManager := &rolloutmanagerv1alpha1.RolloutManager{

--- a/test/openshift/e2e/ginkgo/parallel/1-121_validate_custom_labels_rollouts.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-121_validate_custom_labels_rollouts.go
@@ -35,47 +35,63 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 	Context("1-121_validate_custom_labels_rollouts", func() {
 
+		const rolloutNamespace = "openshift-gitops"
+
 		var (
-			k8sClient client.Client
-			ctx       context.Context
+			k8sClient      client.Client
+			ctx            context.Context
+			rolloutManager *rolloutmanagerv1alpha1.RolloutManager
 		)
 
 		BeforeEach(func() {
 			fixture.EnsureParallelCleanSlate()
 			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
 			ctx = context.Background()
+
+			if !fixture.RunningOnOpenShift() {
+				ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: rolloutNamespace}}
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(ns), ns); err != nil {
+					Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+				}
+			}
 		})
 
-		It("ensures that custom labels set by the operator are added to Argo Rollouts resources", func() {
+		AfterEach(func() {
+			if rolloutManager != nil {
+				_ = k8sClient.Delete(ctx, rolloutManager)
+				Eventually(rolloutManager, "2m", "2s").Should(k8sFixture.NotExistByName())
+			}
+		})
+
+		FIt("ensures that custom labels set by the operator are added to Argo Rollouts resources", func() {
 
 			By("creating namespace-scoped RolloutManager instance")
-			rolloutManager := &rolloutmanagerv1alpha1.RolloutManager{
+			rolloutManager = &rolloutmanagerv1alpha1.RolloutManager{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-rollout-manager",
-					Namespace: "openshift-gitops",
+					Namespace: rolloutNamespace,
 				},
 			}
 			Expect(k8sClient.Create(ctx, rolloutManager)).To(Succeed())
 
 			By("waiting for Argo Rollouts deployment to be created and become available")
-			depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "argo-rollouts", Namespace: "openshift-gitops"}}
+			depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "argo-rollouts", Namespace: rolloutNamespace}}
 			Eventually(depl, "2m", "2s").Should(k8sFixture.ExistByName())
 
 			By("verifying Argo Rollouts Secret has the custom labels")
 			labelKey := "operator.argoproj.io/tracked-by"
 			labelValue := "argocd"
-			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "argo-rollouts-notification-secret", Namespace: "openshift-gitops"}}
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "argo-rollouts-notification-secret", Namespace: rolloutNamespace}}
 			Eventually(secret, "2m", "1s").Should(k8sFixture.ExistByName())
 			Expect(secret.Labels).Should(HaveKeyWithValue(labelKey, labelValue))
 
 			By("verifying Argo Rollouts ConfigMap has the custom labels")
-			configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "argo-rollouts-config", Namespace: "openshift-gitops"}}
+			configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "argo-rollouts-config", Namespace: rolloutNamespace}}
 			Eventually(configMap, "2m", "1s").Should(k8sFixture.ExistByName())
 			Expect(configMap.Labels).Should(HaveKeyWithValue(labelKey, labelValue))
 
 			By("updating RolloutManager spec")
 
-			// Add a new label to trigger reconciliation
 			if rolloutManager.Labels == nil {
 				rolloutManager.Labels = make(map[string]string)
 			}
@@ -84,12 +100,12 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			Expect(k8sClient.Patch(ctx, rolloutManager, patch)).To(Succeed())
 
 			By("ensures that custom labels persist in configmap after RolloutManager updates")
-			configMap = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "argo-rollouts-config", Namespace: "openshift-gitops"}}
+			configMap = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "argo-rollouts-config", Namespace: rolloutNamespace}}
 			Eventually(configMap, "2m", "1s").Should(k8sFixture.ExistByName())
 			Expect(configMap.Labels).Should(HaveKeyWithValue(labelKey, labelValue))
 
 			By("ensures that custom labels persist in secret after RolloutManager updates")
-			secret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "argo-rollouts-notification-secret", Namespace: "openshift-gitops"}}
+			secret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "argo-rollouts-notification-secret", Namespace: rolloutNamespace}}
 			Eventually(secret, "2m", "1s").Should(k8sFixture.ExistByName())
 			Expect(secret.Labels).Should(HaveKeyWithValue(labelKey, labelValue))
 		})

--- a/test/openshift/e2e/ginkgo/parallel/1-121_validate_custom_labels_rollouts.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-121_validate_custom_labels_rollouts.go
@@ -63,7 +63,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			}
 		})
 
-		FIt("ensures that custom labels set by the operator are added to Argo Rollouts resources", func() {
+		It("ensures that custom labels set by the operator are added to Argo Rollouts resources", func() {
 
 			By("creating namespace-scoped RolloutManager instance")
 			rolloutManager = &rolloutmanagerv1alpha1.RolloutManager{

--- a/test/openshift/e2e/ginkgo/parallel/1-121_validate_image_updater_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-121_validate_image_updater_test.go
@@ -43,7 +43,7 @@ import (
 )
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
-
+	//  TODO: update this test to run on xKS cluster
 	Context("1-121_validate_image_updater_test", func() {
 
 		var (

--- a/test/openshift/e2e/ginkgo/parallel/1-121_validate_image_updater_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-121_validate_image_updater_test.go
@@ -43,7 +43,6 @@ import (
 )
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
-	//  TODO: update this test to run on xKS cluster
 	Context("1-121_validate_image_updater_test", func() {
 
 		var (
@@ -76,26 +75,26 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 		})
 
-		It("ensures that Image Updater will update Argo CD Application to the latest image", func() {
+		FIt("ensures that Image Updater will update Argo CD Application to the latest image", func() {
 
 			By("creating simple namespace-scoped Argo CD instance with image updater enabled")
 			ns, cleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
-			By("ensuring default service account has anyuid SCC permission")
-			serviceAccountUser := "system:serviceaccount:" + ns.Name + ":default"
-			output, err := osFixture.ExecCommand("oc", "auth", "can-i", "use", "scc/anyuid", "--as", serviceAccountUser)
-			hasPermission := false
-			if err == nil && len(output) > 0 {
-				// Check if the service account user is already in the users list
-				// Remove quotes and whitespace for comparison
-				output = strings.TrimSpace(strings.Trim(output, "'\""))
-				if strings.Contains(output, serviceAccountUser) {
-					hasPermission = true
+			if fixture.RunningOnOpenShift() {
+				By("ensuring default service account has anyuid SCC permission")
+				serviceAccountUser := "system:serviceaccount:" + ns.Name + ":default"
+				output, err := osFixture.ExecCommand("oc", "auth", "can-i", "use", "scc/anyuid", "--as", serviceAccountUser)
+				hasPermission := false
+				if err == nil && len(output) > 0 {
+					output = strings.TrimSpace(strings.Trim(output, "'\""))
+					if strings.Contains(output, serviceAccountUser) {
+						hasPermission = true
+					}
 				}
-			}
-			if !hasPermission {
-				_, err := osFixture.ExecCommand("oc", "adm", "policy", "add-scc-to-user", "anyuid", "-z", "default", "-n", ns.Name)
-				Expect(err).NotTo(HaveOccurred(), "Failed to add anyuid SCC to default service account")
+				if !hasPermission {
+					_, err := osFixture.ExecCommand("oc", "adm", "policy", "add-scc-to-user", "anyuid", "-z", "default", "-n", ns.Name)
+					Expect(err).NotTo(HaveOccurred(), "Failed to add anyuid SCC to default service account")
+				}
 			}
 
 			argoCD := &argov1beta1api.ArgoCD{

--- a/test/openshift/e2e/ginkgo/parallel/1-121_validate_image_updater_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-121_validate_image_updater_test.go
@@ -75,7 +75,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 		})
 
-		FIt("ensures that Image Updater will update Argo CD Application to the latest image", func() {
+		It("ensures that Image Updater will update Argo CD Application to the latest image", func() {
 
 			By("creating simple namespace-scoped Argo CD instance with image updater enabled")
 			ns, cleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-125_validate_server_serving_cert_annotation_restore_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-125_validate_server_serving_cert_annotation_restore_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("restores service.beta.openshift.io/serving-cert-secret-name when Route TLS returns from passthrough to default reencrypt", Label("notOnXKS"), func() {
+		It("restores service.beta.openshift.io/serving-cert-secret-name when Route TLS returns from passthrough to default reencrypt", Label("openshfit"), func() {
 			ns, nsCleanup := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			defer nsCleanup()
 
@@ -124,7 +124,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 		})
 
-		It("does not add serving-cert annotation when argocd-server-tls already exists as a user-managed secret (not Service CA)", Label("notOnXKS"), func() {
+		It("does not add serving-cert annotation when argocd-server-tls already exists as a user-managed secret (not Service CA)", Label("openshfit"), func() {
 			certPem, keyPem, err := certFixture.GenerateCert()
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/openshift/e2e/ginkgo/parallel/1-125_validate_server_serving_cert_annotation_restore_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-125_validate_server_serving_cert_annotation_restore_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("restores service.beta.openshift.io/serving-cert-secret-name when Route TLS returns from passthrough to default reencrypt", Label("openshift"), func() {
+		It("restores service.beta.openshift.io/serving-cert-secret-name when Route TLS returns from passthrough to default reencrypt", Label("notOnXKS"), func() {
 			ns, nsCleanup := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			defer nsCleanup()
 
@@ -124,7 +124,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 		})
 
-		It("does not add serving-cert annotation when argocd-server-tls already exists as a user-managed secret (not Service CA)", Label("openshift"), func() {
+		It("does not add serving-cert annotation when argocd-server-tls already exists as a user-managed secret (not Service CA)", Label("notOnXKS"), func() {
 			certPem, keyPem, err := certFixture.GenerateCert()
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/openshift/e2e/ginkgo/parallel/1-125_validate_server_serving_cert_annotation_restore_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-125_validate_server_serving_cert_annotation_restore_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("restores service.beta.openshift.io/serving-cert-secret-name when Route TLS returns from passthrough to default reencrypt", func() {
+		It("restores service.beta.openshift.io/serving-cert-secret-name when Route TLS returns from passthrough to default reencrypt", Label("openshift"), func() {
 			ns, nsCleanup := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			defer nsCleanup()
 
@@ -124,7 +124,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 		})
 
-		It("does not add serving-cert annotation when argocd-server-tls already exists as a user-managed secret (not Service CA)", func() {
+		It("does not add serving-cert annotation when argocd-server-tls already exists as a user-managed secret (not Service CA)", Label("openshift"), func() {
 			certPem, keyPem, err := certFixture.GenerateCert()
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/openshift/e2e/ginkgo/parallel/1-125_validate_server_serving_cert_annotation_restore_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-125_validate_server_serving_cert_annotation_restore_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("restores service.beta.openshift.io/serving-cert-secret-name when Route TLS returns from passthrough to default reencrypt", Label("openshfit"), func() {
+		It("restores service.beta.openshift.io/serving-cert-secret-name when Route TLS returns from passthrough to default reencrypt", Label("openshift"), func() {
 			ns, nsCleanup := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			defer nsCleanup()
 
@@ -124,7 +124,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 		})
 
-		It("does not add serving-cert annotation when argocd-server-tls already exists as a user-managed secret (not Service CA)", Label("openshfit"), func() {
+		It("does not add serving-cert annotation when argocd-server-tls already exists as a user-managed secret (not Service CA)", Label("openshift"), func() {
 			certPem, keyPem, err := certFixture.GenerateCert()
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
@@ -36,7 +36,7 @@ import (
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
-	Context("1-126_validate_servicemonitor_metrics_config", Label("notOnXKS"), func() {
+	Context("1-126_validate_servicemonitor_metrics_config", Label("openshfit"), func() {
 
 		var (
 			k8sClient client.Client

--- a/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
@@ -36,7 +36,7 @@ import (
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
-	Context("1-126_validate_servicemonitor_metrics_config", Label("openshift"), func() {
+	Context("1-126_validate_servicemonitor_metrics_config", Label("notOnXKS"), func() {
 
 		var (
 			k8sClient client.Client

--- a/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
@@ -36,7 +36,7 @@ import (
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
-	Context("1-126_validate_servicemonitor_metrics_config", func() {
+	Context("1-126_validate_servicemonitor_metrics_config", Label("openshift"), func() {
 
 		var (
 			k8sClient client.Client

--- a/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
@@ -35,7 +35,7 @@ import (
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
-	Context("1-126_validate_servicemonitor_metrics_config", Label("openshift"), func() {
+	Context("1-126_validate_servicemonitor_metrics_config", Label("notOnXKS"), func() {
 
 		var (
 			k8sClient client.Client

--- a/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
@@ -35,7 +35,7 @@ import (
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
-	Context("1-126_validate_servicemonitor_metrics_config", Label("notOnXKS"), func() {
+	Context("1-126_validate_servicemonitor_metrics_config", Label("openshfit"), func() {
 
 		var (
 			k8sClient client.Client

--- a/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
@@ -36,7 +36,7 @@ import (
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
-	Context("1-126_validate_servicemonitor_metrics_config", Label("openshfit"), func() {
+	Context("1-126_validate_servicemonitor_metrics_config", Label("openshift"), func() {
 
 		var (
 			k8sClient client.Client

--- a/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
@@ -35,7 +35,7 @@ import (
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
-	Context("1-126_validate_servicemonitor_metrics_config", func() {
+	Context("1-126_validate_servicemonitor_metrics_config", Label("openshift"), func() {
 
 		var (
 			k8sClient client.Client

--- a/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-126_validate_servicemonitor_metrics_config_test.go
@@ -35,7 +35,7 @@ import (
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
-	Context("1-126_validate_servicemonitor_metrics_config", Label("openshfit"), func() {
+	Context("1-126_validate_servicemonitor_metrics_config", Label("openshift"), func() {
 
 		var (
 			k8sClient client.Client

--- a/test/openshift/e2e/ginkgo/sequential/1-002-validate_backend_service_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-002-validate_backend_service_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("validates backend service permissions", Label("notOnXKS"), func() {
+		It("validates backend service permissions", Label("openshfit"), func() {
 
 			By("checking the openshift-gitops namespace installed by default")
 			Eventually(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops"}}).Should(k8sFixture.ExistByName())

--- a/test/openshift/e2e/ginkgo/sequential/1-002-validate_backend_service_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-002-validate_backend_service_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("validates backend service permissions", func() {
+		It("validates backend service permissions", Label("openshift"), func() {
 
 			By("checking the openshift-gitops namespace installed by default")
 			Eventually(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops"}}).Should(k8sFixture.ExistByName())

--- a/test/openshift/e2e/ginkgo/sequential/1-002-validate_backend_service_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-002-validate_backend_service_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("validates backend service permissions", Label("openshift"), func() {
+		It("validates backend service permissions", Label("notOnXKS"), func() {
 
 			By("checking the openshift-gitops namespace installed by default")
 			Eventually(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops"}}).Should(k8sFixture.ExistByName())

--- a/test/openshift/e2e/ginkgo/sequential/1-002-validate_backend_service_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-002-validate_backend_service_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("validates backend service permissions", Label("openshfit"), func() {
+		It("validates backend service permissions", Label("openshift"), func() {
 
 			By("checking the openshift-gitops namespace installed by default")
 			Eventually(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops"}}).Should(k8sFixture.ExistByName())

--- a/test/openshift/e2e/ginkgo/sequential/1-004_validate_argocd_installation_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-004_validate_argocd_installation_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies that default openshift-gitops Argo CD instance becomes available after modifying .spec.controller.processors.operation value", Label("notOnXKS"), func() {
+		It("verifies that default openshift-gitops Argo CD instance becomes available after modifying .spec.controller.processors.operation value", Label("openshfit"), func() {
 
 			By("verifying default openshift-gitops Argo CD instance is available")
 			argocd, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-004_validate_argocd_installation_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-004_validate_argocd_installation_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies that default openshift-gitops Argo CD instance becomes available after modifying .spec.controller.processors.operation value", Label("openshift"), func() {
+		It("verifies that default openshift-gitops Argo CD instance becomes available after modifying .spec.controller.processors.operation value", Label("notOnXKS"), func() {
 
 			By("verifying default openshift-gitops Argo CD instance is available")
 			argocd, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-004_validate_argocd_installation_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-004_validate_argocd_installation_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies that default openshift-gitops Argo CD instance becomes available after modifying .spec.controller.processors.operation value", func() {
+		It("verifies that default openshift-gitops Argo CD instance becomes available after modifying .spec.controller.processors.operation value", Label("openshift"), func() {
 
 			By("verifying default openshift-gitops Argo CD instance is available")
 			argocd, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-004_validate_argocd_installation_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-004_validate_argocd_installation_test.go
@@ -28,12 +28,13 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-004_validate_argocd_installation", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies that default openshift-gitops Argo CD instance becomes available after modifying .spec.controller.processors.operation value", Label("openshfit"), func() {
+		It("verifies that default openshift-gitops Argo CD instance becomes available after modifying .spec.controller.processors.operation value", Label("openshift"), func() {
 
 			By("verifying default openshift-gitops Argo CD instance is available")
 			argocd, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
@@ -71,7 +71,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that repo server replicas can be modified via .spec.repo.replicas", Label("notOnXKS"), func() {
+		It("verifies that repo server replicas can be modified via .spec.repo.replicas", Label("openshfit"), func() {
 
 			By("setting the repo server replicas to 2 on openshift-gitops Argo CD")
 			var err error

--- a/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
@@ -71,7 +71,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that repo server replicas can be modified via .spec.repo.replicas", func() {
+		It("verifies that repo server replicas can be modified via .spec.repo.replicas", Label("openshift"), func() {
 
 			By("setting the repo server replicas to 2 on openshift-gitops Argo CD")
 			var err error

--- a/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
@@ -71,7 +71,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that repo server replicas can be modified via .spec.repo.replicas", Label("openshift"), func() {
+		It("verifies that repo server replicas can be modified via .spec.repo.replicas", Label("notOnXKS"), func() {
 
 			By("setting the repo server replicas to 2 on openshift-gitops Argo CD")
 			var err error

--- a/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
@@ -70,7 +70,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that repo server replicas can be modified via .spec.repo.replicas", Label("openshift"), func() {
+		It("verifies that repo server replicas can be modified via .spec.repo.replicas", Label("notOnXKS"), func() {
 
 			By("setting the repo server replicas to 2 on openshift-gitops Argo CD")
 			var err error

--- a/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
@@ -70,7 +70,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that repo server replicas can be modified via .spec.repo.replicas", Label("notOnXKS"), func() {
+		It("verifies that repo server replicas can be modified via .spec.repo.replicas", Label("openshfit"), func() {
 
 			By("setting the repo server replicas to 2 on openshift-gitops Argo CD")
 			var err error

--- a/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
@@ -40,6 +40,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-006_validate_machine_config", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		var (
 			ctx           context.Context
@@ -70,7 +71,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that repo server replicas can be modified via .spec.repo.replicas", Label("openshfit"), func() {
+		It("verifies that repo server replicas can be modified via .spec.repo.replicas", Label("openshift"), func() {
 
 			By("setting the repo server replicas to 2 on openshift-gitops Argo CD")
 			var err error

--- a/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
@@ -70,7 +70,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that repo server replicas can be modified via .spec.repo.replicas", func() {
+		It("verifies that repo server replicas can be modified via .spec.repo.replicas", Label("openshift"), func() {
 
 			By("setting the repo server replicas to 2 on openshift-gitops Argo CD")
 			var err error

--- a/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
@@ -41,6 +41,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-006_validate_machine_config", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		var (
 			ctx           context.Context
@@ -71,7 +72,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that repo server replicas can be modified via .spec.repo.replicas", Label("openshfit"), func() {
+		It("verifies that repo server replicas can be modified via .spec.repo.replicas", Label("openshift"), func() {
 
 			By("setting the repo server replicas to 2 on openshift-gitops Argo CD")
 			var err error

--- a/test/openshift/e2e/ginkgo/sequential/1-008_validate-4.9CI-Failures_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-008_validate-4.9CI-Failures_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies 4.9 CI failures", Label("notOnXKS"), func() {
+		It("verifies 4.9 CI failures", Label("openshfit"), func() {
 
 			sourceNS := fixture.CreateNamespace("source-ns")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-008_validate-4.9CI-Failures_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-008_validate-4.9CI-Failures_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies 4.9 CI failures", func() {
+		It("verifies 4.9 CI failures", Label("openshift"), func() {
 
 			sourceNS := fixture.CreateNamespace("source-ns")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-008_validate-4.9CI-Failures_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-008_validate-4.9CI-Failures_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies 4.9 CI failures", Label("openshift"), func() {
+		It("verifies 4.9 CI failures", Label("notOnXKS"), func() {
 
 			sourceNS := fixture.CreateNamespace("source-ns")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-008_validate-4.9CI-Failures_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-008_validate-4.9CI-Failures_test.go
@@ -38,6 +38,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-008_validate-4.9CI-Failures", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		var (
 			ctx       context.Context
@@ -50,7 +51,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies 4.9 CI failures", Label("openshfit"), func() {
+		It("verifies 4.9 CI failures", func() {
 
 			sourceNS := fixture.CreateNamespace("source-ns")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-010_validate-ootb-manage-other-namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-010_validate-ootb-manage-other-namespace_test.go
@@ -65,7 +65,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that openshift-gitops Argo CD instance is able to manage/unmanage other namespaces via managed-by label", Label("notOnXKS"), func() {
+		It("verifies that openshift-gitops Argo CD instance is able to manage/unmanage other namespaces via managed-by label", Label("openshfit"), func() {
 
 			By("creating a new namespace that is managed by openshift-gitops Argo CD instance")
 			nsTest_1_10_custom, nsCleanupFunc = fixture.CreateManagedNamespaceWithCleanupFunc("test-1-10-custom", "openshift-gitops")

--- a/test/openshift/e2e/ginkgo/sequential/1-010_validate-ootb-manage-other-namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-010_validate-ootb-manage-other-namespace_test.go
@@ -65,7 +65,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that openshift-gitops Argo CD instance is able to manage/unmanage other namespaces via managed-by label", func() {
+		It("verifies that openshift-gitops Argo CD instance is able to manage/unmanage other namespaces via managed-by label", Label("openshift"), func() {
 
 			By("creating a new namespace that is managed by openshift-gitops Argo CD instance")
 			nsTest_1_10_custom, nsCleanupFunc = fixture.CreateManagedNamespaceWithCleanupFunc("test-1-10-custom", "openshift-gitops")

--- a/test/openshift/e2e/ginkgo/sequential/1-010_validate-ootb-manage-other-namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-010_validate-ootb-manage-other-namespace_test.go
@@ -65,7 +65,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that openshift-gitops Argo CD instance is able to manage/unmanage other namespaces via managed-by label", Label("openshift"), func() {
+		It("verifies that openshift-gitops Argo CD instance is able to manage/unmanage other namespaces via managed-by label", Label("notOnXKS"), func() {
 
 			By("creating a new namespace that is managed by openshift-gitops Argo CD instance")
 			nsTest_1_10_custom, nsCleanupFunc = fixture.CreateManagedNamespaceWithCleanupFunc("test-1-10-custom", "openshift-gitops")

--- a/test/openshift/e2e/ginkgo/sequential/1-010_validate-ootb-manage-other-namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-010_validate-ootb-manage-other-namespace_test.go
@@ -39,6 +39,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-010_validate-ootb-manage-other-namespace", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		var (
 			ctx                context.Context
@@ -65,7 +66,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that openshift-gitops Argo CD instance is able to manage/unmanage other namespaces via managed-by label", Label("openshfit"), func() {
+		It("verifies that openshift-gitops Argo CD instance is able to manage/unmanage other namespaces via managed-by label", Label("openshift"), func() {
 
 			By("creating a new namespace that is managed by openshift-gitops Argo CD instance")
 			nsTest_1_10_custom, nsCleanupFunc = fixture.CreateManagedNamespaceWithCleanupFunc("test-1-10-custom", "openshift-gitops")

--- a/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
@@ -40,7 +40,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies that the default ArgoCD instance from openshift-gitops namespace is recreated when deleted manually", Label("notOnXKS"), func() {
+		It("verifies that the default ArgoCD instance from openshift-gitops namespace is recreated when deleted manually", Label("openshfit"), func() {
 
 			openshiftGitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())
@@ -100,7 +100,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(ss, "5m", "5s").Should(statefulsetFixture.HaveReadyReplicas(1))
 		})
 
-		It("verifies that DISABLE_DEFAULT_ARGOCD_INSTANCE env var will delete the argo cd instance from openshift-gitops, and that default Argo CD instance will be restored when the env var is removed", Label("notOnXKS"), func() {
+		It("verifies that DISABLE_DEFAULT_ARGOCD_INSTANCE env var will delete the argo cd instance from openshift-gitops, and that default Argo CD instance will be restored when the env var is removed", Label("openshfit"), func() {
 			if fixture.EnvLocalRun() {
 				Skip("when running locally, there is no subscription or operator deployment to modify, so this test is skipped.")
 				return

--- a/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
@@ -100,7 +100,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(ss, "5m", "5s").Should(statefulsetFixture.HaveReadyReplicas(1))
 		})
 
-		It("verifies that DISABLE_DEFAULT_ARGOCD_INSTANCE env var will delete the argo cd instance from openshift-gitops, and that default Argo CD instance will be restored when the env var is removed", func() {
+		It("verifies that DISABLE_DEFAULT_ARGOCD_INSTANCE env var will delete the argo cd instance from openshift-gitops, and that default Argo CD instance will be restored when the env var is removed", Label("notOnXKS"), func() {
 			if fixture.EnvLocalRun() {
 				Skip("when running locally, there is no subscription or operator deployment to modify, so this test is skipped.")
 				return

--- a/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
@@ -40,7 +40,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies that the default ArgoCD instance from openshift-gitops namespace is recreated when deleted manually", func() {
+		It("verifies that the default ArgoCD instance from openshift-gitops namespace is recreated when deleted manually", Label("openshift"), func() {
 
 			openshiftGitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
@@ -40,7 +40,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies that the default ArgoCD instance from openshift-gitops namespace is recreated when deleted manually", Label("openshift"), func() {
+		It("verifies that the default ArgoCD instance from openshift-gitops namespace is recreated when deleted manually", Label("notOnXKS"), func() {
 
 			openshiftGitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
@@ -35,12 +35,13 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-018_validate_disable_default_instance", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies that the default ArgoCD instance from openshift-gitops namespace is recreated when deleted manually", Label("openshfit"), func() {
+		It("verifies that the default ArgoCD instance from openshift-gitops namespace is recreated when deleted manually", Label("openshift"), func() {
 
 			openshiftGitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())
@@ -100,7 +101,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(ss, "5m", "5s").Should(statefulsetFixture.HaveReadyReplicas(1))
 		})
 
-		It("verifies that DISABLE_DEFAULT_ARGOCD_INSTANCE env var will delete the argo cd instance from openshift-gitops, and that default Argo CD instance will be restored when the env var is removed", Label("openshfit"), func() {
+		It("verifies that DISABLE_DEFAULT_ARGOCD_INSTANCE env var will delete the argo cd instance from openshift-gitops, and that default Argo CD instance will be restored when the env var is removed", Label("openshift"), func() {
 			if fixture.EnvLocalRun() {
 				Skip("when running locally, there is no subscription or operator deployment to modify, so this test is skipped.")
 				return

--- a/test/openshift/e2e/ginkgo/sequential/1-020_validate_redis_ha_nonha_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-020_validate_redis_ha_nonha_test.go
@@ -41,7 +41,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("validates Redis HA and Non-HA", Label("notOnXKS"), func() {
+		It("validates Redis HA and Non-HA", Label("openshfit"), func() {
 
 			// This test enables HA, so it needs to be running on a cluster with at least 3 nodes
 			node.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-020_validate_redis_ha_nonha_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-020_validate_redis_ha_nonha_test.go
@@ -41,7 +41,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("validates Redis HA and Non-HA", func() {
+		It("validates Redis HA and Non-HA", Label("openshift"), func() {
 
 			// This test enables HA, so it needs to be running on a cluster with at least 3 nodes
 			node.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-020_validate_redis_ha_nonha_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-020_validate_redis_ha_nonha_test.go
@@ -41,7 +41,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("validates Redis HA and Non-HA", Label("openshift"), func() {
+		It("validates Redis HA and Non-HA", Label("notOnXKS"), func() {
 
 			// This test enables HA, so it needs to be running on a cluster with at least 3 nodes
 			node.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-020_validate_redis_ha_nonha_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-020_validate_redis_ha_nonha_test.go
@@ -36,12 +36,13 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-020_validate_redis_ha_nonha", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("validates Redis HA and Non-HA", Label("openshfit"), func() {
+		It("validates Redis HA and Non-HA", Label("openshift"), func() {
 
 			// This test enables HA, so it needs to be running on a cluster with at least 3 nodes
 			node.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-026-validate_backend_service_permissions_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-026-validate_backend_service_permissions_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("validates backend service permissions", Label("notOnXKS"), func() {
+		It("validates backend service permissions", Label("openshfit"), func() {
 
 			By("verifying that various backend-related resources exist and have the expected values")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-026-validate_backend_service_permissions_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-026-validate_backend_service_permissions_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("validates backend service permissions", Label("openshift"), func() {
+		It("validates backend service permissions", Label("notOnXKS"), func() {
 
 			By("verifying that various backend-related resources exist and have the expected values")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-026-validate_backend_service_permissions_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-026-validate_backend_service_permissions_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("validates backend service permissions", func() {
+		It("validates backend service permissions", Label("openshift"), func() {
 
 			By("verifying that various backend-related resources exist and have the expected values")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-026-validate_backend_service_permissions_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-026-validate_backend_service_permissions_test.go
@@ -14,12 +14,13 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-026-validate_backend_service_permissions", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("validates backend service permissions", Label("openshfit"), func() {
+		It("validates backend service permissions", Label("openshift"), func() {
 
 			By("verifying that various backend-related resources exist and have the expected values")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-027_validate_operand_from_git_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-027_validate_operand_from_git_test.go
@@ -68,7 +68,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that a custom Argo CD instance can be deployed by the 'openshift-gitops' Argo CD instance. It also verfies that the custom Argo CD instance is able to deploy a simple application", Label("notOnXKS"), func() {
+		It("verifies that a custom Argo CD instance can be deployed by the 'openshift-gitops' Argo CD instance. It also verfies that the custom Argo CD instance is able to deploy a simple application", Label("openshfit"), func() {
 
 			openshiftgitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-027_validate_operand_from_git_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-027_validate_operand_from_git_test.go
@@ -68,7 +68,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that a custom Argo CD instance can be deployed by the 'openshift-gitops' Argo CD instance. It also verfies that the custom Argo CD instance is able to deploy a simple application", Label("openshift"), func() {
+		It("verifies that a custom Argo CD instance can be deployed by the 'openshift-gitops' Argo CD instance. It also verfies that the custom Argo CD instance is able to deploy a simple application", Label("notOnXKS"), func() {
 
 			openshiftgitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-027_validate_operand_from_git_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-027_validate_operand_from_git_test.go
@@ -68,7 +68,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that a custom Argo CD instance can be deployed by the 'openshift-gitops' Argo CD instance. It also verfies that the custom Argo CD instance is able to deploy a simple application", func() {
+		It("verifies that a custom Argo CD instance can be deployed by the 'openshift-gitops' Argo CD instance. It also verfies that the custom Argo CD instance is able to deploy a simple application", Label("openshift"), func() {
 
 			openshiftgitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-027_validate_operand_from_git_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-027_validate_operand_from_git_test.go
@@ -42,6 +42,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-027_validate_operand_from_git", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		var (
 			ctx              context.Context
@@ -68,7 +69,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that a custom Argo CD instance can be deployed by the 'openshift-gitops' Argo CD instance. It also verfies that the custom Argo CD instance is able to deploy a simple application", Label("openshfit"), func() {
+		It("verifies that a custom Argo CD instance can be deployed by the 'openshift-gitops' Argo CD instance. It also verfies that the custom Argo CD instance is able to deploy a simple application", Label("openshift"), func() {
 
 			openshiftgitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-028-validate_run_on_infra_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-028-validate_run_on_infra_test.go
@@ -37,7 +37,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("validates that Argo CD runs on infra nodes", Label("notOnXKS"), func() {
+		It("validates that Argo CD runs on infra nodes", Label("openshfit"), func() {
 
 			By("enabling run on infra on GitOpsService CR")
 			gitopsService := &gitopsoperatorv1alpha1.GitopsService{

--- a/test/openshift/e2e/ginkgo/sequential/1-028-validate_run_on_infra_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-028-validate_run_on_infra_test.go
@@ -37,7 +37,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("validates that Argo CD runs on infra nodes", Label("openshift"), func() {
+		It("validates that Argo CD runs on infra nodes", Label("notOnXKS"), func() {
 
 			By("enabling run on infra on GitOpsService CR")
 			gitopsService := &gitopsoperatorv1alpha1.GitopsService{

--- a/test/openshift/e2e/ginkgo/sequential/1-028-validate_run_on_infra_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-028-validate_run_on_infra_test.go
@@ -37,7 +37,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("validates that Argo CD runs on infra nodes", func() {
+		It("validates that Argo CD runs on infra nodes", Label("openshift"), func() {
 
 			By("enabling run on infra on GitOpsService CR")
 			gitopsService := &gitopsoperatorv1alpha1.GitopsService{

--- a/test/openshift/e2e/ginkgo/sequential/1-028-validate_run_on_infra_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-028-validate_run_on_infra_test.go
@@ -25,6 +25,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-028-validate_run_on_infra_test", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		var (
 			ctx       context.Context
@@ -37,7 +38,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("validates that Argo CD runs on infra nodes", Label("openshfit"), func() {
+		It("validates that Argo CD runs on infra nodes", Label("openshift"), func() {
 
 			By("enabling run on infra on GitOpsService CR")
 			gitopsService := &gitopsoperatorv1alpha1.GitopsService{

--- a/test/openshift/e2e/ginkgo/sequential/1-035_validate_argocd_secret_repopulate_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-035_validate_argocd_secret_repopulate_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies 'argocd-secret' secret is regenerated and we are able to login using that Secret", Label("notOnXKS"), func() {
+		It("verifies 'argocd-secret' secret is regenerated and we are able to login using that Secret", Label("openshfit"), func() {
 
 			By("checking OpenShift GitOps ArgoCD instance is available")
 			argocd, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-035_validate_argocd_secret_repopulate_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-035_validate_argocd_secret_repopulate_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies 'argocd-secret' secret is regenerated and we are able to login using that Secret", Label("openshift"), func() {
+		It("verifies 'argocd-secret' secret is regenerated and we are able to login using that Secret", Label("notOnXKS"), func() {
 
 			By("checking OpenShift GitOps ArgoCD instance is available")
 			argocd, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-035_validate_argocd_secret_repopulate_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-035_validate_argocd_secret_repopulate_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies 'argocd-secret' secret is regenerated and we are able to login using that Secret", func() {
+		It("verifies 'argocd-secret' secret is regenerated and we are able to login using that Secret", Label("openshift"), func() {
 
 			By("checking OpenShift GitOps ArgoCD instance is available")
 			argocd, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-035_validate_argocd_secret_repopulate_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-035_validate_argocd_secret_repopulate_test.go
@@ -20,6 +20,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-035-validate_argocd_secret_repopulate", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		var (
 			ctx       context.Context
@@ -33,7 +34,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies 'argocd-secret' secret is regenerated and we are able to login using that Secret", Label("openshfit"), func() {
+		It("verifies 'argocd-secret' secret is regenerated and we are able to login using that Secret", Label("openshift"), func() {
 
 			By("checking OpenShift GitOps ArgoCD instance is available")
 			argocd, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-036_validate_role_rolebinding_for_source_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-036_validate_role_rolebinding_for_source_namespace_test.go
@@ -59,7 +59,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies that ArgoCD CR '.spec.sourceNamespaces' field wildcard-matching matches and manages only namespaces which match the wildcard", Label("notOnXKS"), func() {
+		It("verifies that ArgoCD CR '.spec.sourceNamespaces' field wildcard-matching matches and manages only namespaces which match the wildcard", Label("openshfit"), func() {
 
 			fixture.SetEnvInOperatorSubscriptionOrDeployment("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "openshift-gitops, argocd-e2e-cluster-config")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-036_validate_role_rolebinding_for_source_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-036_validate_role_rolebinding_for_source_namespace_test.go
@@ -59,7 +59,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies that ArgoCD CR '.spec.sourceNamespaces' field wildcard-matching matches and manages only namespaces which match the wildcard", Label("openshift"), func() {
+		It("verifies that ArgoCD CR '.spec.sourceNamespaces' field wildcard-matching matches and manages only namespaces which match the wildcard", Label("notOnXKS"), func() {
 
 			fixture.SetEnvInOperatorSubscriptionOrDeployment("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "openshift-gitops, argocd-e2e-cluster-config")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-036_validate_role_rolebinding_for_source_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-036_validate_role_rolebinding_for_source_namespace_test.go
@@ -59,7 +59,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies that ArgoCD CR '.spec.sourceNamespaces' field wildcard-matching matches and manages only namespaces which match the wildcard", func() {
+		It("verifies that ArgoCD CR '.spec.sourceNamespaces' field wildcard-matching matches and manages only namespaces which match the wildcard", Label("openshift"), func() {
 
 			fixture.SetEnvInOperatorSubscriptionOrDeployment("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "openshift-gitops, argocd-e2e-cluster-config")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-036_validate_role_rolebinding_for_source_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-036_validate_role_rolebinding_for_source_namespace_test.go
@@ -59,7 +59,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies that ArgoCD CR '.spec.sourceNamespaces' field wildcard-matching matches and manages only namespaces which match the wildcard", Label("openshfit"), func() {
+		It("verifies that ArgoCD CR '.spec.sourceNamespaces' field wildcard-matching matches and manages only namespaces which match the wildcard", func() {
 
 			fixture.SetEnvInOperatorSubscriptionOrDeployment("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "openshift-gitops, argocd-e2e-cluster-config")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
@@ -66,7 +66,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", Label("notOnXKS"), func() {
+		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", Label("openshfit"), func() {
 
 			By("0) create namespaces: appset-argocd, appset-old-ns, appset-new-ns")
 
@@ -846,7 +846,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(roleInTargetNS, "2m", "5s").Should(k8sFixture.NotExistByName())
 		})
 
-		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", Label("notOnXKS"), func() {
+		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", Label("openshfit"), func() {
 
 			By("0) create namespaces: appset-argocd, team-1, team-2, team-frontend, team-backend, other-ns")
 
@@ -1081,7 +1081,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", Label("notOnXKS"), func() {
+		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", Label("openshfit"), func() {
 
 			By("creating Argo CD namespace and target source namespace")
 			argoNamespace, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd-clusterrole")
@@ -1294,7 +1294,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(appset).Should(k8sFixture.NotExistByName())
 		})
 
-		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", Label("notOnXKS"), func() {
+		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", Label("openshfit"), func() {
 			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
 			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
 

--- a/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
@@ -66,7 +66,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", Label("openshift"), func() {
+		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", Label("notOnXKS"), func() {
 
 			By("0) create namespaces: appset-argocd, appset-old-ns, appset-new-ns")
 
@@ -846,7 +846,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(roleInTargetNS, "2m", "5s").Should(k8sFixture.NotExistByName())
 		})
 
-		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", Label("openshift"), func() {
+		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", Label("notOnXKS"), func() {
 
 			By("0) create namespaces: appset-argocd, team-1, team-2, team-frontend, team-backend, other-ns")
 
@@ -1081,7 +1081,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", Label("openshift"), func() {
+		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", Label("notOnXKS"), func() {
 
 			By("creating Argo CD namespace and target source namespace")
 			argoNamespace, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd-clusterrole")
@@ -1294,7 +1294,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(appset).Should(k8sFixture.NotExistByName())
 		})
 
-		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", Label("openshift"), func() {
+		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", Label("notOnXKS"), func() {
 			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
 			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
 

--- a/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
@@ -66,7 +66,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", func() {
+		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", Label("openshift"), func() {
 
 			By("0) create namespaces: appset-argocd, appset-old-ns, appset-new-ns")
 
@@ -846,7 +846,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(roleInTargetNS, "2m", "5s").Should(k8sFixture.NotExistByName())
 		})
 
-		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", func() {
+		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", Label("openshift"), func() {
 
 			By("0) create namespaces: appset-argocd, team-1, team-2, team-frontend, team-backend, other-ns")
 
@@ -1081,7 +1081,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", func() {
+		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", Label("openshift"), func() {
 
 			By("creating Argo CD namespace and target source namespace")
 			argoNamespace, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd-clusterrole")
@@ -1294,7 +1294,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(appset).Should(k8sFixture.NotExistByName())
 		})
 
-		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", func() {
+		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", Label("openshift"), func() {
 			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
 			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
 

--- a/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
@@ -66,7 +66,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", Label("openshfit"), func() {
+		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", func() {
 
 			By("0) create namespaces: appset-argocd, appset-old-ns, appset-new-ns")
 
@@ -846,7 +846,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(roleInTargetNS, "2m", "5s").Should(k8sFixture.NotExistByName())
 		})
 
-		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", Label("openshfit"), func() {
+		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", func() {
 
 			By("0) create namespaces: appset-argocd, team-1, team-2, team-frontend, team-backend, other-ns")
 
@@ -1081,7 +1081,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", Label("openshfit"), func() {
+		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", func() {
 
 			By("creating Argo CD namespace and target source namespace")
 			argoNamespace, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd-clusterrole")
@@ -1294,7 +1294,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(appset).Should(k8sFixture.NotExistByName())
 		})
 
-		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", Label("openshfit"), func() {
+		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", func() {
 			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
 			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
 

--- a/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
@@ -67,7 +67,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", Label("notOnXKS"), func() {
+		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", Label("openshfit"), func() {
 
 			By("0) create namespaces: appset-argocd, appset-old-ns, appset-new-ns")
 
@@ -847,7 +847,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(roleInTargetNS, "2m", "5s").Should(k8sFixture.NotExistByName())
 		})
 
-		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", Label("notOnXKS"), func() {
+		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", Label("openshfit"), func() {
 
 			By("0) create namespaces: appset-argocd, team-1, team-2, team-frontend, team-backend, other-ns")
 
@@ -1082,7 +1082,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", Label("notOnXKS"), func() {
+		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", Label("openshfit"), func() {
 
 			By("creating Argo CD namespace and target source namespace")
 			argoNamespace, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd-clusterrole")
@@ -1295,7 +1295,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(appset).Should(k8sFixture.NotExistByName())
 		})
 
-		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", Label("notOnXKS"), func() {
+		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", Label("openshfit"), func() {
 			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
 			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
 

--- a/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
@@ -67,7 +67,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", func() {
+		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", Label("openshift"), func() {
 
 			By("0) create namespaces: appset-argocd, appset-old-ns, appset-new-ns")
 
@@ -847,7 +847,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(roleInTargetNS, "2m", "5s").Should(k8sFixture.NotExistByName())
 		})
 
-		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", func() {
+		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", Label("openshift"), func() {
 
 			By("0) create namespaces: appset-argocd, team-1, team-2, team-frontend, team-backend, other-ns")
 
@@ -1082,7 +1082,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", func() {
+		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", Label("openshift"), func() {
 
 			By("creating Argo CD namespace and target source namespace")
 			argoNamespace, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd-clusterrole")
@@ -1295,7 +1295,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(appset).Should(k8sFixture.NotExistByName())
 		})
 
-		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", func() {
+		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", Label("openshift"), func() {
 			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
 			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
 

--- a/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
@@ -67,7 +67,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", Label("openshfit"), func() {
+		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", func() {
 
 			By("0) create namespaces: appset-argocd, appset-old-ns, appset-new-ns")
 
@@ -847,7 +847,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(roleInTargetNS, "2m", "5s").Should(k8sFixture.NotExistByName())
 		})
 
-		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", Label("openshfit"), func() {
+		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", func() {
 
 			By("0) create namespaces: appset-argocd, team-1, team-2, team-frontend, team-backend, other-ns")
 
@@ -1082,7 +1082,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", Label("openshfit"), func() {
+		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", func() {
 
 			By("creating Argo CD namespace and target source namespace")
 			argoNamespace, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd-clusterrole")
@@ -1295,7 +1295,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(appset).Should(k8sFixture.NotExistByName())
 		})
 
-		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", Label("openshfit"), func() {
+		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", func() {
 			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
 			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
 

--- a/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
@@ -67,7 +67,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", Label("openshift"), func() {
+		It("verifying that ArgoCD CR '.spec.applicationset.sourcenamespaces' and '.spec.sourcenamespaces' correctly control role/rolebindings within the managed namespaces", Label("notOnXKS"), func() {
 
 			By("0) create namespaces: appset-argocd, appset-old-ns, appset-new-ns")
 
@@ -847,7 +847,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(roleInTargetNS, "2m", "5s").Should(k8sFixture.NotExistByName())
 		})
 
-		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", Label("openshift"), func() {
+		It("verifies that wildcard patterns in .spec.applicationSet.sourceNamespaces correctly match and manage multiple namespaces", Label("notOnXKS"), func() {
 
 			By("0) create namespaces: appset-argocd, team-1, team-2, team-frontend, team-backend, other-ns")
 
@@ -1082,7 +1082,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", Label("openshift"), func() {
+		It("verifies ApplicationSet clusterrole rules and creates appset/app in another namespace", Label("notOnXKS"), func() {
 
 			By("creating Argo CD namespace and target source namespace")
 			argoNamespace, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd-clusterrole")
@@ -1295,7 +1295,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(appset).Should(k8sFixture.NotExistByName())
 		})
 
-		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", Label("openshift"), func() {
+		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", Label("notOnXKS"), func() {
 			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
 			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
 

--- a/test/openshift/e2e/ginkgo/sequential/1-040_validate_quoted_RBAC_group_names_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-040_validate_quoted_RBAC_group_names_test.go
@@ -30,7 +30,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("creates a project role 'somerole' and group claim, and verifies group claim contains the expected data", Label("notOnXKS"), func() {
+		It("creates a project role 'somerole' and group claim, and verifies group claim contains the expected data", Label("openshfit"), func() {
 
 			defaultArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-040_validate_quoted_RBAC_group_names_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-040_validate_quoted_RBAC_group_names_test.go
@@ -30,7 +30,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("creates a project role 'somerole' and group claim, and verifies group claim contains the expected data", Label("openshift"), func() {
+		It("creates a project role 'somerole' and group claim, and verifies group claim contains the expected data", Label("notOnXKS"), func() {
 
 			defaultArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-040_validate_quoted_RBAC_group_names_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-040_validate_quoted_RBAC_group_names_test.go
@@ -30,7 +30,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("creates a project role 'somerole' and group claim, and verifies group claim contains the expected data", func() {
+		It("creates a project role 'somerole' and group claim, and verifies group claim contains the expected data", Label("openshift"), func() {
 
 			defaultArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-040_validate_quoted_RBAC_group_names_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-040_validate_quoted_RBAC_group_names_test.go
@@ -12,6 +12,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-040-validate_quoted_RBAC_group_names", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
@@ -30,7 +31,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("creates a project role 'somerole' and group claim, and verifies group claim contains the expected data", Label("openshfit"), func() {
+		It("creates a project role 'somerole' and group claim, and verifies group claim contains the expected data", Label("openshift"), func() {
 
 			defaultArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -296,7 +296,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			agentFixture.VerifyResourcesDeleted(principalResources)
 		}
 
-		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", Label("openshift"), func() {
+		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", Label("notOnXKS"), func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Principal.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Principal.Image = "quay.io/user/argocd-agent:v1"
@@ -337,7 +337,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("should create argocd agent principal resources, and pod should start successfully with default image", Label("openshift"), func() {
+		It("should create argocd agent principal resources, and pod should start successfully with default image", Label("notOnXKS"), func() {
 
 			// Add a custom environment variable to the principal server
 			argoCD.Spec.ArgoCDAgent.Principal.Env = []corev1.EnvVar{{Name: "TEST_ENV", Value: "test_value"}}
@@ -399,7 +399,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", Label("openshift"), func() {
+		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance")
 
@@ -527,7 +527,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle route enabled configuration correctly", Label("openshift"), func() {
+		It("should handle route enabled configuration correctly", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance with route enabled")
 
@@ -612,7 +612,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle service type ClusterIP configuration correctly", Label("openshift"), func() {
+		It("should handle service type ClusterIP configuration correctly", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance with service type ClusterIP")
 
@@ -637,7 +637,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 		})
 
-		It("should handle service type LoadBalancer configuration correctly", Label("openshift"), func() {
+		It("should handle service type LoadBalancer configuration correctly", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance with service type LoadBalancer")
 
@@ -662,7 +662,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should handle service type updates correctly", Label("openshift"), func() {
+		It("should handle service type updates correctly", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance with service type ClusterIP")
 
@@ -704,7 +704,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "30s", "2s").Should(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", Label("openshift"), func() {
+		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", Label("notOnXKS"), func() {
 
 			By("Create namespace-scoped ArgoCD instance")
 
@@ -838,7 +838,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create principal NetworkPolicy if principal is enabled", Label("openshift"), func() {
+		It("should create principal NetworkPolicy if principal is enabled", Label("notOnXKS"), func() {
 			By("Create ArgoCD instance with principal enabled")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Enabled = new(true)
@@ -901,7 +901,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(principalNetworkPolicy).Should(k8sFixture.NotExistByName())
 		})
 
-		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", Label("openshift"), func() {
+		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance with principal enabled and prometheus enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -297,7 +297,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			agentFixture.VerifyResourcesDeleted(principalResources)
 		}
 
-		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", Label("openshfit"), func() {
+		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Principal.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Principal.Image = "quay.io/user/argocd-agent:v1"
@@ -338,7 +338,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("should create argocd agent principal resources, and pod should start successfully with default image", Label("openshfit"), func() {
+		It("should create argocd agent principal resources, and pod should start successfully with default image", func() {
 
 			// Add a custom environment variable to the principal server
 			argoCD.Spec.ArgoCDAgent.Principal.Env = []corev1.EnvVar{{Name: "TEST_ENV", Value: "test_value"}}
@@ -400,7 +400,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", Label("openshfit"), func() {
+		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", func() {
 
 			By("Create ArgoCD instance")
 
@@ -528,7 +528,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle route enabled configuration correctly", Label("openshfit"), func() {
+		It("should handle route enabled configuration correctly", Label("openshift"), func() {
 
 			By("Create ArgoCD instance with route enabled")
 
@@ -613,7 +613,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle service type ClusterIP configuration correctly", Label("openshfit"), func() {
+		It("should handle service type ClusterIP configuration correctly", func() {
 
 			By("Create ArgoCD instance with service type ClusterIP")
 
@@ -638,7 +638,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 		})
 
-		It("should handle service type LoadBalancer configuration correctly", Label("openshfit"), func() {
+		It("should handle service type LoadBalancer configuration correctly", func() {
 
 			By("Create ArgoCD instance with service type LoadBalancer")
 
@@ -663,7 +663,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should handle service type updates correctly", Label("openshfit"), func() {
+		It("should handle service type updates correctly", func() {
 
 			By("Create ArgoCD instance with service type ClusterIP")
 
@@ -705,7 +705,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "30s", "2s").Should(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", Label("openshfit"), func() {
+		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", func() {
 
 			By("Create namespace-scoped ArgoCD instance")
 
@@ -839,7 +839,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create principal NetworkPolicy if principal is enabled", Label("openshfit"), func() {
+		It("should create principal NetworkPolicy if principal is enabled", func() {
 			By("Create ArgoCD instance with principal enabled")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Enabled = ptr.To(true)
@@ -902,7 +902,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(principalNetworkPolicy).Should(k8sFixture.NotExistByName())
 		})
 
-		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", Label("openshfit"), func() {
+		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", Label("openshift"), func() {
 
 			By("Create ArgoCD instance with principal enabled and prometheus enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -296,7 +296,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			agentFixture.VerifyResourcesDeleted(principalResources)
 		}
 
-		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", func() {
+		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", Label("openshift"), func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Principal.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Principal.Image = "quay.io/user/argocd-agent:v1"
@@ -337,7 +337,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("should create argocd agent principal resources, and pod should start successfully with default image", func() {
+		It("should create argocd agent principal resources, and pod should start successfully with default image", Label("openshift"), func() {
+
 			// Add a custom environment variable to the principal server
 			argoCD.Spec.ArgoCDAgent.Principal.Env = []corev1.EnvVar{{Name: "TEST_ENV", Value: "test_value"}}
 
@@ -398,7 +399,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", func() {
+		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", Label("openshift"), func() {
+
 			By("Create ArgoCD instance")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Image = common.ArgoCDAgentPrincipalDefaultImageName
@@ -525,7 +527,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle route enabled configuration correctly", func() {
+		It("should handle route enabled configuration correctly", Label("openshift"), func() {
+
 			By("Create ArgoCD instance with route enabled")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Server.Route = argov1beta1api.ArgoCDAgentPrincipalRouteSpec{
@@ -609,7 +612,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle service type ClusterIP configuration correctly", func() {
+		It("should handle service type ClusterIP configuration correctly", Label("openshift"), func() {
+
 			By("Create ArgoCD instance with service type ClusterIP")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Server.Service = argov1beta1api.ArgoCDAgentPrincipalServiceSpec{
@@ -633,7 +637,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 		})
 
-		It("should handle service type LoadBalancer configuration correctly", func() {
+		It("should handle service type LoadBalancer configuration correctly", Label("openshift"), func() {
+
 			By("Create ArgoCD instance with service type LoadBalancer")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Server.Service = argov1beta1api.ArgoCDAgentPrincipalServiceSpec{
@@ -657,7 +662,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should handle service type updates correctly", func() {
+		It("should handle service type updates correctly", Label("openshift"), func() {
+
 			By("Create ArgoCD instance with service type ClusterIP")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Server.Service = argov1beta1api.ArgoCDAgentPrincipalServiceSpec{
@@ -698,7 +704,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "30s", "2s").Should(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", func() {
+		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", Label("openshift"), func() {
+
 			By("Create namespace-scoped ArgoCD instance")
 
 			// Create namespace for hosting namespace-scoped ArgoCD instance with principal
@@ -831,7 +838,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create principal NetworkPolicy if principal is enabled", func() {
+		It("should create principal NetworkPolicy if principal is enabled", Label("openshift"), func() {
 			By("Create ArgoCD instance with principal enabled")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Enabled = new(true)
@@ -894,7 +901,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(principalNetworkPolicy).Should(k8sFixture.NotExistByName())
 		})
 
-		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", func() {
+		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", Label("openshift"), func() {
+
 			By("Create ArgoCD instance with principal enabled and prometheus enabled")
 
 			argoCD.Spec.Prometheus.Enabled = true

--- a/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -297,7 +297,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			agentFixture.VerifyResourcesDeleted(principalResources)
 		}
 
-		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", func() {
+		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", Label("openshift"), func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Principal.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Principal.Image = "quay.io/user/argocd-agent:v1"
@@ -338,7 +338,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("should create argocd agent principal resources, and pod should start successfully with default image", func() {
+		It("should create argocd agent principal resources, and pod should start successfully with default image", Label("openshift"), func() {
+
 			// Add a custom environment variable to the principal server
 			argoCD.Spec.ArgoCDAgent.Principal.Env = []corev1.EnvVar{{Name: "TEST_ENV", Value: "test_value"}}
 
@@ -399,7 +400,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", func() {
+		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", Label("openshift"), func() {
+
 			By("Create ArgoCD instance")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Image = common.ArgoCDAgentPrincipalDefaultImageName
@@ -526,7 +528,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle route enabled configuration correctly", func() {
+		It("should handle route enabled configuration correctly", Label("openshift"), func() {
+
 			By("Create ArgoCD instance with route enabled")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Server.Route = argov1beta1api.ArgoCDAgentPrincipalRouteSpec{
@@ -610,7 +613,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle service type ClusterIP configuration correctly", func() {
+		It("should handle service type ClusterIP configuration correctly", Label("openshift"), func() {
+
 			By("Create ArgoCD instance with service type ClusterIP")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Server.Service = argov1beta1api.ArgoCDAgentPrincipalServiceSpec{
@@ -634,7 +638,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 		})
 
-		It("should handle service type LoadBalancer configuration correctly", func() {
+		It("should handle service type LoadBalancer configuration correctly", Label("openshift"), func() {
+
 			By("Create ArgoCD instance with service type LoadBalancer")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Server.Service = argov1beta1api.ArgoCDAgentPrincipalServiceSpec{
@@ -658,7 +663,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should handle service type updates correctly", func() {
+		It("should handle service type updates correctly", Label("openshift"), func() {
+
 			By("Create ArgoCD instance with service type ClusterIP")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Server.Service = argov1beta1api.ArgoCDAgentPrincipalServiceSpec{
@@ -699,7 +705,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "30s", "2s").Should(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", func() {
+		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", Label("openshift"), func() {
+
 			By("Create namespace-scoped ArgoCD instance")
 
 			// Create namespace for hosting namespace-scoped ArgoCD instance with principal
@@ -832,7 +839,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create principal NetworkPolicy if principal is enabled", func() {
+		It("should create principal NetworkPolicy if principal is enabled", Label("openshift"), func() {
 			By("Create ArgoCD instance with principal enabled")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Enabled = ptr.To(true)
@@ -895,7 +902,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(principalNetworkPolicy).Should(k8sFixture.NotExistByName())
 		})
 
-		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", func() {
+		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", Label("openshift"), func() {
+
 			By("Create ArgoCD instance with principal enabled and prometheus enabled")
 
 			argoCD.Spec.Prometheus.Enabled = true

--- a/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -296,7 +296,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			agentFixture.VerifyResourcesDeleted(principalResources)
 		}
 
-		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", Label("notOnXKS"), func() {
+		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", Label("openshfit"), func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Principal.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Principal.Image = "quay.io/user/argocd-agent:v1"
@@ -337,7 +337,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("should create argocd agent principal resources, and pod should start successfully with default image", Label("notOnXKS"), func() {
+		It("should create argocd agent principal resources, and pod should start successfully with default image", Label("openshfit"), func() {
 
 			// Add a custom environment variable to the principal server
 			argoCD.Spec.ArgoCDAgent.Principal.Env = []corev1.EnvVar{{Name: "TEST_ENV", Value: "test_value"}}
@@ -399,7 +399,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", Label("notOnXKS"), func() {
+		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance")
 
@@ -527,7 +527,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle route enabled configuration correctly", Label("notOnXKS"), func() {
+		It("should handle route enabled configuration correctly", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance with route enabled")
 
@@ -612,7 +612,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle service type ClusterIP configuration correctly", Label("notOnXKS"), func() {
+		It("should handle service type ClusterIP configuration correctly", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance with service type ClusterIP")
 
@@ -637,7 +637,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 		})
 
-		It("should handle service type LoadBalancer configuration correctly", Label("notOnXKS"), func() {
+		It("should handle service type LoadBalancer configuration correctly", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance with service type LoadBalancer")
 
@@ -662,7 +662,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should handle service type updates correctly", Label("notOnXKS"), func() {
+		It("should handle service type updates correctly", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance with service type ClusterIP")
 
@@ -704,7 +704,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "30s", "2s").Should(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", Label("notOnXKS"), func() {
+		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", Label("openshfit"), func() {
 
 			By("Create namespace-scoped ArgoCD instance")
 
@@ -838,7 +838,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create principal NetworkPolicy if principal is enabled", Label("notOnXKS"), func() {
+		It("should create principal NetworkPolicy if principal is enabled", Label("openshfit"), func() {
 			By("Create ArgoCD instance with principal enabled")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Enabled = new(true)
@@ -901,7 +901,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(principalNetworkPolicy).Should(k8sFixture.NotExistByName())
 		})
 
-		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", Label("notOnXKS"), func() {
+		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance with principal enabled and prometheus enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -296,7 +296,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			agentFixture.VerifyResourcesDeleted(principalResources)
 		}
 
-		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", Label("openshfit"), func() {
+		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Principal.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Principal.Image = "quay.io/user/argocd-agent:v1"
@@ -337,7 +337,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("should create argocd agent principal resources, and pod should start successfully with default image", Label("openshfit"), func() {
+		It("should create argocd agent principal resources, and pod should start successfully with default image", func() {
 
 			// Add a custom environment variable to the principal server
 			argoCD.Spec.ArgoCDAgent.Principal.Env = []corev1.EnvVar{{Name: "TEST_ENV", Value: "test_value"}}
@@ -399,7 +399,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", Label("openshfit"), func() {
+		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", func() {
 
 			By("Create ArgoCD instance")
 
@@ -527,7 +527,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle route enabled configuration correctly", Label("openshfit"), func() {
+		It("should handle route enabled configuration correctly", Label("openshift"), func() {
 
 			By("Create ArgoCD instance with route enabled")
 
@@ -612,7 +612,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle service type ClusterIP configuration correctly", Label("openshfit"), func() {
+		It("should handle service type ClusterIP configuration correctly", func() {
 
 			By("Create ArgoCD instance with service type ClusterIP")
 
@@ -637,7 +637,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 		})
 
-		It("should handle service type LoadBalancer configuration correctly", Label("openshfit"), func() {
+		It("should handle service type LoadBalancer configuration correctly", func() {
 
 			By("Create ArgoCD instance with service type LoadBalancer")
 
@@ -662,7 +662,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should handle service type updates correctly", Label("openshfit"), func() {
+		It("should handle service type updates correctly", func() {
 
 			By("Create ArgoCD instance with service type ClusterIP")
 
@@ -704,7 +704,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "30s", "2s").Should(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", Label("openshfit"), func() {
+		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", func() {
 
 			By("Create namespace-scoped ArgoCD instance")
 
@@ -838,7 +838,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create principal NetworkPolicy if principal is enabled", Label("openshfit"), func() {
+		It("should create principal NetworkPolicy if principal is enabled", func() {
 			By("Create ArgoCD instance with principal enabled")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Enabled = new(true)
@@ -901,7 +901,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(principalNetworkPolicy).Should(k8sFixture.NotExistByName())
 		})
 
-		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", Label("openshfit"), func() {
+		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", Label("openshift"), func() {
 
 			By("Create ArgoCD instance with principal enabled and prometheus enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -297,7 +297,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			agentFixture.VerifyResourcesDeleted(principalResources)
 		}
 
-		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", Label("notOnXKS"), func() {
+		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", Label("openshfit"), func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Principal.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Principal.Image = "quay.io/user/argocd-agent:v1"
@@ -338,7 +338,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("should create argocd agent principal resources, and pod should start successfully with default image", Label("notOnXKS"), func() {
+		It("should create argocd agent principal resources, and pod should start successfully with default image", Label("openshfit"), func() {
 
 			// Add a custom environment variable to the principal server
 			argoCD.Spec.ArgoCDAgent.Principal.Env = []corev1.EnvVar{{Name: "TEST_ENV", Value: "test_value"}}
@@ -400,7 +400,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", Label("notOnXKS"), func() {
+		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance")
 
@@ -528,7 +528,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle route enabled configuration correctly", Label("notOnXKS"), func() {
+		It("should handle route enabled configuration correctly", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance with route enabled")
 
@@ -613,7 +613,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle service type ClusterIP configuration correctly", Label("notOnXKS"), func() {
+		It("should handle service type ClusterIP configuration correctly", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance with service type ClusterIP")
 
@@ -638,7 +638,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 		})
 
-		It("should handle service type LoadBalancer configuration correctly", Label("notOnXKS"), func() {
+		It("should handle service type LoadBalancer configuration correctly", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance with service type LoadBalancer")
 
@@ -663,7 +663,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should handle service type updates correctly", Label("notOnXKS"), func() {
+		It("should handle service type updates correctly", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance with service type ClusterIP")
 
@@ -705,7 +705,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "30s", "2s").Should(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", Label("notOnXKS"), func() {
+		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", Label("openshfit"), func() {
 
 			By("Create namespace-scoped ArgoCD instance")
 
@@ -839,7 +839,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create principal NetworkPolicy if principal is enabled", Label("notOnXKS"), func() {
+		It("should create principal NetworkPolicy if principal is enabled", Label("openshfit"), func() {
 			By("Create ArgoCD instance with principal enabled")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Enabled = ptr.To(true)
@@ -902,7 +902,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(principalNetworkPolicy).Should(k8sFixture.NotExistByName())
 		})
 
-		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", Label("notOnXKS"), func() {
+		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance with principal enabled and prometheus enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -297,7 +297,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			agentFixture.VerifyResourcesDeleted(principalResources)
 		}
 
-		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", Label("openshift"), func() {
+		It("should create argocd agent principal resources, but pod should fail to start as image does not exist", Label("notOnXKS"), func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Principal.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Principal.Image = "quay.io/user/argocd-agent:v1"
@@ -338,7 +338,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("should create argocd agent principal resources, and pod should start successfully with default image", Label("openshift"), func() {
+		It("should create argocd agent principal resources, and pod should start successfully with default image", Label("notOnXKS"), func() {
 
 			// Add a custom environment variable to the principal server
 			argoCD.Spec.ArgoCDAgent.Principal.Env = []corev1.EnvVar{{Name: "TEST_ENV", Value: "test_value"}}
@@ -400,7 +400,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", Label("openshift"), func() {
+		It("Should reflect configuration changes from ArgoCD CR to the principal deployment", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance")
 
@@ -528,7 +528,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle route enabled configuration correctly", Label("openshift"), func() {
+		It("should handle route enabled configuration correctly", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance with route enabled")
 
@@ -613,7 +613,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("should handle service type ClusterIP configuration correctly", Label("openshift"), func() {
+		It("should handle service type ClusterIP configuration correctly", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance with service type ClusterIP")
 
@@ -638,7 +638,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 		})
 
-		It("should handle service type LoadBalancer configuration correctly", Label("openshift"), func() {
+		It("should handle service type LoadBalancer configuration correctly", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance with service type LoadBalancer")
 
@@ -663,7 +663,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(principalService.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should handle service type updates correctly", Label("openshift"), func() {
+		It("should handle service type updates correctly", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance with service type ClusterIP")
 
@@ -705,7 +705,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "30s", "2s").Should(Equal(corev1.ServiceTypeLoadBalancer))
 		})
 
-		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", Label("openshift"), func() {
+		It("should deploy principal via namespace-scoped ArgoCD instance and verify cluster role and cluster role binding are not created", Label("notOnXKS"), func() {
 
 			By("Create namespace-scoped ArgoCD instance")
 
@@ -839,7 +839,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create principal NetworkPolicy if principal is enabled", Label("openshift"), func() {
+		It("should create principal NetworkPolicy if principal is enabled", Label("notOnXKS"), func() {
 			By("Create ArgoCD instance with principal enabled")
 
 			argoCD.Spec.ArgoCDAgent.Principal.Enabled = ptr.To(true)
@@ -902,7 +902,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(principalNetworkPolicy).Should(k8sFixture.NotExistByName())
 		})
 
-		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", Label("openshift"), func() {
+		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance with principal enabled and prometheus enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -278,7 +278,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		}
 
-		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", Label("openshfit"), func() {
+		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Agent.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Agent.Image = "quay.io/user/argocd-agent:v1"
@@ -364,7 +364,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", Label("openshfit"), func() {
+		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", func() {
 
 			By("Create ArgoCD instance")
 
@@ -578,7 +578,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", Label("openshfit"), func() {
+		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", Label("openshift"), func() {
 
 			By("Create ArgoCD instance with agent enabled and prometheus enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -277,7 +277,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		}
 
-		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", Label("notOnXKS"), func() {
+		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", Label("openshfit"), func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Agent.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Agent.Image = "quay.io/user/argocd-agent:v1"
@@ -363,7 +363,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", Label("notOnXKS"), func() {
+		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance")
 
@@ -577,7 +577,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", Label("notOnXKS"), func() {
+		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance with agent enabled and prometheus enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -277,7 +277,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		}
 
-		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", func() {
+		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", Label("openshift"), func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Agent.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Agent.Image = "quay.io/user/argocd-agent:v1"
@@ -363,7 +363,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", func() {
+		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", Label("openshift"), func() {
+
 			By("Create ArgoCD instance")
 
 			argoCD.Spec.ArgoCDAgent.Agent.Image = common.ArgoCDAgentAgentDefaultImageName
@@ -576,7 +577,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", func() {
+		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", Label("openshift"), func() {
+
 			By("Create ArgoCD instance with agent enabled and prometheus enabled")
 
 			argoCD.Spec.Prometheus.Enabled = true

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -278,7 +278,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		}
 
-		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", Label("openshift"), func() {
+		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", Label("notOnXKS"), func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Agent.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Agent.Image = "quay.io/user/argocd-agent:v1"
@@ -364,7 +364,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", Label("openshift"), func() {
+		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance")
 
@@ -578,7 +578,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", Label("openshift"), func() {
+		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance with agent enabled and prometheus enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -277,7 +277,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		}
 
-		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", Label("openshfit"), func() {
+		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Agent.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Agent.Image = "quay.io/user/argocd-agent:v1"
@@ -363,7 +363,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", Label("openshfit"), func() {
+		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", func() {
 
 			By("Create ArgoCD instance")
 
@@ -577,7 +577,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", Label("openshfit"), func() {
+		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", Label("openshift"), func() {
 
 			By("Create ArgoCD instance with agent enabled and prometheus enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -277,7 +277,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		}
 
-		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", Label("openshift"), func() {
+		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", Label("notOnXKS"), func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Agent.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Agent.Image = "quay.io/user/argocd-agent:v1"
@@ -363,7 +363,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", Label("openshift"), func() {
+		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance")
 
@@ -577,7 +577,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", Label("openshift"), func() {
+		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", Label("notOnXKS"), func() {
 
 			By("Create ArgoCD instance with agent enabled and prometheus enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -278,7 +278,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		}
 
-		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", Label("notOnXKS"), func() {
+		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", Label("openshfit"), func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Agent.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Agent.Image = "quay.io/user/argocd-agent:v1"
@@ -364,7 +364,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", Label("notOnXKS"), func() {
+		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance")
 
@@ -578,7 +578,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", Label("notOnXKS"), func() {
+		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", Label("openshfit"), func() {
 
 			By("Create ArgoCD instance with agent enabled and prometheus enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -278,7 +278,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		}
 
-		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", func() {
+		It("should create argocd agent agent resources, but pod should not be expected to run successfully without principal", Label("openshift"), func() {
 			// Change log level to trace and custom image name
 			argoCD.Spec.ArgoCDAgent.Agent.LogLevel = "trace"
 			argoCD.Spec.ArgoCDAgent.Agent.Image = "quay.io/user/argocd-agent:v1"
@@ -364,7 +364,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourcesDeleted()
 		})
 
-		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", func() {
+		It("Should reflect configuration changes from ArgoCD CR to the agent deployment", Label("openshift"), func() {
+
 			By("Create ArgoCD instance")
 
 			argoCD.Spec.ArgoCDAgent.Agent.Image = common.ArgoCDAgentAgentDefaultImageName
@@ -577,7 +578,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
 		})
 
-		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", func() {
+		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", Label("openshift"), func() {
+
 			By("Create ArgoCD instance with agent enabled and prometheus enabled")
 
 			argoCD.Spec.Prometheus.Enabled = true

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_rolebinding_number_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_rolebinding_number_test.go
@@ -35,7 +35,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies RoleBindings are added to namespace-scoped Namespace when that Namespace is managed by openshift-gitops", Label("notOnXKS"), func() {
+		It("verifies RoleBindings are added to namespace-scoped Namespace when that Namespace is managed by openshift-gitops", Label("openshfit"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_rolebinding_number_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_rolebinding_number_test.go
@@ -35,7 +35,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies RoleBindings are added to namespace-scoped Namespace when that Namespace is managed by openshift-gitops", func() {
+		It("verifies RoleBindings are added to namespace-scoped Namespace when that Namespace is managed by openshift-gitops", Label("openshift"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_rolebinding_number_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_rolebinding_number_test.go
@@ -35,7 +35,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies RoleBindings are added to namespace-scoped Namespace when that Namespace is managed by openshift-gitops", Label("openshift"), func() {
+		It("verifies RoleBindings are added to namespace-scoped Namespace when that Namespace is managed by openshift-gitops", Label("notOnXKS"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-052_validate_rolebinding_number_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-052_validate_rolebinding_number_test.go
@@ -30,12 +30,13 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-052_validate_rolebinding_number", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies RoleBindings are added to namespace-scoped Namespace when that Namespace is managed by openshift-gitops", Label("openshfit"), func() {
+		It("verifies RoleBindings are added to namespace-scoped Namespace when that Namespace is managed by openshift-gitops", Label("openshift"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
@@ -531,7 +531,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		// 4. Redis proxy can be accessed, and it contains data from child resources (e.g. pod), for both managed, and autonomous.
 		// 5. Resource proxy can be accessed, and it contains data from agent resources.
 		// This validates the core connectivity and basic workflow of agent-principal architecture, including RBAC, connection, and application propagation.
-		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", Label("notOnXKS"), func() {
+		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", Label("openshfit"), func() {
 
 			By("Deploy principal and verify it starts successfully")
 			deployPrincipal(ctx, k8sClient, registerCleanup, false)

--- a/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
@@ -531,7 +531,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		// 4. Redis proxy can be accessed, and it contains data from child resources (e.g. pod), for both managed, and autonomous.
 		// 5. Resource proxy can be accessed, and it contains data from agent resources.
 		// This validates the core connectivity and basic workflow of agent-principal architecture, including RBAC, connection, and application propagation.
-		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", Label("openshift"), func() {
+		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", Label("notOnXKS"), func() {
 
 			By("Deploy principal and verify it starts successfully")
 			deployPrincipal(ctx, k8sClient, registerCleanup, false)

--- a/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
@@ -531,7 +531,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		// 4. Redis proxy can be accessed, and it contains data from child resources (e.g. pod), for both managed, and autonomous.
 		// 5. Resource proxy can be accessed, and it contains data from agent resources.
 		// This validates the core connectivity and basic workflow of agent-principal architecture, including RBAC, connection, and application propagation.
-		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", func() {
+		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", Label("openshift"), func() {
 
 			By("Deploy principal and verify it starts successfully")
 			deployPrincipal(ctx, k8sClient, registerCleanup, false)

--- a/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
@@ -530,7 +530,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		// 4. Redis proxy can be accessed, and it contains data from child resources (e.g. pod), for both managed, and autonomous.
 		// 5. Resource proxy can be accessed, and it contains data from agent resources.
 		// This validates the core connectivity and basic workflow of agent-principal architecture, including RBAC, connection, and application propagation.
-		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", Label("openshift"), func() {
+		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", Label("notOnXKS"), func() {
 
 			By("Deploy principal and verify it starts successfully")
 			deployPrincipal(ctx, k8sClient, registerCleanup, false)

--- a/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
@@ -530,7 +530,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		// 4. Redis proxy can be accessed, and it contains data from child resources (e.g. pod), for both managed, and autonomous.
 		// 5. Resource proxy can be accessed, and it contains data from agent resources.
 		// This validates the core connectivity and basic workflow of agent-principal architecture, including RBAC, connection, and application propagation.
-		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", func() {
+		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", Label("openshift"), func() {
 
 			By("Deploy principal and verify it starts successfully")
 			deployPrincipal(ctx, k8sClient, registerCleanup, false)

--- a/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
@@ -530,7 +530,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		// 4. Redis proxy can be accessed, and it contains data from child resources (e.g. pod), for both managed, and autonomous.
 		// 5. Resource proxy can be accessed, and it contains data from agent resources.
 		// This validates the core connectivity and basic workflow of agent-principal architecture, including RBAC, connection, and application propagation.
-		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", Label("notOnXKS"), func() {
+		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", Label("openshfit"), func() {
 
 			By("Deploy principal and verify it starts successfully")
 			deployPrincipal(ctx, k8sClient, registerCleanup, false)

--- a/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
@@ -530,7 +530,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		// 4. Redis proxy can be accessed, and it contains data from child resources (e.g. pod), for both managed, and autonomous.
 		// 5. Resource proxy can be accessed, and it contains data from agent resources.
 		// This validates the core connectivity and basic workflow of agent-principal architecture, including RBAC, connection, and application propagation.
-		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", Label("openshfit"), func() {
+		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", Label("openshift"), func() {
 
 			By("Deploy principal and verify it starts successfully")
 			deployPrincipal(ctx, k8sClient, registerCleanup, false)

--- a/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
@@ -531,7 +531,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		// 4. Redis proxy can be accessed, and it contains data from child resources (e.g. pod), for both managed, and autonomous.
 		// 5. Resource proxy can be accessed, and it contains data from agent resources.
 		// This validates the core connectivity and basic workflow of agent-principal architecture, including RBAC, connection, and application propagation.
-		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", Label("openshfit"), func() {
+		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", Label("openshift"), func() {
 
 			By("Deploy principal and verify it starts successfully")
 			deployPrincipal(ctx, k8sClient, registerCleanup, false)

--- a/test/openshift/e2e/ginkgo/sequential/1-054_validate_argocd_agent_destination_mapping_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-054_validate_argocd_agent_destination_mapping_test.go
@@ -443,7 +443,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		// 1. Principal and agent with destination-based mapping enabled can be deployed and connected.
 		// 2. An Application created in the principal's namespace is routed to the agent via destination.name.
 		// 3. The Application reaches Synced and Healthy status.
-		It("Should deploy principal and agent with destination-based mapping", func() {
+		// TODO: update the test to pass on xKS cluster
+		It("Should deploy principal and agent with destination-based mapping",Label("openshift") func() {
 
 			By("Deploy principal with destination-based mapping enabled")
 			deployDestMapPrincipal()

--- a/test/openshift/e2e/ginkgo/sequential/1-054_validate_argocd_agent_destination_mapping_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-054_validate_argocd_agent_destination_mapping_test.go
@@ -444,7 +444,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		// 2. An Application created in the principal's namespace is routed to the agent via destination.name.
 		// 3. The Application reaches Synced and Healthy status.
 		// TODO: update the test to pass on xKS cluster
-		It("Should deploy principal and agent with destination-based mapping",Label("openshift") func() {
+		It("Should deploy principal and agent with destination-based mapping", Label("openshift"), func() {
 
 			By("Deploy principal with destination-based mapping enabled")
 			deployDestMapPrincipal()

--- a/test/openshift/e2e/ginkgo/sequential/1-058_validate_notifications_source_namespaces_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-058_validate_notifications_source_namespaces_test.go
@@ -58,7 +58,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail("not-argocd-ns")
 		})
 
-		It("ensures that NotificationsConfiguration, Role, and RoleBinding are created in source namespaces when  notifications.sourceNamespaces is configured", Label("notOnXKS"), func() {
+		It("ensures that NotificationsConfiguration, Role, and RoleBinding are created in source namespaces when  notifications.sourceNamespaces is configured", Label("openshfit"), func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -198,7 +198,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that resources are not created when namespace is not in SourceNamespaces", Label("notOnXKS"), func() {
+		It("ensures that resources are not created when namespace is not in SourceNamespaces", Label("openshfit"), func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -393,7 +393,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that resources are not created when notifications are disabled", Label("notOnXKS"), func() {
+		It("ensures that resources are not created when notifications are disabled", Label("openshfit"), func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -462,7 +462,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that notifications controller deployment command is updated when sourceNamespaces change", Label("notOnXKS"), func() {
+		It("ensures that notifications controller deployment command is updated when sourceNamespaces change", Label("openshfit"), func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -543,7 +543,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that resources are created when notifications are enabled after being disabled", Label("notOnXKS"), func() {
+		It("ensures that resources are created when notifications are enabled after being disabled", Label("openshfit"), func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")

--- a/test/openshift/e2e/ginkgo/sequential/1-058_validate_notifications_source_namespaces_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-058_validate_notifications_source_namespaces_test.go
@@ -58,7 +58,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail("not-argocd-ns")
 		})
 
-		It("ensures that NotificationsConfiguration, Role, and RoleBinding are created in source namespaces when  notifications.sourceNamespaces is configured", Label("openshift"), func() {
+		It("ensures that NotificationsConfiguration, Role, and RoleBinding are created in source namespaces when  notifications.sourceNamespaces is configured", Label("notOnXKS"), func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -198,7 +198,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that resources are not created when namespace is not in SourceNamespaces", Label("openshift"), func() {
+		It("ensures that resources are not created when namespace is not in SourceNamespaces", Label("notOnXKS"), func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -393,7 +393,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that resources are not created when notifications are disabled", Label("openshift"), func() {
+		It("ensures that resources are not created when notifications are disabled", Label("notOnXKS"), func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -462,7 +462,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that notifications controller deployment command is updated when sourceNamespaces change", Label("openshift"), func() {
+		It("ensures that notifications controller deployment command is updated when sourceNamespaces change", Label("notOnXKS"), func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -543,7 +543,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that resources are created when notifications are enabled after being disabled", Label("openshift"), func() {
+		It("ensures that resources are created when notifications are enabled after being disabled", Label("notOnXKS"), func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")

--- a/test/openshift/e2e/ginkgo/sequential/1-058_validate_notifications_source_namespaces_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-058_validate_notifications_source_namespaces_test.go
@@ -58,7 +58,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail("not-argocd-ns")
 		})
 
-		It("ensures that NotificationsConfiguration, Role, and RoleBinding are created in source namespaces when  notifications.sourceNamespaces is configured", func() {
+		It("ensures that NotificationsConfiguration, Role, and RoleBinding are created in source namespaces when  notifications.sourceNamespaces is configured", Label("openshift"), func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -198,7 +198,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that resources are not created when namespace is not in SourceNamespaces", func() {
+		It("ensures that resources are not created when namespace is not in SourceNamespaces", Label("openshift"), func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -393,7 +393,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that resources are not created when notifications are disabled", func() {
+		It("ensures that resources are not created when notifications are disabled", Label("openshift"), func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -462,7 +462,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that notifications controller deployment command is updated when sourceNamespaces change", func() {
+		It("ensures that notifications controller deployment command is updated when sourceNamespaces change", Label("openshift"), func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -543,7 +543,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that resources are created when notifications are enabled after being disabled", func() {
+		It("ensures that resources are created when notifications are enabled after being disabled", Label("openshift"), func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")

--- a/test/openshift/e2e/ginkgo/sequential/1-058_validate_notifications_source_namespaces_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-058_validate_notifications_source_namespaces_test.go
@@ -58,7 +58,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail("not-argocd-ns")
 		})
 
-		It("ensures that NotificationsConfiguration, Role, and RoleBinding are created in source namespaces when  notifications.sourceNamespaces is configured", Label("openshfit"), func() {
+		It("ensures that NotificationsConfiguration, Role, and RoleBinding are created in source namespaces when  notifications.sourceNamespaces is configured", func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -198,7 +198,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that resources are not created when namespace is not in SourceNamespaces", Label("openshfit"), func() {
+		It("ensures that resources are not created when namespace is not in SourceNamespaces", func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -393,7 +393,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that resources are not created when notifications are disabled", Label("openshfit"), func() {
+		It("ensures that resources are not created when notifications are disabled", func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -462,7 +462,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that notifications controller deployment command is updated when sourceNamespaces change", Label("openshfit"), func() {
+		It("ensures that notifications controller deployment command is updated when sourceNamespaces change", func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
@@ -543,7 +543,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("ensures that resources are created when notifications are enabled after being disabled", Label("openshfit"), func() {
+		It("ensures that resources are created when notifications are enabled after being disabled", func() {
 
 			By("creating Argo CD instance namespace")
 			argocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")

--- a/test/openshift/e2e/ginkgo/sequential/1-059_validate_argocd_agent_terminal_streaming_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-059_validate_argocd_agent_terminal_streaming_test.go
@@ -157,7 +157,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			registerCleanup(cleanupFuncManagedApplication)
 		})
 
-		It("Should open a terminal session to a pod deployed via ArgoCD agent and execute commands", Label("notOnXKS"), func() {
+		It("Should open a terminal session to a pod deployed via ArgoCD agent and execute commands", Label("openshfit"), func() {
 
 			By("Deploy principal with server route enabled and verify it starts successfully")
 			deployPrincipal(ctx, k8sClient, registerCleanup, true)

--- a/test/openshift/e2e/ginkgo/sequential/1-059_validate_argocd_agent_terminal_streaming_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-059_validate_argocd_agent_terminal_streaming_test.go
@@ -157,7 +157,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			registerCleanup(cleanupFuncManagedApplication)
 		})
 
-		It("Should open a terminal session to a pod deployed via ArgoCD agent and execute commands", func() {
+		It("Should open a terminal session to a pod deployed via ArgoCD agent and execute commands", Label("openshift"), func() {
 
 			By("Deploy principal with server route enabled and verify it starts successfully")
 			deployPrincipal(ctx, k8sClient, registerCleanup, true)

--- a/test/openshift/e2e/ginkgo/sequential/1-059_validate_argocd_agent_terminal_streaming_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-059_validate_argocd_agent_terminal_streaming_test.go
@@ -157,7 +157,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			registerCleanup(cleanupFuncManagedApplication)
 		})
 
-		It("Should open a terminal session to a pod deployed via ArgoCD agent and execute commands", Label("openshift"), func() {
+		It("Should open a terminal session to a pod deployed via ArgoCD agent and execute commands", Label("notOnXKS"), func() {
 
 			By("Deploy principal with server route enabled and verify it starts successfully")
 			deployPrincipal(ctx, k8sClient, registerCleanup, true)

--- a/test/openshift/e2e/ginkgo/sequential/1-059_validate_argocd_agent_terminal_streaming_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-059_validate_argocd_agent_terminal_streaming_test.go
@@ -157,7 +157,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			registerCleanup(cleanupFuncManagedApplication)
 		})
 
-		It("Should open a terminal session to a pod deployed via ArgoCD agent and execute commands", Label("openshfit"), func() {
+		It("Should open a terminal session to a pod deployed via ArgoCD agent and execute commands", Label("openshift"), func() {
 
 			By("Deploy principal with server route enabled and verify it starts successfully")
 			deployPrincipal(ctx, k8sClient, registerCleanup, true)

--- a/test/openshift/e2e/ginkgo/sequential/1-064_validate_tcp_reset_error_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-064_validate_tcp_reset_error_test.go
@@ -66,7 +66,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that argocd cli app manifests command will succesfully retrieve app manifests, and tcp reset error will not occur", Label("notOnXKS"), func() {
+		It("verifies that argocd cli app manifests command will succesfully retrieve app manifests, and tcp reset error will not occur", Label("openshfit"), func() {
 
 			// This test is VERY similar to 1-027.
 

--- a/test/openshift/e2e/ginkgo/sequential/1-064_validate_tcp_reset_error_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-064_validate_tcp_reset_error_test.go
@@ -66,7 +66,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that argocd cli app manifests command will succesfully retrieve app manifests, and tcp reset error will not occur", Label("openshift"), func() {
+		It("verifies that argocd cli app manifests command will succesfully retrieve app manifests, and tcp reset error will not occur", Label("notOnXKS"), func() {
 
 			// This test is VERY similar to 1-027.
 

--- a/test/openshift/e2e/ginkgo/sequential/1-064_validate_tcp_reset_error_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-064_validate_tcp_reset_error_test.go
@@ -66,7 +66,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that argocd cli app manifests command will succesfully retrieve app manifests, and tcp reset error will not occur", func() {
+		It("verifies that argocd cli app manifests command will succesfully retrieve app manifests, and tcp reset error will not occur", Label("openshift"), func() {
 
 			// This test is VERY similar to 1-027.
 

--- a/test/openshift/e2e/ginkgo/sequential/1-064_validate_tcp_reset_error_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-064_validate_tcp_reset_error_test.go
@@ -40,6 +40,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-064_validate_tcp_reset_error_test", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		var (
 			ctx                context.Context
@@ -66,7 +67,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("verifies that argocd cli app manifests command will succesfully retrieve app manifests, and tcp reset error will not occur", Label("openshfit"), func() {
+		It("verifies that argocd cli app manifests command will succesfully retrieve app manifests, and tcp reset error will not occur", Label("openshift"), func() {
 
 			// This test is VERY similar to 1-027.
 

--- a/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates SCC and ensure HA Argo CD starts as expected", Label("notOnXKS"), func() {
+		It("creates SCC and ensure HA Argo CD starts as expected", Label("openshfit"), func() {
 
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates SCC and ensure HA Argo CD starts as expected", func() {
+		It("creates SCC and ensure HA Argo CD starts as expected", Label("openshift"), func() {
 
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates SCC and ensure HA Argo CD starts as expected", Label("openshift"), func() {
+		It("creates SCC and ensure HA Argo CD starts as expected", Label("notOnXKS"), func() {
 
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates SCC and ensure HA Argo CD starts as expected", Label("notOnXKS"), func() {
+		It("creates SCC and ensure HA Argo CD starts as expected", Label("openshfit"), func() {
 
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates SCC and ensure HA Argo CD starts as expected", Label("openshfit"), func() {
+		It("creates SCC and ensure HA Argo CD starts as expected", Label("openshift"), func() {
 
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates SCC and ensure HA Argo CD starts as expected", func() {
+		It("creates SCC and ensure HA Argo CD starts as expected", Label("openshift"), func() {
 
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates SCC and ensure HA Argo CD starts as expected", Label("openshfit"), func() {
+		It("creates SCC and ensure HA Argo CD starts as expected", Label("openshift"), func() {
 
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates SCC and ensure HA Argo CD starts as expected", Label("openshift"), func() {
+		It("creates SCC and ensure HA Argo CD starts as expected", Label("notOnXKS"), func() {
 
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-071_validate_node_selectors_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-071_validate_node_selectors_test.go
@@ -36,7 +36,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies changes to GitOpsService's nodeselector, tolerations, and runOnInfra will modify Argo CD Deployments and StatefulSets", Label("notOnXKS"), func() {
+		It("verifies changes to GitOpsService's nodeselector, tolerations, and runOnInfra will modify Argo CD Deployments and StatefulSets", Label("openshfit"), func() {
 
 			By("ensuring Deployments and StatefulSets have nodeSelector of 'kubernetes.io/os: linux'")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-071_validate_node_selectors_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-071_validate_node_selectors_test.go
@@ -36,7 +36,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies changes to GitOpsService's nodeselector, tolerations, and runOnInfra will modify Argo CD Deployments and StatefulSets", func() {
+		It("verifies changes to GitOpsService's nodeselector, tolerations, and runOnInfra will modify Argo CD Deployments and StatefulSets", Label("openshift"), func() {
 
 			By("ensuring Deployments and StatefulSets have nodeSelector of 'kubernetes.io/os: linux'")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-071_validate_node_selectors_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-071_validate_node_selectors_test.go
@@ -36,7 +36,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies changes to GitOpsService's nodeselector, tolerations, and runOnInfra will modify Argo CD Deployments and StatefulSets", Label("openshift"), func() {
+		It("verifies changes to GitOpsService's nodeselector, tolerations, and runOnInfra will modify Argo CD Deployments and StatefulSets", Label("notOnXKS"), func() {
 
 			By("ensuring Deployments and StatefulSets have nodeSelector of 'kubernetes.io/os: linux'")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-071_validate_node_selectors_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-071_validate_node_selectors_test.go
@@ -23,6 +23,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-071_validate_node_selectors", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		var (
 			ctx       context.Context
@@ -36,7 +37,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies changes to GitOpsService's nodeselector, tolerations, and runOnInfra will modify Argo CD Deployments and StatefulSets", Label("openshfit"), func() {
+		It("verifies changes to GitOpsService's nodeselector, tolerations, and runOnInfra will modify Argo CD Deployments and StatefulSets", Label("openshift"), func() {
 
 			By("ensuring Deployments and StatefulSets have nodeSelector of 'kubernetes.io/os: linux'")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", Label("notOnXKS"), func() {
+		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", Label("openshfit"), func() {
 
 			By("creating an Argo CD instance that will manage other namespaces")
 			gitops_2242_ns_main, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("gitops-2242-ns-main")

--- a/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", func() {
+		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", Label("openshift"), func() {
 
 			By("creating an Argo CD instance that will manage other namespaces")
 			gitops_2242_ns_main, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("gitops-2242-ns-main")

--- a/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", Label("openshift"), func() {
+		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", Label("notOnXKS"), func() {
 
 			By("creating an Argo CD instance that will manage other namespaces")
 			gitops_2242_ns_main, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("gitops-2242-ns-main")

--- a/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", Label("openshfit"), func() {
+		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", func() {
 
 			By("creating an Argo CD instance that will manage other namespaces")
 			gitops_2242_ns_main, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("gitops-2242-ns-main")

--- a/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", func() {
+		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", Label("openshift"), func() {
 
 			By("creating an Argo CD instance that will manage other namespaces")
 			gitops_2242_ns_main, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("gitops-2242-ns-main")

--- a/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", Label("openshfit"), func() {
+		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", func() {
 
 			By("creating an Argo CD instance that will manage other namespaces")
 			gitops_2242_ns_main, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("gitops-2242-ns-main")

--- a/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", Label("notOnXKS"), func() {
+		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", Label("openshfit"), func() {
 
 			By("creating an Argo CD instance that will manage other namespaces")
 			gitops_2242_ns_main, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("gitops-2242-ns-main")

--- a/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-074_validate_terminating_namespace_block_test.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", Label("openshift"), func() {
+		It("ensures that if one managed namespace is stuck in deleting state -- due to a finalizer -- it does not block other managed namespaces from being reconciled", Label("notOnXKS"), func() {
 
 			By("creating an Argo CD instance that will manage other namespaces")
 			gitops_2242_ns_main, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("gitops-2242-ns-main")

--- a/test/openshift/e2e/ginkgo/sequential/1-077_validate_disable_dex_removed_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-077_validate_disable_dex_removed_test.go
@@ -46,6 +46,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
+		// TODO: skipped on xKS, check if this can be ported for xKS testing
 		It("verifies that DISABLE_DEX is not specified in the Subscription/CSV that was used to install the operator", func() {
 
 			if fixture.EnvNonOLM() || fixture.EnvLocalRun() {

--- a/test/openshift/e2e/ginkgo/sequential/1-078_validate_default_argocd_consoleLink_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-078_validate_default_argocd_consoleLink_test.go
@@ -18,7 +18,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies that DISABLE_DEFAULT_ARGOCD_CONSOLELINK disables the ConsoleLink, and it tolerates improper values and can be re-enabled", Label("notOnXKS"), func() {
+		It("verifies that DISABLE_DEFAULT_ARGOCD_CONSOLELINK disables the ConsoleLink, and it tolerates improper values and can be re-enabled", Label("openshfit"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("skipping as LOCAL_RUN is set, which implies we are running the operator locally. When running locally, there is no Subscription or Deployment upon which we can set the DISABLE_DEFAULT_ARGOCD_CONSOLELINK env var")

--- a/test/openshift/e2e/ginkgo/sequential/1-078_validate_default_argocd_consoleLink_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-078_validate_default_argocd_consoleLink_test.go
@@ -18,7 +18,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies that DISABLE_DEFAULT_ARGOCD_CONSOLELINK disables the ConsoleLink, and it tolerates improper values and can be re-enabled", func() {
+		It("verifies that DISABLE_DEFAULT_ARGOCD_CONSOLELINK disables the ConsoleLink, and it tolerates improper values and can be re-enabled", Label("notOnXKS"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("skipping as LOCAL_RUN is set, which implies we are running the operator locally. When running locally, there is no Subscription or Deployment upon which we can set the DISABLE_DEFAULT_ARGOCD_CONSOLELINK env var")

--- a/test/openshift/e2e/ginkgo/sequential/1-078_validate_default_argocd_consoleLink_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-078_validate_default_argocd_consoleLink_test.go
@@ -18,7 +18,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies that DISABLE_DEFAULT_ARGOCD_CONSOLELINK disables the ConsoleLink, and it tolerates improper values and can be re-enabled", Label("openshfit"), func() {
+		It("verifies that DISABLE_DEFAULT_ARGOCD_CONSOLELINK disables the ConsoleLink, and it tolerates improper values and can be re-enabled", Label("openshift"), func() {
 
 			if fixture.EnvLocalRun() {
 				Skip("skipping as LOCAL_RUN is set, which implies we are running the operator locally. When running locally, there is no Subscription or Deployment upon which we can set the DISABLE_DEFAULT_ARGOCD_CONSOLELINK env var")

--- a/test/openshift/e2e/ginkgo/sequential/1-083_validate_apps_in_any_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-083_validate_apps_in_any_namespace_test.go
@@ -54,7 +54,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that namespaces added to .spec.sourceNamespaces are managed by openshift-gitops Argo CD instance, except when those namespaces also have managed-by label. Both addition and removal of values from this field are tested", Label("notOnXKS"), func() {
+		It("verifies that namespaces added to .spec.sourceNamespaces are managed by openshift-gitops Argo CD instance, except when those namespaces also have managed-by label. Both addition and removal of values from this field are tested", Label("openshfit"), func() {
 
 			By("1) create test-1-24-custom namespace managed by openshift-gitops instance")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-083_validate_apps_in_any_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-083_validate_apps_in_any_namespace_test.go
@@ -54,7 +54,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that namespaces added to .spec.sourceNamespaces are managed by openshift-gitops Argo CD instance, except when those namespaces also have managed-by label. Both addition and removal of values from this field are tested", func() {
+		It("verifies that namespaces added to .spec.sourceNamespaces are managed by openshift-gitops Argo CD instance, except when those namespaces also have managed-by label. Both addition and removal of values from this field are tested", Label("openshift"), func() {
 
 			By("1) create test-1-24-custom namespace managed by openshift-gitops instance")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-083_validate_apps_in_any_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-083_validate_apps_in_any_namespace_test.go
@@ -54,7 +54,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that namespaces added to .spec.sourceNamespaces are managed by openshift-gitops Argo CD instance, except when those namespaces also have managed-by label. Both addition and removal of values from this field are tested", Label("openshift"), func() {
+		It("verifies that namespaces added to .spec.sourceNamespaces are managed by openshift-gitops Argo CD instance, except when those namespaces also have managed-by label. Both addition and removal of values from this field are tested", Label("notOnXKS"), func() {
 
 			By("1) create test-1-24-custom namespace managed by openshift-gitops instance")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-083_validate_apps_in_any_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-083_validate_apps_in_any_namespace_test.go
@@ -42,6 +42,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-083_validate_apps_in_any_namespace", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		var (
 			ctx       context.Context
@@ -54,7 +55,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that namespaces added to .spec.sourceNamespaces are managed by openshift-gitops Argo CD instance, except when those namespaces also have managed-by label. Both addition and removal of values from this field are tested", Label("openshfit"), func() {
+		It("verifies that namespaces added to .spec.sourceNamespaces are managed by openshift-gitops Argo CD instance, except when those namespaces also have managed-by label. Both addition and removal of values from this field are tested", Label("openshift"), func() {
 
 			By("1) create test-1-24-custom namespace managed by openshift-gitops instance")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-084_validate_prune_templates.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-084_validate_prune_templates.go
@@ -63,7 +63,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail(ns)
 		})
 
-		It("validates that resources with duplicate GVKs can be pruned successfully with local sync", Label("notOnXKS"), func() {
+		It("validates that resources with duplicate GVKs can be pruned successfully with local sync", Label("openshfit"), func() {
 			By("creating a temp dir for git repo")
 			workDir, err := os.MkdirTemp("", "gitops-prune-test")
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-084_validate_prune_templates.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-084_validate_prune_templates.go
@@ -63,7 +63,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail(ns)
 		})
 
-		It("validates that resources with duplicate GVKs can be pruned successfully with local sync", Label("openshift"), func() {
+		It("validates that resources with duplicate GVKs can be pruned successfully with local sync", Label("notOnXKS"), func() {
 			By("creating a temp dir for git repo")
 			workDir, err := os.MkdirTemp("", "gitops-prune-test")
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-084_validate_prune_templates.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-084_validate_prune_templates.go
@@ -63,7 +63,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail(ns)
 		})
 
-		It("validates that resources with duplicate GVKs can be pruned successfully with local sync", func() {
+		It("validates that resources with duplicate GVKs can be pruned successfully with local sync", Label("openshift"), func() {
 			By("creating a temp dir for git repo")
 			workDir, err := os.MkdirTemp("", "gitops-prune-test")
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-084_validate_prune_templates.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-084_validate_prune_templates.go
@@ -63,7 +63,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail(ns)
 		})
 
-		It("validates that resources with duplicate GVKs can be pruned successfully with local sync", Label("openshfit"), func() {
+		It("validates that resources with duplicate GVKs can be pruned successfully with local sync", Label("openshift"), func() {
 			By("creating a temp dir for git repo")
 			workDir, err := os.MkdirTemp("", "gitops-prune-test")
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-085_validate_dynamic_plugin_installation_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-085_validate_dynamic_plugin_installation_test.go
@@ -20,8 +20,8 @@ import (
 )
 
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
-
-	Context("1-085_validate_dynamic_plugin_installation", func() {
+	// Only works on openshift platform
+	Context("1-085_validate_dynamic_plugin_installation", Label("openshift"), func() {
 
 		var (
 			ctx       context.Context

--- a/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", Label("notOnXKS"), func() {
+		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", Label("openshfit"), func() {
 
 			By("verifying default ArgoCD in openshift-gitops is running and has defined expected RBAC values in ConfigMap argocd-rbac-cm")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", func() {
+		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", Label("openshift"), func() {
 
 			By("verifying default ArgoCD in openshift-gitops is running and has defined expected RBAC values in ConfigMap argocd-rbac-cm")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", Label("openshift"), func() {
+		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", Label("notOnXKS"), func() {
 
 			By("verifying default ArgoCD in openshift-gitops is running and has defined expected RBAC values in ConfigMap argocd-rbac-cm")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
@@ -19,6 +19,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-086_validate_default_argocd_role", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		var (
 			ctx       context.Context
@@ -32,7 +33,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", Label("openshfit"), func() {
+		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", Label("openshift"), func() {
 
 			By("verifying default ArgoCD in openshift-gitops is running and has defined expected RBAC values in ConfigMap argocd-rbac-cm")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
@@ -32,7 +32,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", Label("openshift"), func() {
+		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", Label("notOnXKS"), func() {
 
 			By("verifying default ArgoCD in openshift-gitops is running and has defined expected RBAC values in ConfigMap argocd-rbac-cm")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
@@ -32,7 +32,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", Label("notOnXKS"), func() {
+		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", Label("openshfit"), func() {
 
 			By("verifying default ArgoCD in openshift-gitops is running and has defined expected RBAC values in ConfigMap argocd-rbac-cm")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
@@ -32,7 +32,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", func() {
+		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", Label("openshift"), func() {
 
 			By("verifying default ArgoCD in openshift-gitops is running and has defined expected RBAC values in ConfigMap argocd-rbac-cm")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-086_validate_default_argocd_role_test.go
@@ -20,6 +20,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-086_validate_default_argocd_role", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		var (
 			ctx       context.Context
@@ -33,7 +34,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", Label("openshfit"), func() {
+		It("verifies that Argo CD roles are defined as expected in argocd-rbac-cm, based on values in ArgoCD .spec.rbac.defaultPolicy", Label("openshift"), func() {
 
 			By("verifying default ArgoCD in openshift-gitops is running and has defined expected RBAC values in ConfigMap argocd-rbac-cm")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-092_validate_workload_status_monitoring_alert.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-092_validate_workload_status_monitoring_alert.go
@@ -45,7 +45,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail(nsNamespaced)
 		})
 
-		It("validates monitoring setup, alert rule creation, and teardown", Label("notOnXKS"), func() {
+		It("validates monitoring setup, alert rule creation, and teardown", Label("openshfit"), func() {
 			const (
 				// picking image that exists to avoid ImagePullBackOff but should fail to run as an ApplicationSet controller
 				invalidImage        = "quay.io/libpod/alpine:latest"

--- a/test/openshift/e2e/ginkgo/sequential/1-092_validate_workload_status_monitoring_alert.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-092_validate_workload_status_monitoring_alert.go
@@ -45,7 +45,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail(nsNamespaced)
 		})
 
-		It("validates monitoring setup, alert rule creation, and teardown", func() {
+		It("validates monitoring setup, alert rule creation, and teardown", Label("openshift"), func() {
 			const (
 				// picking image that exists to avoid ImagePullBackOff but should fail to run as an ApplicationSet controller
 				invalidImage        = "quay.io/libpod/alpine:latest"

--- a/test/openshift/e2e/ginkgo/sequential/1-092_validate_workload_status_monitoring_alert.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-092_validate_workload_status_monitoring_alert.go
@@ -45,7 +45,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail(nsNamespaced)
 		})
 
-		It("validates monitoring setup, alert rule creation, and teardown", Label("openshift"), func() {
+		It("validates monitoring setup, alert rule creation, and teardown", Label("notOnXKS"), func() {
 			const (
 				// picking image that exists to avoid ImagePullBackOff but should fail to run as an ApplicationSet controller
 				invalidImage        = "quay.io/libpod/alpine:latest"

--- a/test/openshift/e2e/ginkgo/sequential/1-092_validate_workload_status_monitoring_alert.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-092_validate_workload_status_monitoring_alert.go
@@ -45,7 +45,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail(nsNamespaced)
 		})
 
-		It("validates monitoring setup, alert rule creation, and teardown", Label("openshfit"), func() {
+		It("validates monitoring setup, alert rule creation, and teardown", Label("openshift"), func() {
 			const (
 				// picking image that exists to avoid ImagePullBackOff but should fail to run as an ApplicationSet controller
 				invalidImage        = "quay.io/libpod/alpine:latest"

--- a/test/openshift/e2e/ginkgo/sequential/1-100_validate_rollouts_resources_creation_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-100_validate_rollouts_resources_creation_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates a cluster-scopes Argo Rollouts instance and verifies the expected K8s resources are created", Label("notOnXKS"), func() {
+		It("creates a cluster-scopes Argo Rollouts instance and verifies the expected K8s resources are created", Label("openshfit"), func() {
 
 			By("creating simple cluster-scoped Argo Rollouts instance via RolloutManager in openshift-gitops namespace")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-100_validate_rollouts_resources_creation_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-100_validate_rollouts_resources_creation_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates a cluster-scopes Argo Rollouts instance and verifies the expected K8s resources are created", func() {
+		It("creates a cluster-scopes Argo Rollouts instance and verifies the expected K8s resources are created", Label("openshift"), func() {
 
 			By("creating simple cluster-scoped Argo Rollouts instance via RolloutManager in openshift-gitops namespace")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-100_validate_rollouts_resources_creation_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-100_validate_rollouts_resources_creation_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates a cluster-scopes Argo Rollouts instance and verifies the expected K8s resources are created", Label("openshift"), func() {
+		It("creates a cluster-scopes Argo Rollouts instance and verifies the expected K8s resources are created", Label("notOnXKS"), func() {
 
 			By("creating simple cluster-scoped Argo Rollouts instance via RolloutManager in openshift-gitops namespace")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-100_validate_rollouts_resources_creation_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-100_validate_rollouts_resources_creation_test.go
@@ -20,6 +20,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-100_validate_rollouts_resources_creation", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		var (
 			ctx       context.Context
@@ -33,7 +34,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates a cluster-scopes Argo Rollouts instance and verifies the expected K8s resources are created", Label("openshfit"), func() {
+		It("creates a cluster-scopes Argo Rollouts instance and verifies the expected K8s resources are created", Label("openshift"), func() {
 
 			By("creating simple cluster-scoped Argo Rollouts instance via RolloutManager in openshift-gitops namespace")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-101_validate_rollout_policyrules_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-101_validate_rollout_policyrules_test.go
@@ -30,7 +30,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifying Rollouts operator creates the expected policy rules", Label("notOnXKS"), func() {
+		It("verifying Rollouts operator creates the expected policy rules", Label("openshfit"), func() {
 
 			By("creating cluster-scoped Argo Rollouts instance in openshift-gitops RolloutManager")
 			rm := &rolloutmanagerv1alpha1.RolloutManager{

--- a/test/openshift/e2e/ginkgo/sequential/1-101_validate_rollout_policyrules_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-101_validate_rollout_policyrules_test.go
@@ -30,7 +30,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifying Rollouts operator creates the expected policy rules", func() {
+		It("verifying Rollouts operator creates the expected policy rules", Label("openshift"), func() {
 
 			By("creating cluster-scoped Argo Rollouts instance in openshift-gitops RolloutManager")
 			rm := &rolloutmanagerv1alpha1.RolloutManager{

--- a/test/openshift/e2e/ginkgo/sequential/1-101_validate_rollout_policyrules_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-101_validate_rollout_policyrules_test.go
@@ -30,7 +30,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifying Rollouts operator creates the expected policy rules", Label("openshift"), func() {
+		It("verifying Rollouts operator creates the expected policy rules", Label("notOnXKS"), func() {
 
 			By("creating cluster-scoped Argo Rollouts instance in openshift-gitops RolloutManager")
 			rm := &rolloutmanagerv1alpha1.RolloutManager{

--- a/test/openshift/e2e/ginkgo/sequential/1-101_validate_rollout_policyrules_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-101_validate_rollout_policyrules_test.go
@@ -30,7 +30,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifying Rollouts operator creates the expected policy rules", Label("openshfit"), func() {
+		It("verifying Rollouts operator creates the expected policy rules", Label("openshift"), func() {
 
 			By("creating cluster-scoped Argo Rollouts instance in openshift-gitops RolloutManager")
 			rm := &rolloutmanagerv1alpha1.RolloutManager{

--- a/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
@@ -81,7 +81,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", Label("notOnXKS"), func() {
+		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", Label("openshfit"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, nsCleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
@@ -81,7 +81,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", Label("openshift"), func() {
+		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", Label("notOnXKS"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, nsCleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
@@ -81,7 +81,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", func() {
+		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", Label("openshift"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, nsCleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
@@ -80,7 +80,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", func() {
+		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", Label("openshift"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, nsCleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
@@ -80,7 +80,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", Label("notOnXKS"), func() {
+		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", Label("openshfit"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, nsCleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
@@ -81,7 +81,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", Label("openshfit"), func() {
+		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, nsCleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
@@ -80,7 +80,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", Label("openshfit"), func() {
+		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, nsCleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-102_validate_handle_terminating_namespaces_test.go
@@ -80,7 +80,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", Label("openshift"), func() {
+		It("ensures that if one managed-by namespace is stuck in terminating, it does not prevent other managed-by namespaces from being managed or deployed to", Label("notOnXKS"), func() {
 
 			By("creating simple namespace-scoped Argo CD instance")
 			ns, nsCleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-103-validate-rollouts-imagepullpolicy.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-103-validate-rollouts-imagepullpolicy.go
@@ -115,7 +115,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				"Deployment %s should have all containers with ImagePullPolicy set to IfNotPresent", deplName)
 		})
 
-		It("creates a cluster-scopes Argo Rollouts instance and verifies subscription image pull policy is applied", func() {
+		It("creates a cluster-scopes Argo Rollouts instance and verifies subscription image pull policy is applied", Label("notOnXKS"), func() {
 			if fixture.EnvLocalRun() {
 				Skip("This test does not support local run, as when the controller is running locally there is no env var to modify")
 				return

--- a/test/openshift/e2e/ginkgo/sequential/1-103-validate-rollouts-imagepullpolicy.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-103-validate-rollouts-imagepullpolicy.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates a cluster-scopes Argo Rollouts instance and verifies the default image pull policy", Label("notOnXKS"), func() {
+		It("creates a cluster-scopes Argo Rollouts instance and verifies the default image pull policy", Label("openshfit"), func() {
 
 			By("creating simple cluster-scoped Argo Rollouts instance via RolloutManager in openshift-gitops namespace")
 
@@ -72,7 +72,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("creates a cluster-scopes Argo Rollouts instance and verifies the CR value imagePullPolicy is applied", Label("notOnXKS"), func() {
+		It("creates a cluster-scopes Argo Rollouts instance and verifies the CR value imagePullPolicy is applied", Label("openshfit"), func() {
 
 			By("creating simple cluster-scoped Argo Rollouts instance via RolloutManager in openshift-gitops namespace with imagePullPolicy set to Always")
 
@@ -115,7 +115,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				"Deployment %s should have all containers with ImagePullPolicy set to IfNotPresent", deplName)
 		})
 
-		It("creates a cluster-scopes Argo Rollouts instance and verifies subscription image pull policy is applied", Label("notOnXKS"), func() {
+		It("creates a cluster-scopes Argo Rollouts instance and verifies subscription image pull policy is applied", Label("openshfit"), func() {
 			if fixture.EnvLocalRun() {
 				Skip("This test does not support local run, as when the controller is running locally there is no env var to modify")
 				return

--- a/test/openshift/e2e/ginkgo/sequential/1-103-validate-rollouts-imagepullpolicy.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-103-validate-rollouts-imagepullpolicy.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates a cluster-scopes Argo Rollouts instance and verifies the default image pull policy", Label("openshift"), func() {
+		It("creates a cluster-scopes Argo Rollouts instance and verifies the default image pull policy", Label("notOnXKS"), func() {
 
 			By("creating simple cluster-scoped Argo Rollouts instance via RolloutManager in openshift-gitops namespace")
 
@@ -72,7 +72,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("creates a cluster-scopes Argo Rollouts instance and verifies the CR value imagePullPolicy is applied", Label("openshift"), func() {
+		It("creates a cluster-scopes Argo Rollouts instance and verifies the CR value imagePullPolicy is applied", Label("notOnXKS"), func() {
 
 			By("creating simple cluster-scoped Argo Rollouts instance via RolloutManager in openshift-gitops namespace with imagePullPolicy set to Always")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-103-validate-rollouts-imagepullpolicy.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-103-validate-rollouts-imagepullpolicy.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates a cluster-scopes Argo Rollouts instance and verifies the default image pull policy", func() {
+		It("creates a cluster-scopes Argo Rollouts instance and verifies the default image pull policy", Label("openshift"), func() {
 
 			By("creating simple cluster-scoped Argo Rollouts instance via RolloutManager in openshift-gitops namespace")
 
@@ -72,7 +72,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("creates a cluster-scopes Argo Rollouts instance and verifies the CR value imagePullPolicy is applied", func() {
+		It("creates a cluster-scopes Argo Rollouts instance and verifies the CR value imagePullPolicy is applied", Label("openshift"), func() {
 
 			By("creating simple cluster-scoped Argo Rollouts instance via RolloutManager in openshift-gitops namespace with imagePullPolicy set to Always")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-103-validate-rollouts-imagepullpolicy.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-103-validate-rollouts-imagepullpolicy.go
@@ -35,6 +35,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-103_validate_rollouts_imagepullpolicy", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		var (
 			ctx       context.Context
@@ -48,7 +49,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("creates a cluster-scopes Argo Rollouts instance and verifies the default image pull policy", Label("openshfit"), func() {
+		It("creates a cluster-scopes Argo Rollouts instance and verifies the default image pull policy", Label("openshift"), func() {
 
 			By("creating simple cluster-scoped Argo Rollouts instance via RolloutManager in openshift-gitops namespace")
 
@@ -72,7 +73,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("creates a cluster-scopes Argo Rollouts instance and verifies the CR value imagePullPolicy is applied", Label("openshfit"), func() {
+		It("creates a cluster-scopes Argo Rollouts instance and verifies the CR value imagePullPolicy is applied", Label("openshift"), func() {
 
 			By("creating simple cluster-scoped Argo Rollouts instance via RolloutManager in openshift-gitops namespace with imagePullPolicy set to Always")
 
@@ -115,7 +116,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				"Deployment %s should have all containers with ImagePullPolicy set to IfNotPresent", deplName)
 		})
 
-		It("creates a cluster-scopes Argo Rollouts instance and verifies subscription image pull policy is applied", Label("openshfit"), func() {
+		It("creates a cluster-scopes Argo Rollouts instance and verifies subscription image pull policy is applied", Label("openshift"), func() {
 			if fixture.EnvLocalRun() {
 				Skip("This test does not support local run, as when the controller is running locally there is no env var to modify")
 				return

--- a/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
@@ -39,7 +39,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", Label("notOnXKS"), func() {
+		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", Label("openshfit"), func() {
 
 			By("verifying Argo CD in openshift-gitops exists and has server route enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
@@ -39,7 +39,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", Label("openshift"), func() {
+		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", Label("notOnXKS"), func() {
 
 			By("verifying Argo CD in openshift-gitops exists and has server route enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
@@ -39,7 +39,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", func() {
+		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", Label("openshift"), func() {
 
 			By("verifying Argo CD in openshift-gitops exists and has server route enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
@@ -38,7 +38,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", func() {
+		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", Label("openshift"), func() {
 
 			By("verifying Argo CD in openshift-gitops exists and has server route enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
@@ -39,7 +39,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", Label("openshfit"), func() {
+		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", Label("openshift"), func() {
 
 			By("verifying Argo CD in openshift-gitops exists and has server route enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
@@ -38,7 +38,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", Label("openshfit"), func() {
+		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", Label("openshift"), func() {
 
 			By("verifying Argo CD in openshift-gitops exists and has server route enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
@@ -38,7 +38,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", Label("notOnXKS"), func() {
+		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", Label("openshfit"), func() {
 
 			By("verifying Argo CD in openshift-gitops exists and has server route enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-105_validate_default_argocd_route_test.go
@@ -38,7 +38,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", Label("openshift"), func() {
+		It("ensure that openshift-gitops Argo CD has correct default settings, and those settings can be changed which will affect the server Route", Label("notOnXKS"), func() {
 
 			By("verifying Argo CD in openshift-gitops exists and has server route enabled")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		}
 
-		It("verifies Argo CD metrics can be disabled and re-enabled", Label("notOnXKS"), func() {
+		It("verifies Argo CD metrics can be disabled and re-enabled", Label("openshfit"), func() {
 
 			By("verifying Argo CD metrics are enabled by default in openshift-gitops")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		}
 
-		It("verifies Argo CD metrics can be disabled and re-enabled", Label("openshift"), func() {
+		It("verifies Argo CD metrics can be disabled and re-enabled", Label("notOnXKS"), func() {
 
 			By("verifying Argo CD metrics are enabled by default in openshift-gitops")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		}
 
-		It("verifies Argo CD metrics can be disabled and re-enabled", func() {
+		It("verifies Argo CD metrics can be disabled and re-enabled", Label("openshift"), func() {
 
 			By("verifying Argo CD metrics are enabled by default in openshift-gitops")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		}
 
-		It("verifies Argo CD metrics can be disabled and re-enabled", Label("notOnXKS"), func() {
+		It("verifies Argo CD metrics can be disabled and re-enabled", Label("openshfit"), func() {
 
 			By("verifying Argo CD metrics are enabled by default in openshift-gitops")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		}
 
-		It("verifies Argo CD metrics can be disabled and re-enabled", Label("openshfit"), func() {
+		It("verifies Argo CD metrics can be disabled and re-enabled", Label("openshift"), func() {
 
 			By("verifying Argo CD metrics are enabled by default in openshift-gitops")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		}
 
-		It("verifies Argo CD metrics can be disabled and re-enabled", func() {
+		It("verifies Argo CD metrics can be disabled and re-enabled", Label("openshift"), func() {
 
 			By("verifying Argo CD metrics are enabled by default in openshift-gitops")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		}
 
-		It("verifies Argo CD metrics can be disabled and re-enabled", Label("openshift"), func() {
+		It("verifies Argo CD metrics can be disabled and re-enabled", Label("notOnXKS"), func() {
 
 			By("verifying Argo CD metrics are enabled by default in openshift-gitops")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-106_validate_argocd_metrics_controller_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		}
 
-		It("verifies Argo CD metrics can be disabled and re-enabled", Label("openshfit"), func() {
+		It("verifies Argo CD metrics can be disabled and re-enabled", Label("openshift"), func() {
 
 			By("verifying Argo CD metrics are enabled by default in openshift-gitops")
 

--- a/test/openshift/e2e/ginkgo/sequential/1-107_validate_redis_scc_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-107_validate_redis_scc_test.go
@@ -32,7 +32,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that when Argo CD has HA enabled that the redis pods use restricted-v2 security policy", Label("notOnXKS"), func() {
+		It("verifies that when Argo CD has HA enabled that the redis pods use restricted-v2 security policy", Label("openshfit"), func() {
 
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-107_validate_redis_scc_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-107_validate_redis_scc_test.go
@@ -32,7 +32,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that when Argo CD has HA enabled that the redis pods use restricted-v2 security policy", func() {
+		It("verifies that when Argo CD has HA enabled that the redis pods use restricted-v2 security policy", Label("openshift"), func() {
 
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-107_validate_redis_scc_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-107_validate_redis_scc_test.go
@@ -32,7 +32,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that when Argo CD has HA enabled that the redis pods use restricted-v2 security policy", Label("openshift"), func() {
+		It("verifies that when Argo CD has HA enabled that the redis pods use restricted-v2 security policy", Label("notOnXKS"), func() {
 
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-107_validate_redis_scc_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-107_validate_redis_scc_test.go
@@ -32,7 +32,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that when Argo CD has HA enabled that the redis pods use restricted-v2 security policy", Label("openshfit"), func() {
+		It("verifies that when Argo CD has HA enabled that the redis pods use restricted-v2 security policy", Label("openshift"), func() {
 
 			By("verifying we are running on a cluster with at least 3 nodes. This is required for Redis HA")
 			nodeFixture.ExpectHasAtLeastXNodes(3)

--- a/test/openshift/e2e/ginkgo/sequential/1-110_validate_podsecurity_alerts_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-110_validate_podsecurity_alerts_test.go
@@ -28,7 +28,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies openshift-gitops: operator sets podSecurityLabelSync and OpenShift sets audit to restricted", Label("notOnXKS"), func() {
+		It("verifies openshift-gitops: operator sets podSecurityLabelSync and OpenShift sets audit to restricted", Label("openshfit"), func() {
 			gitopsNS := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "openshift-gitops",

--- a/test/openshift/e2e/ginkgo/sequential/1-110_validate_podsecurity_alerts_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-110_validate_podsecurity_alerts_test.go
@@ -28,7 +28,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies openshift-gitops: operator sets podSecurityLabelSync and OpenShift sets audit to restricted", func() {
+		It("verifies openshift-gitops: operator sets podSecurityLabelSync and OpenShift sets audit to restricted", Label("openshift"), func() {
 			gitopsNS := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "openshift-gitops",

--- a/test/openshift/e2e/ginkgo/sequential/1-110_validate_podsecurity_alerts_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-110_validate_podsecurity_alerts_test.go
@@ -28,7 +28,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies openshift-gitops: operator sets podSecurityLabelSync and OpenShift sets audit to restricted", Label("openshift"), func() {
+		It("verifies openshift-gitops: operator sets podSecurityLabelSync and OpenShift sets audit to restricted", Label("notOnXKS"), func() {
 			gitopsNS := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "openshift-gitops",

--- a/test/openshift/e2e/ginkgo/sequential/1-110_validate_podsecurity_alerts_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-110_validate_podsecurity_alerts_test.go
@@ -28,7 +28,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("verifies openshift-gitops: operator sets podSecurityLabelSync and OpenShift sets audit to restricted", Label("openshfit"), func() {
+		It("verifies openshift-gitops: operator sets podSecurityLabelSync and OpenShift sets audit to restricted", Label("openshift"), func() {
 			gitopsNS := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "openshift-gitops",

--- a/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
@@ -24,7 +24,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", Label("notOnXKS"), func() {
+		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", Label("openshfit"), func() {
 
 			By("verifying route of openshift-gitops Argo CD instance has expected values")
 			openshiftArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
@@ -24,7 +24,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", Label("openshift"), func() {
+		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", Label("notOnXKS"), func() {
 
 			By("verifying route of openshift-gitops Argo CD instance has expected values")
 			openshiftArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
@@ -24,7 +24,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", func() {
+		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", Label("openshift"), func() {
 
 			By("verifying route of openshift-gitops Argo CD instance has expected values")
 			openshiftArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
@@ -23,7 +23,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", Label("openshfit"), func() {
+		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", Label("openshift"), func() {
 
 			By("verifying route of openshift-gitops Argo CD instance has expected values")
 			openshiftArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
@@ -24,7 +24,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", Label("openshfit"), func() {
+		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", Label("openshift"), func() {
 
 			By("verifying route of openshift-gitops Argo CD instance has expected values")
 			openshiftArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
@@ -23,7 +23,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", Label("notOnXKS"), func() {
+		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", Label("openshfit"), func() {
 
 			By("verifying route of openshift-gitops Argo CD instance has expected values")
 			openshiftArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
@@ -23,7 +23,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", Label("openshift"), func() {
+		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", Label("notOnXKS"), func() {
 
 			By("verifying route of openshift-gitops Argo CD instance has expected values")
 			openshiftArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-111_validate_default_argocd_route_test.go
@@ -23,7 +23,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.EnsureSequentialCleanSlate()
 		})
 
-		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", func() {
+		It("ensuring that default openshift-gitops instance has expected default Argo CD server route, and that it is possible to modify the values on that default instance", Label("openshift"), func() {
 
 			By("verifying route of openshift-gitops Argo CD instance has expected values")
 			openshiftArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-112_validate_rollout_plugin_support_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-112_validate_rollout_plugin_support_test.go
@@ -35,7 +35,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that custom traffic management and metrics plugins can be added to Argo Rollouts instance via RolloutManager CR", Label("notOnXKS"), func() {
+		It("verifies that custom traffic management and metrics plugins can be added to Argo Rollouts instance via RolloutManager CR", Label("openshfit"), func() {
 
 			By("creating a new Argo Rollouts instance in openshift-gitops namespace, containing a custom traffic management plugin and a custom metrics plugin")
 			rm := &rolloutmanagerv1alpha1.RolloutManager{

--- a/test/openshift/e2e/ginkgo/sequential/1-112_validate_rollout_plugin_support_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-112_validate_rollout_plugin_support_test.go
@@ -35,7 +35,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that custom traffic management and metrics plugins can be added to Argo Rollouts instance via RolloutManager CR", func() {
+		It("verifies that custom traffic management and metrics plugins can be added to Argo Rollouts instance via RolloutManager CR", Label("openshift"), func() {
 
 			By("creating a new Argo Rollouts instance in openshift-gitops namespace, containing a custom traffic management plugin and a custom metrics plugin")
 			rm := &rolloutmanagerv1alpha1.RolloutManager{

--- a/test/openshift/e2e/ginkgo/sequential/1-112_validate_rollout_plugin_support_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-112_validate_rollout_plugin_support_test.go
@@ -35,7 +35,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that custom traffic management and metrics plugins can be added to Argo Rollouts instance via RolloutManager CR", Label("openshift"), func() {
+		It("verifies that custom traffic management and metrics plugins can be added to Argo Rollouts instance via RolloutManager CR", Label("notOnXKS"), func() {
 
 			By("creating a new Argo Rollouts instance in openshift-gitops namespace, containing a custom traffic management plugin and a custom metrics plugin")
 			rm := &rolloutmanagerv1alpha1.RolloutManager{

--- a/test/openshift/e2e/ginkgo/sequential/1-112_validate_rollout_plugin_support_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-112_validate_rollout_plugin_support_test.go
@@ -35,7 +35,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that custom traffic management and metrics plugins can be added to Argo Rollouts instance via RolloutManager CR", Label("openshfit"), func() {
+		It("verifies that custom traffic management and metrics plugins can be added to Argo Rollouts instance via RolloutManager CR", Label("openshift"), func() {
 
 			By("creating a new Argo Rollouts instance in openshift-gitops namespace, containing a custom traffic management plugin and a custom metrics plugin")
 			rm := &rolloutmanagerv1alpha1.RolloutManager{

--- a/test/openshift/e2e/ginkgo/sequential/1-113_validate_controller_role_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-113_validate_controller_role_test.go
@@ -76,7 +76,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail(testNS, "openshift-gitops")
 		})
 
-		It("validates openshift-gitops application-controller Role aggregates admin ClusterRole rules and removes them on delete", func() {
+		It("validates openshift-gitops application-controller Role aggregates admin ClusterRole rules and removes them on delete", Label("openshift"), func() {
 
 			By("creating a namespace managed by openshift-gitops")
 			testNS = fixture.CreateManagedNamespace("test-1-113-ns", "openshift-gitops")

--- a/test/openshift/e2e/ginkgo/sequential/1-114_validate_imagepullpolicy_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-114_validate_imagepullpolicy_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that imagePullPolicy from ArgoCD CR spec is propagated to all ArgoCD workload resources", Label("notOnXKS"), func() {
+		It("verifies that imagePullPolicy from ArgoCD CR spec is propagated to all ArgoCD workload resources", Label("openshfit"), func() {
 
 			By("creating a test namespace for ArgoCD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
@@ -138,7 +138,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies that imagePullPolicy works correctly on default openshift-gitops ArgoCD instance", Label("notOnXKS"), func() {
+		It("verifies that imagePullPolicy works correctly on default openshift-gitops ArgoCD instance", Label("openshfit"), func() {
 
 			openshiftGitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())
@@ -194,7 +194,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies default imagePullPolicy is applied to all ArgoCD workload resources when not specified in either CR spec or subscription", Label("notOnXKS"), func() {
+		It("verifies default imagePullPolicy is applied to all ArgoCD workload resources when not specified in either CR spec or subscription", Label("openshfit"), func() {
 
 			openshiftGitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-114_validate_imagepullpolicy_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-114_validate_imagepullpolicy_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that imagePullPolicy from ArgoCD CR spec is propagated to all ArgoCD workload resources", func() {
+		It("verifies that imagePullPolicy from ArgoCD CR spec is propagated to all ArgoCD workload resources", Label("openshift"), func() {
 
 			By("creating a test namespace for ArgoCD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
@@ -138,7 +138,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies that imagePullPolicy works correctly on default openshift-gitops ArgoCD instance", func() {
+		It("verifies that imagePullPolicy works correctly on default openshift-gitops ArgoCD instance", Label("openshift"), func() {
 
 			openshiftGitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())
@@ -194,7 +194,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies default imagePullPolicy is applied to all ArgoCD workload resources when not specified in either CR spec or subscription", func() {
+		It("verifies default imagePullPolicy is applied to all ArgoCD workload resources when not specified in either CR spec or subscription", Label("openshift"), func() {
 
 			openshiftGitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-114_validate_imagepullpolicy_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-114_validate_imagepullpolicy_test.go
@@ -49,7 +49,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that imagePullPolicy from ArgoCD CR spec is propagated to all ArgoCD workload resources", Label("openshift"), func() {
+		It("verifies that imagePullPolicy from ArgoCD CR spec is propagated to all ArgoCD workload resources", Label("notOnXKS"), func() {
 
 			By("creating a test namespace for ArgoCD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
@@ -138,7 +138,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies that imagePullPolicy works correctly on default openshift-gitops ArgoCD instance", Label("openshift"), func() {
+		It("verifies that imagePullPolicy works correctly on default openshift-gitops ArgoCD instance", Label("notOnXKS"), func() {
 
 			openshiftGitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())
@@ -194,7 +194,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies default imagePullPolicy is applied to all ArgoCD workload resources when not specified in either CR spec or subscription", Label("openshift"), func() {
+		It("verifies default imagePullPolicy is applied to all ArgoCD workload resources when not specified in either CR spec or subscription", Label("notOnXKS"), func() {
 
 			openshiftGitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-114_validate_imagepullpolicy_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-114_validate_imagepullpolicy_test.go
@@ -37,6 +37,7 @@ import (
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-114_validate_imagepullpolicy", func() {
+		// TODO: check if this test can use a new ArgoCD instance instead of the default openshift-gitops instance
 
 		var (
 			k8sClient client.Client
@@ -49,7 +50,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that imagePullPolicy from ArgoCD CR spec is propagated to all ArgoCD workload resources", Label("openshfit"), func() {
+		It("verifies that imagePullPolicy from ArgoCD CR spec is propagated to all ArgoCD workload resources", func() {
 
 			By("creating a test namespace for ArgoCD instance")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
@@ -138,7 +139,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies that imagePullPolicy works correctly on default openshift-gitops ArgoCD instance", Label("openshfit"), func() {
+		It("verifies that imagePullPolicy works correctly on default openshift-gitops ArgoCD instance", Label("openshift"), func() {
 
 			openshiftGitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())
@@ -194,7 +195,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("verifies default imagePullPolicy is applied to all ArgoCD workload resources when not specified in either CR spec or subscription", Label("openshfit"), func() {
+		It("verifies default imagePullPolicy is applied to all ArgoCD workload resources when not specified in either CR spec or subscription", Label("openshift"), func() {
 
 			openshiftGitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/openshift/e2e/ginkgo/sequential/1-115_validate_imagepullpolicy_console_plugin_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-115_validate_imagepullpolicy_console_plugin_test.go
@@ -37,7 +37,7 @@ import (
 
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
-	Context("1-115-validate_imagepullpolicy_gitopsservice", func() {
+	Context("1-115-validate_imagepullpolicy_gitopsservice", Label("openshift"), func() {
 
 		var (
 			ctx       context.Context

--- a/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
@@ -81,7 +81,7 @@ var (
 )
 
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
-	Context("1-120_repo_server_system_ca_trust", func() {
+	Context("1-120_repo_server_system_ca_trust", Label("notOnXKS"), func() {
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
 

--- a/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
@@ -81,7 +81,7 @@ var (
 )
 
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
-	Context("1-120_repo_server_system_ca_trust", Label("notOnXKS"), func() {
+	Context("1-120_repo_server_system_ca_trust", Label("openshfit"), func() {
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
 
@@ -100,7 +100,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			purgeCtbs()
 		})
 
-		It("ensures that missing Secret aborts startup", Label("notOnXKS"), func() {
+		It("ensures that missing Secret aborts startup", Label("openshfit"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with missing Secret")
@@ -162,7 +162,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			)))
 		})
 
-		It("ensures that CMs and Secrets are trusted in repo-server and plugins", Label("notOnXKS"), func() {
+		It("ensures that CMs and Secrets are trusted in repo-server and plugins", Label("openshfit"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			cmCert := createCmFromCert(ns, getCACert("github.com"))
@@ -210,7 +210,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyCorrectlyConfiguredTrust(ns)
 		})
 
-		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", Label("notOnXKS"), func() {
+		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", Label("openshfit"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -242,7 +242,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(trustedHelmApp).Should(appFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeUnknown))
 		})
 
-		It("ensures that empty trust keeps image certs in place", Label("notOnXKS"), func() {
+		It("ensures that empty trust keeps image certs in place", Label("openshfit"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -256,7 +256,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(repoServerSystemCaTrust(ns)).Should(trustCerts(BeNumerically(">", 100), Not(BeEmpty())))
 		})
 
-		It("ensures that Secrets and ConfigMaps get reconciled", Label("notOnXKS"), func() {
+		It("ensures that Secrets and ConfigMaps get reconciled", Label("openshfit"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust, but full of anticipation")

--- a/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
@@ -100,7 +100,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			purgeCtbs()
 		})
 
-		It("ensures that missing Secret aborts startup", Label("openshift"), func() {
+		It("ensures that missing Secret aborts startup", Label("notOnXKS"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with missing Secret")
@@ -162,7 +162,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			)))
 		})
 
-		It("ensures that CMs and Secrets are trusted in repo-server and plugins", Label("openshift"), func() {
+		It("ensures that CMs and Secrets are trusted in repo-server and plugins", Label("notOnXKS"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			cmCert := createCmFromCert(ns, getCACert("github.com"))
@@ -210,7 +210,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyCorrectlyConfiguredTrust(ns)
 		})
 
-		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", Label("openshift"), func() {
+		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", Label("notOnXKS"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -242,7 +242,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(trustedHelmApp).Should(appFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeUnknown))
 		})
 
-		It("ensures that empty trust keeps image certs in place", Label("openshift"), func() {
+		It("ensures that empty trust keeps image certs in place", Label("notOnXKS"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -256,7 +256,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(repoServerSystemCaTrust(ns)).Should(trustCerts(BeNumerically(">", 100), Not(BeEmpty())))
 		})
 
-		It("ensures that Secrets and ConfigMaps get reconciled", Label("openshift"), func() {
+		It("ensures that Secrets and ConfigMaps get reconciled", Label("notOnXKS"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust, but full of anticipation")

--- a/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
@@ -100,7 +100,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			purgeCtbs()
 		})
 
-		It("ensures that missing Secret aborts startup", func() {
+		It("ensures that missing Secret aborts startup", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with missing Secret")
@@ -162,7 +162,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			)))
 		})
 
-		It("ensures that CMs and Secrets are trusted in repo-server and plugins", func() {
+		It("ensures that CMs and Secrets are trusted in repo-server and plugins", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			cmCert := createCmFromCert(ns, getCACert("github.com"))
@@ -210,7 +210,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyCorrectlyConfiguredTrust(ns)
 		})
 
-		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", func() {
+		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -242,7 +242,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(trustedHelmApp).Should(appFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeUnknown))
 		})
 
-		It("ensures that empty trust keeps image certs in place", func() {
+		It("ensures that empty trust keeps image certs in place", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -256,7 +256,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(repoServerSystemCaTrust(ns)).Should(trustCerts(BeNumerically(">", 100), Not(BeEmpty())))
 		})
 
-		It("ensures that Secrets and ConfigMaps get reconciled", func() {
+		It("ensures that Secrets and ConfigMaps get reconciled", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust, but full of anticipation")

--- a/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
@@ -81,7 +81,7 @@ var (
 )
 
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
-	Context("1-120_repo_server_system_ca_trust", Label("openshfit"), func() {
+	Context("1-120_repo_server_system_ca_trust", Label("openshift"), func() {
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
 
@@ -100,7 +100,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			purgeCtbs()
 		})
 
-		It("ensures that missing Secret aborts startup", Label("openshfit"), func() {
+		It("ensures that missing Secret aborts startup", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with missing Secret")
@@ -162,7 +162,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			)))
 		})
 
-		It("ensures that CMs and Secrets are trusted in repo-server and plugins", Label("openshfit"), func() {
+		It("ensures that CMs and Secrets are trusted in repo-server and plugins", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			cmCert := createCmFromCert(ns, getCACert("github.com"))
@@ -210,7 +210,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyCorrectlyConfiguredTrust(ns)
 		})
 
-		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", Label("openshfit"), func() {
+		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -242,7 +242,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(trustedHelmApp).Should(appFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeUnknown))
 		})
 
-		It("ensures that empty trust keeps image certs in place", Label("openshfit"), func() {
+		It("ensures that empty trust keeps image certs in place", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -256,7 +256,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(repoServerSystemCaTrust(ns)).Should(trustCerts(BeNumerically(">", 100), Not(BeEmpty())))
 		})
 
-		It("ensures that Secrets and ConfigMaps get reconciled", Label("openshfit"), func() {
+		It("ensures that Secrets and ConfigMaps get reconciled", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust, but full of anticipation")

--- a/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
@@ -79,7 +79,7 @@ var (
 )
 
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
-	Context("1-120_repo_server_system_ca_trust", Label("notOnXKS"), func() {
+	Context("1-120_repo_server_system_ca_trust", Label("openshfit"), func() {
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
 
@@ -98,7 +98,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			purgeCtbs()
 		})
 
-		It("ensures that missing Secret aborts startup", Label("notOnXKS"), func() {
+		It("ensures that missing Secret aborts startup", Label("openshfit"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with missing Secret")
@@ -160,7 +160,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			)))
 		})
 
-		It("ensures that CMs and Secrets are trusted in repo-server and plugins", Label("notOnXKS"), func() {
+		It("ensures that CMs and Secrets are trusted in repo-server and plugins", Label("openshfit"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			cmCert := createCmFromCert(ns, getCACert("github.com"))
@@ -208,7 +208,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyCorrectlyConfiguredTrust(ns)
 		})
 
-		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", Label("notOnXKS"), func() {
+		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", Label("openshfit"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -240,7 +240,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(trustedHelmApp).Should(appFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeUnknown))
 		})
 
-		It("ensures that empty trust keeps image certs in place", Label("notOnXKS"), func() {
+		It("ensures that empty trust keeps image certs in place", Label("openshfit"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -254,7 +254,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(repoServerSystemCaTrust(ns)).Should(trustCerts(BeNumerically(">", 100), Not(BeEmpty())))
 		})
 
-		It("ensures that Secrets and ConfigMaps get reconciled", Label("notOnXKS"), func() {
+		It("ensures that Secrets and ConfigMaps get reconciled", Label("openshfit"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust, but full of anticipation")

--- a/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
@@ -98,7 +98,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			purgeCtbs()
 		})
 
-		It("ensures that missing Secret aborts startup", func() {
+		It("ensures that missing Secret aborts startup", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with missing Secret")
@@ -160,7 +160,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			)))
 		})
 
-		It("ensures that CMs and Secrets are trusted in repo-server and plugins", func() {
+		It("ensures that CMs and Secrets are trusted in repo-server and plugins", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			cmCert := createCmFromCert(ns, getCACert("github.com"))
@@ -208,7 +208,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyCorrectlyConfiguredTrust(ns)
 		})
 
-		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", func() {
+		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -240,7 +240,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(trustedHelmApp).Should(appFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeUnknown))
 		})
 
-		It("ensures that empty trust keeps image certs in place", func() {
+		It("ensures that empty trust keeps image certs in place", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -254,7 +254,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(repoServerSystemCaTrust(ns)).Should(trustCerts(BeNumerically(">", 100), Not(BeEmpty())))
 		})
 
-		It("ensures that Secrets and ConfigMaps get reconciled", func() {
+		It("ensures that Secrets and ConfigMaps get reconciled", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust, but full of anticipation")

--- a/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
@@ -79,7 +79,7 @@ var (
 )
 
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
-	Context("1-120_repo_server_system_ca_trust", Label("openshfit"), func() {
+	Context("1-120_repo_server_system_ca_trust", Label("openshift"), func() {
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
 
@@ -98,7 +98,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			purgeCtbs()
 		})
 
-		It("ensures that missing Secret aborts startup", Label("openshfit"), func() {
+		It("ensures that missing Secret aborts startup", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with missing Secret")
@@ -160,7 +160,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			)))
 		})
 
-		It("ensures that CMs and Secrets are trusted in repo-server and plugins", Label("openshfit"), func() {
+		It("ensures that CMs and Secrets are trusted in repo-server and plugins", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			cmCert := createCmFromCert(ns, getCACert("github.com"))
@@ -208,7 +208,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyCorrectlyConfiguredTrust(ns)
 		})
 
-		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", Label("openshfit"), func() {
+		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -240,7 +240,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(trustedHelmApp).Should(appFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeUnknown))
 		})
 
-		It("ensures that empty trust keeps image certs in place", Label("openshfit"), func() {
+		It("ensures that empty trust keeps image certs in place", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -254,7 +254,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(repoServerSystemCaTrust(ns)).Should(trustCerts(BeNumerically(">", 100), Not(BeEmpty())))
 		})
 
-		It("ensures that Secrets and ConfigMaps get reconciled", Label("openshfit"), func() {
+		It("ensures that Secrets and ConfigMaps get reconciled", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust, but full of anticipation")

--- a/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
@@ -98,7 +98,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			purgeCtbs()
 		})
 
-		It("ensures that missing Secret aborts startup", Label("openshift"), func() {
+		It("ensures that missing Secret aborts startup", Label("notOnXKS"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with missing Secret")
@@ -160,7 +160,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			)))
 		})
 
-		It("ensures that CMs and Secrets are trusted in repo-server and plugins", Label("openshift"), func() {
+		It("ensures that CMs and Secrets are trusted in repo-server and plugins", Label("notOnXKS"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			cmCert := createCmFromCert(ns, getCACert("github.com"))
@@ -208,7 +208,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyCorrectlyConfiguredTrust(ns)
 		})
 
-		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", Label("openshift"), func() {
+		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", Label("notOnXKS"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -240,7 +240,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(trustedHelmApp).Should(appFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeUnknown))
 		})
 
-		It("ensures that empty trust keeps image certs in place", Label("openshift"), func() {
+		It("ensures that empty trust keeps image certs in place", Label("notOnXKS"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
@@ -254,7 +254,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(repoServerSystemCaTrust(ns)).Should(trustCerts(BeNumerically(">", 100), Not(BeEmpty())))
 		})
 
-		It("ensures that Secrets and ConfigMaps get reconciled", Label("openshift"), func() {
+		It("ensures that Secrets and ConfigMaps get reconciled", Label("notOnXKS"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust, but full of anticipation")

--- a/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
@@ -79,7 +79,7 @@ var (
 )
 
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
-	Context("1-120_repo_server_system_ca_trust", func() {
+	Context("1-120_repo_server_system_ca_trust", Label("notOnXKS"), func() {
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
 

--- a/test/openshift/e2e/ginkgo/sequential/1-120_validate_running_must_gather.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_validate_running_must_gather.go
@@ -62,7 +62,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verified the files collected for must gather are valid", Label("notOnXKS"), func() {
+		It("verified the files collected for must gather are valid", Label("openshfit"), func() {
 			By("creating namespace-scoped Argo CD instance")
 			ns, nsCleanup := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			defer nsCleanup()

--- a/test/openshift/e2e/ginkgo/sequential/1-120_validate_running_must_gather.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_validate_running_must_gather.go
@@ -62,7 +62,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verified the files collected for must gather are valid", Label("openshift"), func() {
+		It("verified the files collected for must gather are valid", Label("notOnXKS"), func() {
 			By("creating namespace-scoped Argo CD instance")
 			ns, nsCleanup := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			defer nsCleanup()

--- a/test/openshift/e2e/ginkgo/sequential/1-120_validate_running_must_gather.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_validate_running_must_gather.go
@@ -62,7 +62,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verified the files collected for must gather are valid", func() {
+		It("verified the files collected for must gather are valid", Label("openshift"), func() {
 			By("creating namespace-scoped Argo CD instance")
 			ns, nsCleanup := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			defer nsCleanup()

--- a/test/openshift/e2e/ginkgo/sequential/1-120_validate_running_must_gather.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_validate_running_must_gather.go
@@ -62,7 +62,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verified the files collected for must gather are valid", Label("openshfit"), func() {
+		It("verified the files collected for must gather are valid", Label("openshift"), func() {
 			By("creating namespace-scoped Argo CD instance")
 			ns, nsCleanup := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			defer nsCleanup()

--- a/test/openshift/e2e/ginkgo/sequential/1-121-valiate_resource_constraints_gitopsservice_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-121-valiate_resource_constraints_gitopsservice_test.go
@@ -73,7 +73,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("validates that GitOpsService can take in custom resource constraints", Label("notOnXKS"), func() {
+		It("validates that GitOpsService can take in custom resource constraints", Label("openshfit"), func() {
 			csv := clusterserviceversion.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()
@@ -154,7 +154,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourceConstraints(k8sClient, "cluster", expectedReq, expectedLim)
 		})
 
-		It("validates that GitOpsService can update resource constraints", Label("notOnXKS"), func() {
+		It("validates that GitOpsService can update resource constraints", Label("openshfit"), func() {
 			csv := clusterserviceversion.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()
@@ -225,7 +225,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourceConstraints(k8sClient, "cluster", expectedReq, expectedLim)
 		})
 
-		It("validates gitops plugin and backend can have different resource constraints", Label("notOnXKS"), func() {
+		It("validates gitops plugin and backend can have different resource constraints", Label("openshfit"), func() {
 			csv := clusterserviceversion.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()

--- a/test/openshift/e2e/ginkgo/sequential/1-121-valiate_resource_constraints_gitopsservice_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-121-valiate_resource_constraints_gitopsservice_test.go
@@ -73,7 +73,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("validates that GitOpsService can take in custom resource constraints", Label("openshift"), func() {
+		It("validates that GitOpsService can take in custom resource constraints", Label("notOnXKS"), func() {
 			csv := clusterserviceversion.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()
@@ -154,7 +154,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourceConstraints(k8sClient, "cluster", expectedReq, expectedLim)
 		})
 
-		It("validates that GitOpsService can update resource constraints", Label("openshift"), func() {
+		It("validates that GitOpsService can update resource constraints", Label("notOnXKS"), func() {
 			csv := clusterserviceversion.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()
@@ -225,7 +225,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourceConstraints(k8sClient, "cluster", expectedReq, expectedLim)
 		})
 
-		It("validates gitops plugin and backend can have different resource constraints", Label("openshift"), func() {
+		It("validates gitops plugin and backend can have different resource constraints", Label("notOnXKS"), func() {
 			csv := clusterserviceversion.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()

--- a/test/openshift/e2e/ginkgo/sequential/1-121-valiate_resource_constraints_gitopsservice_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-121-valiate_resource_constraints_gitopsservice_test.go
@@ -73,7 +73,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("validates that GitOpsService can take in custom resource constraints", func() {
+		It("validates that GitOpsService can take in custom resource constraints", Label("openshift"), func() {
 			csv := clusterserviceversion.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()
@@ -154,7 +154,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourceConstraints(k8sClient, "cluster", expectedReq, expectedLim)
 		})
 
-		It("validates that GitOpsService can update resource constraints", func() {
+		It("validates that GitOpsService can update resource constraints", Label("openshift"), func() {
 			csv := clusterserviceversion.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()
@@ -225,7 +225,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourceConstraints(k8sClient, "cluster", expectedReq, expectedLim)
 		})
 
-		It("validates gitops plugin and backend can have different resource constraints", func() {
+		It("validates gitops plugin and backend can have different resource constraints", Label("openshift"), func() {
 			csv := clusterserviceversion.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()

--- a/test/openshift/e2e/ginkgo/sequential/1-121-valiate_resource_constraints_gitopsservice_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-121-valiate_resource_constraints_gitopsservice_test.go
@@ -73,7 +73,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("validates that GitOpsService can take in custom resource constraints", Label("openshfit"), func() {
+		It("validates that GitOpsService can take in custom resource constraints", Label("openshift"), func() {
 			csv := clusterserviceversion.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()
@@ -154,7 +154,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourceConstraints(k8sClient, "cluster", expectedReq, expectedLim)
 		})
 
-		It("validates that GitOpsService can update resource constraints", Label("openshfit"), func() {
+		It("validates that GitOpsService can update resource constraints", Label("openshift"), func() {
 			csv := clusterserviceversion.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()
@@ -225,7 +225,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			verifyResourceConstraints(k8sClient, "cluster", expectedReq, expectedLim)
 		})
 
-		It("validates gitops plugin and backend can have different resource constraints", Label("openshfit"), func() {
+		It("validates gitops plugin and backend can have different resource constraints", Label("openshift"), func() {
 			csv := clusterserviceversion.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()

--- a/test/openshift/e2e/ginkgo/sequential/1-122_validate_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-122_validate_namespace_test.go
@@ -71,7 +71,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("Should validate namespace for new resources", Label("notOnXKS"), func() {
+		It("Should validate namespace for new resources", Label("openshfit"), func() {
 
 			argoNamespace, cleanupArgoNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			sourceNamespace, cleanupSourceNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
@@ -163,7 +163,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("Should validate namespace for existing resources", Label("notOnXKS"), func() {
+		It("Should validate namespace for existing resources", Label("openshfit"), func() {
 
 			argoNamespace, cleanupArgoNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			sourceNamespace, cleanupSourceNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-122_validate_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-122_validate_namespace_test.go
@@ -71,7 +71,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("Should validate namespace for new resources", Label("openshift"), func() {
+		It("Should validate namespace for new resources", Label("notOnXKS"), func() {
 
 			argoNamespace, cleanupArgoNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			sourceNamespace, cleanupSourceNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
@@ -163,7 +163,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("Should validate namespace for existing resources", Label("openshift"), func() {
+		It("Should validate namespace for existing resources", Label("notOnXKS"), func() {
 
 			argoNamespace, cleanupArgoNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			sourceNamespace, cleanupSourceNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-122_validate_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-122_validate_namespace_test.go
@@ -71,7 +71,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("Should validate namespace for new resources", func() {
+		It("Should validate namespace for new resources", Label("openshift"), func() {
 
 			argoNamespace, cleanupArgoNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			sourceNamespace, cleanupSourceNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
@@ -163,7 +163,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("Should validate namespace for existing resources", func() {
+		It("Should validate namespace for existing resources", Label("openshift"), func() {
 
 			argoNamespace, cleanupArgoNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			sourceNamespace, cleanupSourceNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-122_validate_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-122_validate_namespace_test.go
@@ -71,7 +71,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 		})
 
-		It("Should validate namespace for new resources", Label("openshfit"), func() {
+		It("Should validate namespace for new resources", func() {
 
 			argoNamespace, cleanupArgoNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			sourceNamespace, cleanupSourceNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
@@ -163,7 +163,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("Should validate namespace for existing resources", Label("openshfit"), func() {
+		It("Should validate namespace for existing resources", func() {
 
 			argoNamespace, cleanupArgoNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			sourceNamespace, cleanupSourceNamespace = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/sequential/1-123_validate_list_order_comparison_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-123_validate_list_order_comparison_test.go
@@ -117,7 +117,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail(openshiftGitopsNamespace)
 		})
 
-		It("Should not trigger updates when only list order differs", Label("notOnXKS"), func() {
+		It("Should not trigger updates when only list order differs", Label("openshfit"), func() {
 			gitopsService := &gitopsoperatorv1alpha1.GitopsService{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 			}
@@ -214,7 +214,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("Should trigger updates when actual changes are made", Label("notOnXKS"), func() {
+		It("Should trigger updates when actual changes are made", Label("openshfit"), func() {
 			gitopsService := &gitopsoperatorv1alpha1.GitopsService{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 			}

--- a/test/openshift/e2e/ginkgo/sequential/1-123_validate_list_order_comparison_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-123_validate_list_order_comparison_test.go
@@ -117,7 +117,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail(openshiftGitopsNamespace)
 		})
 
-		It("Should not trigger updates when only list order differs", Label("openshift"), func() {
+		It("Should not trigger updates when only list order differs", Label("notOnXKS"), func() {
 			gitopsService := &gitopsoperatorv1alpha1.GitopsService{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 			}
@@ -214,7 +214,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("Should trigger updates when actual changes are made", Label("openshift"), func() {
+		It("Should trigger updates when actual changes are made", Label("notOnXKS"), func() {
 			gitopsService := &gitopsoperatorv1alpha1.GitopsService{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 			}

--- a/test/openshift/e2e/ginkgo/sequential/1-123_validate_list_order_comparison_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-123_validate_list_order_comparison_test.go
@@ -117,7 +117,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail(openshiftGitopsNamespace)
 		})
 
-		It("Should not trigger updates when only list order differs", func() {
+		It("Should not trigger updates when only list order differs", Label("openshift"), func() {
 			gitopsService := &gitopsoperatorv1alpha1.GitopsService{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 			}
@@ -214,7 +214,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("Should trigger updates when actual changes are made", func() {
+		It("Should trigger updates when actual changes are made", Label("openshift"), func() {
 			gitopsService := &gitopsoperatorv1alpha1.GitopsService{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 			}

--- a/test/openshift/e2e/ginkgo/sequential/1-123_validate_list_order_comparison_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-123_validate_list_order_comparison_test.go
@@ -117,7 +117,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail(openshiftGitopsNamespace)
 		})
 
-		It("Should not trigger updates when only list order differs", Label("openshfit"), func() {
+		It("Should not trigger updates when only list order differs", Label("openshift"), func() {
 			gitopsService := &gitopsoperatorv1alpha1.GitopsService{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 			}
@@ -214,7 +214,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		})
 
-		It("Should trigger updates when actual changes are made", Label("openshfit"), func() {
+		It("Should trigger updates when actual changes are made", Label("openshift"), func() {
 			gitopsService := &gitopsoperatorv1alpha1.GitopsService{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 			}


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:
Operator currently only tested on OpenShift. This PR enables running e2e suite on non-OpenShift Kubernetes (xKS) by separating OpenShift-dependent tests via labels. Run --label-filter="!openshift" on xKS to skip tests requiring Routes/ConsoleLinks/SCCs/OLM. Broadens CI coverage to vanilla k8s environments.

Currently we are only labellling tests that are passing on openshift and failing on xks, this currenlty helps with the filtering.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
NON_OLM=true ./bin/ginkgo -v --trace -p --timeout 240m -r ./test/openshift/e2e/ginkgo/sequential 
NON_OLM=true ./bin/ginkgo -v --trace -p --timeout 240m -r ./test/openshift/e2e/ginkgo/parallel