### PR TITLE
test(configmap): mask the token value annotation in the ArgoCD UI/CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.2
 require (
 	github.com/argoproj-labs/argo-rollouts-manager v0.0.9-0.20260505092152-3e07addcb2cb
 	github.com/argoproj-labs/argocd-image-updater v1.2.1
-	github.com/argoproj-labs/argocd-operator v0.19.0-rc1.0.20260708101223-285ef22c61ea
+	github.com/argoproj-labs/argocd-operator v0.19.0-rc1.0.20260716120206-de224a6ab38e
 	github.com/argoproj/argo-cd/gitops-engine v0.7.1-0.20250908182407-97ad5b59a627
 	github.com/argoproj/argo-cd/v3 v3.4.2
 	github.com/go-logr/logr v1.4.3
@@ -21,7 +21,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.74.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.28.0
-	golang.org/x/mod v0.37.0
+	golang.org/x/mod v0.38.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.35.2
@@ -189,7 +189,7 @@ require (
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
-	golang.org/x/tools v0.45.0 // indirect
+	golang.org/x/tools v0.47.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/argoproj-labs/argo-rollouts-manager v0.0.9-0.20260505092152-3e07addcb
 github.com/argoproj-labs/argo-rollouts-manager v0.0.9-0.20260505092152-3e07addcb2cb/go.mod h1:Ouqjtkj48SPJhW6r00CYqJ4uM7QDy3D4tinKIK9Y69Q=
 github.com/argoproj-labs/argocd-image-updater v1.2.1 h1:yaJdmpFOOKTkC9688/a7jjOBLpCREj7Wdnmn4A3v1nU=
 github.com/argoproj-labs/argocd-image-updater v1.2.1/go.mod h1:sBS1JqoM9R0QhIDVD4bdWS/GejDQaFwdFUV+yE9TzjA=
-github.com/argoproj-labs/argocd-operator v0.19.0-rc1.0.20260708101223-285ef22c61ea h1:v8qfDg4zlWu+YQB+RRmWT86Krp0+HIYs89ZQ6+eVKCc=
-github.com/argoproj-labs/argocd-operator v0.19.0-rc1.0.20260708101223-285ef22c61ea/go.mod h1:VahP4wwBBcLux2I/rNgcPo4nVWmuUOvE4K2Wqg5M0vQ=
+github.com/argoproj-labs/argocd-operator v0.19.0-rc1.0.20260716120206-de224a6ab38e h1:ZhAGLdcI5+/48qvzTPeSReusNmr0+Joo+4OE3Zmi00U=
+github.com/argoproj-labs/argocd-operator v0.19.0-rc1.0.20260716120206-de224a6ab38e/go.mod h1:vVd7s8gzmMfA3pueuG5ylvvdIk3aFlk+M3uf0xrIvDE=
 github.com/argoproj/argo-cd/gitops-engine v0.0.0-20260512203152-0dc6b1b57dd5 h1:IMzPK0gt1lZRDHtiKGzU0VAez0FmT2veytxlmE2AwyU=
 github.com/argoproj/argo-cd/gitops-engine v0.0.0-20260512203152-0dc6b1b57dd5/go.mod h1:6Q1KZzkeKlnCpzzZ1Fu72+WPMAt+ZeMD9KOO6aMjW68=
 github.com/argoproj/argo-cd/v3 v3.4.2 h1:S3j0K34uGW4geWiM88+0cHcCEtInn2Sa9U7/Sa18L7Y=
@@ -538,8 +538,8 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.25.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/mod v0.26.0/go.mod h1:/j6NAhSk8iQ723BGAUyoAcn7SlD7s15Dp9Nd/SfeaFQ=
-golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
-golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=
+golang.org/x/mod v0.38.0/go.mod h1:V6Xz0pq8TQ3dGqVQ1FVHuelZpAL0uNhSkk9ogYP3c40=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/test/openshift/e2e/ginkgo/parallel/1-132_validate_sensitive_annotation_masking_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-132_validate_sensitive_annotation_masking_test.go
@@ -124,8 +124,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			By("logging in to the namespace-scoped ArgoCD instance via CLI with a per-test config file")
 			Eventually(func() bool {
 				output, loginErr := argocdFixture.RunArgoCDCLI(
-					"--config", cliConfigFile.Name(),
 					"login", routeHost,
+					"--config", cliConfigFile.Name(),
 					"--username", "admin",
 					"--password", adminPassword,
 					"--insecure",

--- a/test/openshift/e2e/ginkgo/parallel/1-132_validate_sensitive_annotation_masking_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-132_validate_sensitive_annotation_masking_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallel
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj/argo-cd/gitops-engine/pkg/health"
+	argocdv1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
+	appFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/application"
+	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
+	configmapFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/configmap"
+	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
+	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
+
+	Context("1-132_validate_sensitive_annotation_masking_test", func() {
+
+		// tokenAnnotationKey is the OpenShift annotation that carries a service-account
+		// token in plain text on secrets of type kubernetes.io/dockercfg.
+		const tokenAnnotationKey = "openshift.io/token-secret.value"
+
+		// sensitiveToken is a fake token that represents the kind of value OpenShift
+		// stores in the annotation.  It must NOT appear in argocd app diff output.
+		const sensitiveToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.fake-openshift-service-account-token"
+
+		var (
+			k8sClient client.Client
+			ctx       context.Context
+		)
+
+		BeforeEach(func() {
+			fixture.EnsureParallelCleanSlate()
+			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
+			ctx = context.Background()
+		})
+
+		It("verifies that resource.sensitive.mask.annotations is set in argocd-cm and that the openshift.io/token-secret.value annotation is hidden from diff computation so the app stays Synced and the token is never visible in CLI output", func() {
+
+			fixture.EnsureRunningOnOpenShift()
+
+			By("creating namespace for the ArgoCD instance")
+			argoCDNS, cleanupArgoCDNS := fixture.CreateNamespaceWithCleanupFunc("test-1-132-argocd")
+			defer cleanupArgoCDNS()
+
+			By("creating a namespace-scoped ArgoCD instance with the server Route enabled")
+			argoCD := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{Name: "argocd", Namespace: argoCDNS.Name},
+				Spec: argov1beta1api.ArgoCDSpec{
+					Server: argov1beta1api.ArgoCDServerSpec{
+						Route: argov1beta1api.ArgoCDRouteSpec{Enabled: true},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("waiting for ArgoCD instance to be available")
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+
+			By("verifying argocd-cm has resource.sensitive.mask.annotations set to openshift.io/token-secret.value")
+			argocdCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "argocd-cm", Namespace: argoCDNS.Name}}
+			Eventually(argocdCM).Should(k8sFixture.ExistByName())
+			Eventually(argocdCM).Should(configmapFixture.HaveStringDataKeyValue("resource.sensitive.mask.annotations", tokenAnnotationKey))
+
+			By("creating a managed namespace for app deployment")
+			appNS, cleanupAppNS := fixture.CreateManagedNamespaceWithCleanupFunc("test-1-132-apps", argoCDNS.Name)
+			defer cleanupAppNS()
+
+			By("creating a per-test ArgoCD CLI config file to prevent parallel-test login context conflicts")
+			cliConfigFile, err := os.CreateTemp("", "argocd-e2e-1-132-*.yaml")
+			Expect(err).ToNot(HaveOccurred())
+			cliConfigFile.Close()
+			defer os.Remove(cliConfigFile.Name())
+
+			By("waiting for the ArgoCD server Route to be admitted and assigned a host")
+			argoCDRoute := &routev1.Route{ObjectMeta: metav1.ObjectMeta{Name: "argocd-server", Namespace: argoCDNS.Name}}
+			Eventually(argoCDRoute).Should(k8sFixture.ExistByName())
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(argoCDRoute), argoCDRoute); err != nil {
+					return false
+				}
+				return argoCDRoute.Spec.Host != "" ||
+					(len(argoCDRoute.Status.Ingress) > 0 && argoCDRoute.Status.Ingress[0].Host != "")
+			}, "2m", "5s").Should(BeTrue())
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(argoCDRoute), argoCDRoute)).To(Succeed())
+			routeHost := argoCDRoute.Spec.Host
+			if routeHost == "" {
+				routeHost = argoCDRoute.Status.Ingress[0].Host
+			}
+
+			By("reading the admin password from the ArgoCD cluster secret")
+			adminSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "argocd-cluster", Namespace: argoCDNS.Name}}
+			Eventually(adminSecret).Should(k8sFixture.ExistByName())
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(adminSecret), adminSecret)).To(Succeed())
+			adminPassword := string(adminSecret.Data["admin.password"])
+
+			By("logging in to the namespace-scoped ArgoCD instance via CLI with a per-test config file")
+			Eventually(func() bool {
+				output, loginErr := argocdFixture.RunArgoCDCLI(
+					"--config", cliConfigFile.Name(),
+					"login", routeHost,
+					"--username", "admin",
+					"--password", adminPassword,
+					"--insecure",
+					"--skip-test-tls",
+				)
+				if loginErr != nil {
+					GinkgoWriter.Println("CLI login error:", loginErr, "output:", output)
+					return false
+				}
+				return strings.Contains(output, "logged in successfully")
+			}, "3m", "10s").Should(BeTrue())
+
+			By("creating an ArgoCD Application that deploys a kubernetes.io/dockercfg secret (the git source does NOT include the sensitive annotation)")
+			app := &argocdv1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{Name: "dockercfg-test-app", Namespace: argoCDNS.Name},
+				Spec: argocdv1alpha1.ApplicationSpec{
+					Project: "default",
+					Source: &argocdv1alpha1.ApplicationSource{
+						RepoURL:        "https://github.com/redhat-developer/gitops-operator",
+						Path:           "test/examples/dockercfg-token-secret",
+						TargetRevision: "HEAD",
+					},
+					Destination: argocdv1alpha1.ApplicationDestination{
+						Server:    "https://kubernetes.default.svc",
+						Namespace: appNS.Name,
+					},
+					SyncPolicy: &argocdv1alpha1.SyncPolicy{
+						Automated: &argocdv1alpha1.SyncPolicyAutomated{
+							// SelfHeal is disabled to make the test deterministic: without it
+							// ArgoCD would still auto-sync (reverting the annotation) on the
+							// next periodic cycle before the Consistently check completes.
+							SelfHeal: ptr.To(false),
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+			By("waiting for the app to sync and the dockercfg secret to be deployed")
+			Eventually(app, "5m", "5s").Should(appFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
+			Eventually(app, "5m", "5s").Should(appFixture.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
+
+			By("simulating OpenShift behavior: adding openshift.io/token-secret.value to the live secret")
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "dockercfg-token-secret", Namespace: appNS.Name}}
+			Eventually(secret).Should(k8sFixture.ExistByName())
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+			if secret.Annotations == nil {
+				secret.Annotations = map[string]string{}
+			}
+			secret.Annotations[tokenAnnotationKey] = sensitiveToken
+			Expect(k8sClient.Update(ctx, secret)).To(Succeed())
+
+			By("forcing a single ArgoCD refresh so the live state is re-evaluated")
+			// --grpc-web suppresses the gRPC-over-HTTP2 warning emitted by newer ArgoCD CLIs
+			_, refreshErr := argocdFixture.RunArgoCDCLI(
+				"--config", cliConfigFile.Name(),
+				"app", "get", "dockercfg-test-app",
+				"--refresh", "--insecure", "--grpc-web",
+			)
+			Expect(refreshErr).NotTo(HaveOccurred())
+
+			By("verifying the app STAYS Synced even though the annotation is present on the live secret")
+			// resource.sensitive.mask.annotations strips the annotation from the normalized
+			// manifest before diff computation, so the live drift is invisible to ArgoCD.
+			// The app must never transition to OutOfSync – that is the feature under test.
+			Consistently(app, "30s", "5s").Should(appFixture.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
+
+			By("running argocd app diff and verifying the sensitive token value is not visible in the output")
+			// argocd app diff exits 0 when there are no differences and 1 when differences exist.
+			// Asserting no error therefore also proves ArgoCD computed an empty diff, which
+			// is the expected outcome when the annotation is properly masked.
+			diffOutput, diffErr := argocdFixture.RunArgoCDCLI(
+				"--config", cliConfigFile.Name(),
+				"app", "diff", "dockercfg-test-app",
+				"--insecure", "--grpc-web",
+			)
+			GinkgoWriter.Println("argocd app diff output:", diffOutput)
+			Expect(diffErr).NotTo(HaveOccurred(), diffOutput)
+			Expect(diffOutput).NotTo(
+				ContainSubstring(sensitiveToken),
+				"sensitive token value must not appear in argocd app diff output",
+			)
+		})
+	})
+})


### PR DESCRIPTION
This PR has temporarilly changes in `go.mod` and `test/openshift/e2e/ginkgo/parallel/1-132_validate_sensitive_annotation_masking_test.go`.

1. go.mod uses temp commit `github.com/argoproj-labs/argocd-operator v0.0.0-20260715184606-28cf63dec3bb` that will be replaced with master commit when https://github.com/argoproj-labs/argocd-operator/pull/2284 is merged 

UPD: done

2. 
```
					Source: &argocdv1alpha1.ApplicationSource{
						RepoURL:        "https://github.com/dkarpele/gitops-operator",
						Path:           "test/examples/dockercfg-token-secret",
						TargetRevision: "dk-GITOPS-10509",
					},
```
will be replaced with
```
					Source: &argocdv1alpha1.ApplicationSource{
						RepoURL:        "https://github.com/redhat-developer/gitops-operator",
						Path:           "test/examples/dockercfg-token-secret",
						TargetRevision: "HEAD",
					},
```

UPD: done

3. I created a separate PR to push `test/examples/dockercfg-token-secret/secret.yaml` to master https://github.com/redhat-developer/gitops-operator/pull/1222

UPD: done

**What type of PR is this?**
/kind failing-test

**What does this PR do / why we need it**:
E2e Test for https://github.com/argoproj-labs/argocd-operator/pull/2284: feat(configmap): mask the token value annotation in the ArgoCD UI/CLI on OpenShift


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://redhat.atlassian.net/browse/GITOPS-10509

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [*] E2E Test

**How to test changes / Special notes to the reviewer**: