### PR TITLE
feat(gitops-backend): Configure TLS MinVersion and Ciphers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -312,7 +312,7 @@ func main() {
 			Client:                client,
 			Scheme:                mgr.GetScheme(),
 			DisableDefaultInstall: strings.ToLower(os.Getenv(common.DisableDefaultInstallEnvVar)) == "true",
-			CentralTLSProfile:     configv1.TLSProfileSpec{},
+			CentralTLSProfile:     profile,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "GitopsService")
 			os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -312,8 +312,7 @@ func main() {
 			Client:                client,
 			Scheme:                mgr.GetScheme(),
 			DisableDefaultInstall: strings.ToLower(os.Getenv(common.DisableDefaultInstallEnvVar)) == "true",
-			TLSMinVersion:         string(profile.MinTLSVersion),
-			TLSCiphers:            profile.Ciphers,
+			CentralTLSProfile:     configv1.TLSProfileSpec{},
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "GitopsService")
 			os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -312,6 +312,8 @@ func main() {
 			Client:                client,
 			Scheme:                mgr.GetScheme(),
 			DisableDefaultInstall: strings.ToLower(os.Getenv(common.DisableDefaultInstallEnvVar)) == "true",
+			TLSMinVersion:         string(profile.MinTLSVersion),
+			TLSCiphers:            profile.Ciphers,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "GitopsService")
 			os.Exit(1)

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -27,7 +27,6 @@ import (
 	argoapp "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	argocommon "github.com/argoproj-labs/argocd-operator/common"
 	argocdcontroller "github.com/argoproj-labs/argocd-operator/controllers/argocd"
-	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 	argocdutil "github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 	"github.com/go-logr/logr"
 	version "github.com/hashicorp/go-version"
@@ -812,10 +811,10 @@ func newBackendDeployment(ns types.NamespacedName, crImagePullPolicy corev1.Pull
 			Value: insecureEnvVarValue,
 		},
 	}
-	if argoutil.TLSProtocolVersionString(CentralTLSProfile.MinTLSVersion) != "" {
+	if argocdutil.TLSProtocolVersionString(CentralTLSProfile.MinTLSVersion) != "" {
 		env = append(env, corev1.EnvVar{
 			Name:  "TLS_MIN_VERSION",
-			Value: argoutil.TLSProtocolVersionString(CentralTLSProfile.MinTLSVersion),
+			Value: argocdutil.TLSProtocolVersionString(CentralTLSProfile.MinTLSVersion),
 		})
 	}
 

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -27,6 +27,7 @@ import (
 	argoapp "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	argocommon "github.com/argoproj-labs/argocd-operator/common"
 	argocdcontroller "github.com/argoproj-labs/argocd-operator/controllers/argocd"
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 	argocdutil "github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 	"github.com/go-logr/logr"
 	version "github.com/hashicorp/go-version"
@@ -54,6 +55,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 var logs = logf.Log.WithName("controller_gitopsservice")
@@ -146,10 +149,8 @@ type ReconcileGitopsService struct {
 
 	// disableDefaultInstall, if true, will ensure that the default ArgoCD instance is not instantiated in the openshift-gitops namespace.
 	DisableDefaultInstall bool
-	// TLSMinVersion is the minimum TLS version to use for the GitOps plugin.
-	TLSMinVersion string
-	// TLSCiphers is the list of supported TLS ciphers for the GitOps plugin.
-	TLSCiphers []string
+	//CentralTLSProfile contains MinVersion and CipherSuites
+	CentralTLSProfile configv1.TLSProfileSpec
 }
 
 // +kubebuilder:rbac:groups=config.openshift.io,resources=authentications,verbs=get;list;watch
@@ -662,7 +663,7 @@ func (r *ReconcileGitopsService) reconcileBackend(gitopsserviceNamespacedName ty
 
 	// Define a new backend Deployment
 	{
-		deploymentObj := newBackendDeployment(gitopsserviceNamespacedName, instance.Spec.ImagePullPolicy, r.TLSMinVersion, r.TLSCiphers)
+		deploymentObj := newBackendDeployment(gitopsserviceNamespacedName, instance.Spec.ImagePullPolicy, r.CentralTLSProfile)
 
 		// Add SeccompProfile based on cluster version
 		util.AddSeccompProfileForOpenShift(r.Client, &deploymentObj.Spec.Template.Spec)
@@ -800,20 +801,7 @@ func objectMeta(resourceName string, namespace string, opts ...func(*metav1.Obje
 	return objectMeta
 }
 
-func TLSVersionToBackend(tlsVersion string) string {
-	versionMap := map[string]string{
-		"VersionTLS12": "1.2",
-		"VersionTLS13": "1.3",
-		"VersionTLS11": "1.1",
-		"VersionTLS10": "1",
-	}
-	if v, ok := versionMap[tlsVersion]; ok {
-		return v
-	}
-	return "" // default fallback
-}
-
-func newBackendDeployment(ns types.NamespacedName, crImagePullPolicy corev1.PullPolicy, TLSMinVersion string, TLSCiphers []string) *appsv1.Deployment {
+func newBackendDeployment(ns types.NamespacedName, crImagePullPolicy corev1.PullPolicy, CentralTLSProfile configv1.TLSProfileSpec) *appsv1.Deployment {
 	image := os.Getenv(backendImageEnvName)
 	if image == "" {
 		image = backendImage
@@ -824,17 +812,17 @@ func newBackendDeployment(ns types.NamespacedName, crImagePullPolicy corev1.Pull
 			Value: insecureEnvVarValue,
 		},
 	}
-	if TLSVersionToBackend(TLSMinVersion) != "" {
+	if argoutil.TLSProtocolVersionString(CentralTLSProfile.MinTLSVersion) != "" {
 		env = append(env, corev1.EnvVar{
 			Name:  "TLS_MIN_VERSION",
-			Value: TLSVersionToBackend(TLSMinVersion),
+			Value: argoutil.TLSProtocolVersionString(CentralTLSProfile.MinTLSVersion),
 		})
 	}
 
-	if len(TLSCiphers) > 0 {
+	if len(CentralTLSProfile.Ciphers) > 0 {
 		env = append(env, corev1.EnvVar{
 			Name:  "TLS_CIPHER_SUITES",
-			Value: strings.Join(TLSCiphers, ":"),
+			Value: strings.Join(CentralTLSProfile.Ciphers, ":"),
 		})
 	}
 	podSpec := corev1.PodSpec{

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -146,6 +146,10 @@ type ReconcileGitopsService struct {
 
 	// disableDefaultInstall, if true, will ensure that the default ArgoCD instance is not instantiated in the openshift-gitops namespace.
 	DisableDefaultInstall bool
+	// TLSMinVersion is the minimum TLS version to use for the GitOps plugin.
+	TLSMinVersion string
+	// TLSCiphers is the list of supported TLS ciphers for the GitOps plugin.
+	TLSCiphers []string
 }
 
 // +kubebuilder:rbac:groups=config.openshift.io,resources=authentications,verbs=get;list;watch
@@ -658,7 +662,7 @@ func (r *ReconcileGitopsService) reconcileBackend(gitopsserviceNamespacedName ty
 
 	// Define a new backend Deployment
 	{
-		deploymentObj := newBackendDeployment(gitopsserviceNamespacedName, instance.Spec.ImagePullPolicy)
+		deploymentObj := newBackendDeployment(gitopsserviceNamespacedName, instance.Spec.ImagePullPolicy, r.TLSMinVersion, r.TLSCiphers)
 
 		// Add SeccompProfile based on cluster version
 		util.AddSeccompProfileForOpenShift(r.Client, &deploymentObj.Spec.Template.Spec)
@@ -796,10 +800,42 @@ func objectMeta(resourceName string, namespace string, opts ...func(*metav1.Obje
 	return objectMeta
 }
 
-func newBackendDeployment(ns types.NamespacedName, crImagePullPolicy corev1.PullPolicy) *appsv1.Deployment {
+func TLSVersionToBackend(tlsVersion string) string {
+	versionMap := map[string]string{
+		"VersionTLS12": "1.2",
+		"VersionTLS13": "1.3",
+		"VersionTLS11": "1.1",
+		"VersionTLS10": "1",
+	}
+	if v, ok := versionMap[tlsVersion]; ok {
+		return v
+	}
+	return "" // default fallback
+}
+
+func newBackendDeployment(ns types.NamespacedName, crImagePullPolicy corev1.PullPolicy, TLSMinVersion string, TLSCiphers []string) *appsv1.Deployment {
 	image := os.Getenv(backendImageEnvName)
 	if image == "" {
 		image = backendImage
+	}
+	env := []corev1.EnvVar{
+		{
+			Name:  insecureEnvVar,
+			Value: insecureEnvVarValue,
+		},
+	}
+	if TLSVersionToBackend(TLSMinVersion) != "" {
+		env = append(env, corev1.EnvVar{
+			Name:  "TLS_MIN_VERSION",
+			Value: TLSVersionToBackend(TLSMinVersion),
+		})
+	}
+
+	if len(TLSCiphers) > 0 {
+		env = append(env, corev1.EnvVar{
+			Name:  "TLS_CIPHER_SUITES",
+			Value: strings.Join(TLSCiphers, ":"),
+		})
 	}
 	podSpec := corev1.PodSpec{
 		Containers: []corev1.Container{
@@ -814,12 +850,7 @@ func newBackendDeployment(ns types.NamespacedName, crImagePullPolicy corev1.Pull
 						ContainerPort: port, // should come from flag
 					},
 				},
-				Env: []corev1.EnvVar{
-					{
-						Name:  insecureEnvVar,
-						Value: insecureEnvVarValue,
-					},
-				},
+				Env: env,
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						MountPath: "/etc/gitops/ssl",

--- a/controllers/gitopsservice_controller_test.go
+++ b/controllers/gitopsservice_controller_test.go
@@ -62,7 +62,7 @@ func TestImageFromEnvVariable(t *testing.T) {
 		image := "quay.io/org/test"
 		t.Setenv(backendImageEnvName, image)
 
-		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), "", nil)
+		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), configv1.TLSProfileSpec{})
 
 		got := deployment.Spec.Template.Spec.Containers[0].Image
 		if got != image {
@@ -70,7 +70,7 @@ func TestImageFromEnvVariable(t *testing.T) {
 		}
 	})
 	t.Run("env variable for image not found", func(t *testing.T) {
-		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), "", nil)
+		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), configv1.TLSProfileSpec{})
 
 		got := deployment.Spec.Template.Spec.Containers[0].Image
 		if got != backendImage {
@@ -79,7 +79,7 @@ func TestImageFromEnvVariable(t *testing.T) {
 	})
 
 	t.Run("TLS Min Version 1.3 and empty ciphers", func(t *testing.T) {
-		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), string(configv1.VersionTLS13), nil)
+		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), configv1.TLSProfileSpec{MinTLSVersion: configv1.VersionTLS13})
 		var gotTLSMinVersion string
 		for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
 			if env.Name == "TLS_MIN_VERSION" {
@@ -93,7 +93,7 @@ func TestImageFromEnvVariable(t *testing.T) {
 	})
 
 	t.Run("TLS Min Version 1.2 and empty ciphers", func(t *testing.T) {
-		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), string(configv1.VersionTLS12), nil)
+		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), configv1.TLSProfileSpec{MinTLSVersion: configv1.VersionTLS12})
 		var gotTLSMinVersion string
 		for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
 			if env.Name == "TLS_MIN_VERSION" {
@@ -107,7 +107,7 @@ func TestImageFromEnvVariable(t *testing.T) {
 	})
 
 	t.Run("TLS Min Version 1.3 and single ciphers", func(t *testing.T) {
-		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), string(configv1.VersionTLS13), []string{"dummy1"})
+		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), configv1.TLSProfileSpec{MinTLSVersion: configv1.VersionTLS13, Ciphers: []string{"dummy1"}})
 		var gotTLSMinVersion string
 		var gotTLSCiphers string
 		for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
@@ -127,7 +127,7 @@ func TestImageFromEnvVariable(t *testing.T) {
 	})
 
 	t.Run("TLS Min Version 1.3 and double ciphers", func(t *testing.T) {
-		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), string(configv1.VersionTLS13), []string{"dummy1", "dummy2"})
+		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), configv1.TLSProfileSpec{MinTLSVersion: configv1.VersionTLS13, Ciphers: []string{"dummy1", "dummy2"}})
 		var gotTLSMinVersion string
 		var gotTLSCiphers string
 		for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {

--- a/controllers/gitopsservice_controller_test.go
+++ b/controllers/gitopsservice_controller_test.go
@@ -62,7 +62,7 @@ func TestImageFromEnvVariable(t *testing.T) {
 		image := "quay.io/org/test"
 		t.Setenv(backendImageEnvName, image)
 
-		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent))
+		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), "", nil)
 
 		got := deployment.Spec.Template.Spec.Containers[0].Image
 		if got != image {
@@ -70,7 +70,7 @@ func TestImageFromEnvVariable(t *testing.T) {
 		}
 	})
 	t.Run("env variable for image not found", func(t *testing.T) {
-		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent))
+		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), "", nil)
 
 		got := deployment.Spec.Template.Spec.Containers[0].Image
 		if got != backendImage {
@@ -78,6 +78,73 @@ func TestImageFromEnvVariable(t *testing.T) {
 		}
 	})
 
+	t.Run("TLS Min Version 1.3 and empty ciphers", func(t *testing.T) {
+		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), string(configv1.VersionTLS13), nil)
+		var gotTLSMinVersion string
+		for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+			if env.Name == "TLS_MIN_VERSION" {
+				gotTLSMinVersion = env.Value
+				break
+			}
+		}
+		if gotTLSMinVersion != "1.3" {
+			t.Errorf("TLS Min Version mismatch: got %s, want %s", gotTLSMinVersion, "1.3")
+		}
+	})
+
+	t.Run("TLS Min Version 1.2 and empty ciphers", func(t *testing.T) {
+		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), string(configv1.VersionTLS12), nil)
+		var gotTLSMinVersion string
+		for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+			if env.Name == "TLS_MIN_VERSION" {
+				gotTLSMinVersion = env.Value
+				break
+			}
+		}
+		if gotTLSMinVersion != "1.2" {
+			t.Errorf("TLS Min Version mismatch: got %s, want %s", gotTLSMinVersion, "1.2")
+		}
+	})
+
+	t.Run("TLS Min Version 1.3 and single ciphers", func(t *testing.T) {
+		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), string(configv1.VersionTLS13), []string{"dummy1"})
+		var gotTLSMinVersion string
+		var gotTLSCiphers string
+		for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+			if env.Name == "TLS_MIN_VERSION" {
+				gotTLSMinVersion = env.Value
+				break
+			}
+			if env.Name == "TLS_CIPHER_SUITES" {
+				gotTLSCiphers = env.Value
+				break
+			}
+		}
+		if gotTLSMinVersion != "1.3" && gotTLSCiphers != "dummy1" {
+			t.Errorf("TLS Min Version mismatch: got %s, want %s", gotTLSMinVersion, "1.3")
+			t.Errorf("TLS Cipher mismatch: got %s, want %s", gotTLSCiphers, "dummy1")
+		}
+	})
+
+	t.Run("TLS Min Version 1.3 and double ciphers", func(t *testing.T) {
+		deployment := newBackendDeployment(ns, corev1.PullPolicy(corev1.PullIfNotPresent), string(configv1.VersionTLS13), []string{"dummy1", "dummy2"})
+		var gotTLSMinVersion string
+		var gotTLSCiphers string
+		for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+			if env.Name == "TLS_MIN_VERSION" {
+				gotTLSMinVersion = env.Value
+				break
+			}
+			if env.Name == "TLS_CIPHER_SUITES" {
+				gotTLSCiphers = env.Value
+				break
+			}
+		}
+		if gotTLSMinVersion != "1.3" && gotTLSCiphers != "dummy1:dummy2" {
+			t.Errorf("TLS Min Version mismatch: got %s, want %s", gotTLSMinVersion, "1.3")
+			t.Errorf("TLS Cipher mismatch: got %s, want %s", gotTLSCiphers, "dummy1:dummy2")
+		}
+	})
 }
 
 func TestReconcileDefaultForArgoCDNodeplacement(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement
**What does this PR do / why we need it**:

To make gitops backend component complaint with OCP 5.0 goals, making tls minversion and ciphers configurable.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
https://redhat.atlassian.net/browse/GITOPS-10474
**Test acceptance criteria**:

* [x] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
> deploy gitops operator on ocp cluster, check the apiserver and tls settings accordingly for create and update scenarios.