### PR TITLE
feat: decouple console plugin from default ArgoCD instance 

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -311,12 +311,26 @@ func main() {
 		}
 	}
 
+	pluginNamespace := "openshift-gitops-operator"
+	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		if os.IsNotExist(err) {
+			setupLog.Info(fmt.Sprintf("Unable to retrieve the operator's running namespace via serviceaccount: %v. Using default namespace '%s'. This is expected when running locally.", err, pluginNamespace))
+		} else {
+			setupLog.Error(err, "Error retrieving operator's running namespace")
+			os.Exit(1)
+		}
+	} else {
+		pluginNamespace = strings.TrimSpace(string(data))
+	}
+
 	if util.IsOpenShiftCluster() {
 		if err = (&controllers.ReconcileGitopsService{
 			Client:                client,
 			Scheme:                mgr.GetScheme(),
 			DisableDefaultInstall: strings.ToLower(os.Getenv(common.DisableDefaultInstallEnvVar)) == "true",
 			CentralTLSProfile:     profile,
+			PluginNamespace:       pluginNamespace,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "GitopsService")
 			os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -311,17 +311,10 @@ func main() {
 		}
 	}
 
-	pluginNamespace := "openshift-gitops-operator"
-	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	pluginNamespace, err := util.GetOperatorNamespace()
 	if err != nil {
-		if os.IsNotExist(err) {
-			setupLog.Info(fmt.Sprintf("Unable to retrieve the operator's running namespace via serviceaccount: %v. Using default namespace '%s'. This is expected when running locally.", err, pluginNamespace))
-		} else {
-			setupLog.Error(err, "Error retrieving operator's running namespace")
-			os.Exit(1)
-		}
-	} else {
-		pluginNamespace = strings.TrimSpace(string(data))
+		setupLog.Error(err, "Error retrieving operator's running namespace")
+		os.Exit(1)
 	}
 
 	if util.IsOpenShiftCluster() {

--- a/controllers/consoleplugin.go
+++ b/controllers/consoleplugin.go
@@ -552,7 +552,6 @@ func getConfigMapHash(cm *corev1.ConfigMap) string {
 
 func (r *ReconcileGitopsService) reconcileConfigMap(instance *pipelinesv1alpha1.GitopsService, request reconcile.Request, newPluginConfigMap *corev1.ConfigMap) (reconcile.Result, error) {
 	reqLogger := logs.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	newPluginConfigMap = r.pluginConfigMap(r.PluginNamespace)
 
 	if err := controllerutil.SetControllerReference(instance, newPluginConfigMap, r.Scheme); err != nil {
 		return reconcile.Result{}, err
@@ -582,6 +581,41 @@ func (r *ReconcileGitopsService) reconcileConfigMap(instance *pipelinesv1alpha1.
 		}
 	}
 	return reconcile.Result{}, nil
+}
+
+// cleanupOldPluginResources removes plugin resources from the old namespace (openshift-gitops) after they have been moved to the operator namespace, since owner references on the cluster-scoped GitopsService CR won't trigger garbage collection.
+func (r *ReconcileGitopsService) cleanupOldPluginResources(ctx context.Context) error {
+	if r.PluginNamespace == serviceNamespace {
+		return nil
+	}
+
+	reqLogger := logs.WithValues()
+
+	oldDeploy := &appsv1.Deployment{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: gitopsPluginName, Namespace: serviceNamespace}, oldDeploy); err == nil {
+		reqLogger.Info("Cleaning up old plugin Deployment from previous namespace", "Namespace", serviceNamespace)
+		if err := r.Client.Delete(ctx, oldDeploy); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete old plugin Deployment from namespace %s: %w", serviceNamespace, err)
+		}
+	}
+
+	oldSvc := &corev1.Service{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: gitopsPluginName, Namespace: serviceNamespace}, oldSvc); err == nil {
+		reqLogger.Info("Cleaning up old plugin Service from previous namespace", "Namespace", serviceNamespace)
+		if err := r.Client.Delete(ctx, oldSvc); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete old plugin Service from namespace %s: %w", serviceNamespace, err)
+		}
+	}
+
+	oldCM := &corev1.ConfigMap{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: httpdConfigMapName, Namespace: serviceNamespace}, oldCM); err == nil {
+		reqLogger.Info("Cleaning up old plugin ConfigMap from previous namespace", "Namespace", serviceNamespace)
+		if err := r.Client.Delete(ctx, oldCM); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete old plugin ConfigMap from namespace %s: %w", serviceNamespace, err)
+		}
+	}
+
+	return nil
 }
 
 // reconcilePlugin is the entry point for reconciling all console plugin resources.

--- a/controllers/consoleplugin.go
+++ b/controllers/consoleplugin.go
@@ -145,7 +145,7 @@ func getPluginPodSpec(crImagePullPolicy corev1.PullPolicy, isPF5 bool) corev1.Po
 	return podSpec
 }
 
-func pluginDeployment(crImagePullPolicy corev1.PullPolicy, isPF5 bool) *appsv1.Deployment {
+func pluginDeployment(namespace string, crImagePullPolicy corev1.PullPolicy, isPF5 bool) *appsv1.Deployment {
 	podSpec := getPluginPodSpec(crImagePullPolicy, isPF5)
 	template := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -159,13 +159,13 @@ func pluginDeployment(crImagePullPolicy corev1.PullPolicy, isPF5 bool) *appsv1.D
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gitopsPluginName,
-			Namespace: serviceNamespace,
+			Namespace: namespace,
 			Labels: map[string]string{
 				kubeAppLabelApp:              gitopsPluginName,
 				kubeAppLabelComponent:        gitopsPluginName,
 				kubeAppLabelInstance:         gitopsPluginName,
 				kubeAppLabelPartOf:           gitopsPluginName,
-				kubeAppLabelRuntimeNamespace: serviceNamespace,
+				kubeAppLabelRuntimeNamespace: namespace,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -180,7 +180,7 @@ func pluginDeployment(crImagePullPolicy corev1.PullPolicy, isPF5 bool) *appsv1.D
 	}
 }
 
-func consolePlugin() *consolev1.ConsolePlugin {
+func consolePlugin(namespace string) *consolev1.ConsolePlugin {
 	return &consolev1.ConsolePlugin{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: gitopsPluginName,
@@ -191,7 +191,7 @@ func consolePlugin() *consolev1.ConsolePlugin {
 				Type: consolev1.Service,
 				Service: &consolev1.ConsolePluginService{
 					Name:      gitopsPluginName,
-					Namespace: serviceNamespace,
+					Namespace: namespace,
 					Port:      servicePort,
 					BasePath:  "/",
 				},
@@ -203,7 +203,7 @@ func consolePlugin() *consolev1.ConsolePlugin {
 	}
 }
 
-func pluginService() *corev1.Service {
+func pluginService(namespace string) *corev1.Service {
 	spec := corev1.ServiceSpec{
 		Selector: map[string]string{
 			kubeAppLabelApp: gitopsPluginName,
@@ -219,7 +219,7 @@ func pluginService() *corev1.Service {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gitopsPluginName,
-			Namespace: serviceNamespace,
+			Namespace: namespace,
 			Labels: map[string]string{
 				kubeAppLabelApp:       gitopsPluginName,
 				kubeAppLabelComponent: gitopsPluginName,
@@ -281,13 +281,13 @@ ServerRoot "/etc/httpd"
 }
 
 // pluginConfigMap creates the ConfigMap with dynamic httpd.conf
-func (r *ReconcileGitopsService) pluginConfigMap() *corev1.ConfigMap {
+func (r *ReconcileGitopsService) pluginConfigMap(namespace string) *corev1.ConfigMap {
 	httpdConfig := r.buildHttpdConfig()
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      httpdConfigMapName,
-			Namespace: serviceNamespace,
+			Namespace: namespace,
 			Labels: map[string]string{
 				kubeAppLabelApp:    gitopsPluginName,
 				kubeAppLabelPartOf: gitopsPluginName,
@@ -371,7 +371,7 @@ func sortTolerations(tolerations []corev1.Toleration) []corev1.Toleration {
 
 func (r *ReconcileGitopsService) reconcileDeployment(cr *pipelinesv1alpha1.GitopsService, request reconcile.Request, newPluginConfigMap *corev1.ConfigMap, isPF5 bool) (reconcile.Result, error) {
 	reqLogger := logs.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	newPluginDeployment := pluginDeployment(cr.Spec.ImagePullPolicy, isPF5)
+	newPluginDeployment := pluginDeployment(r.PluginNamespace, cr.Spec.ImagePullPolicy, isPF5)
 
 	if err := controllerutil.SetControllerReference(cr, newPluginDeployment, r.Scheme); err != nil {
 		return reconcile.Result{}, err
@@ -456,7 +456,7 @@ func (r *ReconcileGitopsService) reconcileDeployment(cr *pipelinesv1alpha1.Gitop
 
 func (r *ReconcileGitopsService) reconcileService(instance *pipelinesv1alpha1.GitopsService, request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := logs.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	pluginServiceRef := pluginService()
+	pluginServiceRef := pluginService(r.PluginNamespace)
 	// Set GitopsService instance as the owner and controller
 	if err := controllerutil.SetControllerReference(instance, pluginServiceRef, r.Scheme); err != nil {
 		return reconcile.Result{}, err
@@ -496,7 +496,7 @@ func (r *ReconcileGitopsService) reconcileService(instance *pipelinesv1alpha1.Gi
 
 func (r *ReconcileGitopsService) reconcileConsolePlugin(instance *pipelinesv1alpha1.GitopsService, request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := logs.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	newConsolePlugin := consolePlugin()
+	newConsolePlugin := consolePlugin(r.PluginNamespace)
 
 	if err := controllerutil.SetControllerReference(instance, newConsolePlugin, r.Scheme); err != nil {
 		return reconcile.Result{}, err
@@ -507,7 +507,7 @@ func (r *ReconcileGitopsService) reconcileConsolePlugin(instance *pipelinesv1alp
 	if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: gitopsPluginName},
 		existingPlugin); err != nil {
 		if errors.IsNotFound(err) {
-			reqLogger.Info("Creating a new ConsolePlugin", "Namespace", serviceNamespace, "Name", gitopsPluginName)
+			reqLogger.Info("Creating a new ConsolePlugin", "Namespace", r.PluginNamespace, "Name", gitopsPluginName)
 			err = r.Client.Create(context.TODO(), newConsolePlugin)
 			if err != nil {
 				reqLogger.Error(err, "Error creating a new console plugin",
@@ -552,6 +552,7 @@ func getConfigMapHash(cm *corev1.ConfigMap) string {
 
 func (r *ReconcileGitopsService) reconcileConfigMap(instance *pipelinesv1alpha1.GitopsService, request reconcile.Request, newPluginConfigMap *corev1.ConfigMap) (reconcile.Result, error) {
 	reqLogger := logs.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	newPluginConfigMap = r.pluginConfigMap(r.PluginNamespace)
 
 	if err := controllerutil.SetControllerReference(instance, newPluginConfigMap, r.Scheme); err != nil {
 		return reconcile.Result{}, err
@@ -593,7 +594,7 @@ func (r *ReconcileGitopsService) reconcilePlugin(instance *pipelinesv1alpha1.Git
 	}
 
 	// Generate ConfigMap once
-	newPluginConfigMap := r.pluginConfigMap()
+	newPluginConfigMap := r.pluginConfigMap(r.PluginNamespace)
 
 	if result, err := r.reconcileService(instance, request); err != nil {
 		return result, err

--- a/controllers/consoleplugin_test.go
+++ b/controllers/consoleplugin_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestPlugin(t *testing.T) {
-	testConsolePlugin := consolePlugin()
+	testConsolePlugin := consolePlugin(serviceNamespace)
 
 	testDisplayName := displayName
 	assert.Equal(t, testConsolePlugin.Spec.DisplayName, testDisplayName)

--- a/controllers/consoleplugin_test.go
+++ b/controllers/consoleplugin_test.go
@@ -602,7 +602,7 @@ func TestPlugin_reconcileDeployment_changedTemplateLabels(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(newGitopsService(), d).Build()
 			reconciler := newReconcileGitOpsService(fakeClient, s)
 
-			_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+			_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 			assertNoError(t, err)
 
 			deployment := &appsv1.Deployment{}
@@ -647,7 +647,7 @@ func TestPlugin_reconcileDeployment_changedContainers(t *testing.T) {
 		assert.DeepEqual(t, deployment.Spec.Template.Spec.Containers[0].SecurityContext, securityContextForPlugin())
 	}
 
-	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 	assertNoError(t, err)
 
 	// There should be a new console plugin deployment created
@@ -672,7 +672,7 @@ func TestPlugin_reconcileDeployment_changedContainers(t *testing.T) {
 	assertNoError(t, err)
 
 	// Verify if the containers are reconciled back to the default values
-	_, err = reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+	_, err = reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 	assertNoError(t, err)
 
 	deployment = &appsv1.Deployment{}
@@ -979,7 +979,7 @@ func TestPlugin_reconcileDeployment_infraNodeSelectorNotInPodSpec(t *testing.T) 
 	fakeClient := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(gitopsService).Build()
 	reconciler := newReconcileGitOpsService(fakeClient, s)
 
-	_, err := reconciler.reconcileDeployment(gitopsService, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+	_, err := reconciler.reconcileDeployment(gitopsService, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 	assertNoError(t, err)
 
 	deployment := &appsv1.Deployment{}
@@ -999,7 +999,7 @@ func TestPlugin_reconcileDeployment(t *testing.T) {
 	reconciler := newReconcileGitOpsService(fakeClient, s)
 	instance := &pipelinesv1alpha1.GitopsService{}
 
-	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 	assertNoError(t, err)
 
 	deployment := &appsv1.Deployment{}
@@ -1036,7 +1036,7 @@ func TestPlugin_reconcileDeployment_ChangedResources(t *testing.T) {
 		},
 	}
 
-	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 	assertNoError(t, err)
 
 	deployment := &appsv1.Deployment{}
@@ -1056,7 +1056,7 @@ func TestPlugin_ReconcileDeployment_DefaultResourceValues(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(newGitopsService()).Build()
 	reconciler := newReconcileGitOpsService(fakeClient, s)
 	instance := &pipelinesv1alpha1.GitopsService{}
-	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 	assertNoError(t, err)
 
 	deployment := &appsv1.Deployment{}
@@ -1096,7 +1096,7 @@ func TestPlugin_ReconcileDeployment_ChangeExistingResourceValues(t *testing.T) {
 			Resources: Resources,
 		},
 	}
-	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 	assertNoError(t, err)
 
 	deployment := &appsv1.Deployment{}
@@ -1120,7 +1120,7 @@ func TestPlugin_ReconcileDeployment_ChangeExistingResourceValues(t *testing.T) {
 	}
 	instance.Spec.ConsolePlugin.Backend.Resources, instance.Spec.ConsolePlugin.GitopsPlugin.Resources = updatedResources, updatedResources
 
-	_, err = reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+	_, err = reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 	assertNoError(t, err)
 
 	deployment = &appsv1.Deployment{}
@@ -1593,7 +1593,7 @@ func TestPlug_reconcileConfigMap(t *testing.T) {
 	reconciler := newReconcileGitOpsService(fakeClient, s)
 
 	instance := &pipelinesv1alpha1.GitopsService{}
-	_, err := reconciler.reconcileConfigMap(instance, newRequest(serviceNamespace, httpdConfigMapName), reconciler.pluginConfigMap())
+	_, err := reconciler.reconcileConfigMap(instance, newRequest(serviceNamespace, httpdConfigMapName), reconciler.pluginConfigMap(serviceNamespace))
 	assertNoError(t, err)
 
 	configMap := &corev1.ConfigMap{}
@@ -1669,7 +1669,7 @@ func TestReconcileDeployment_NoUpdateWhenContainersOrderDiffers(t *testing.T) {
 	instance := &pipelinesv1alpha1.GitopsService{}
 
 	// Create deployment
-	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 	assertNoError(t, err)
 
 	// Get the deployment and capture initial ResourceVersion and Generation
@@ -1692,7 +1692,7 @@ func TestReconcileDeployment_NoUpdateWhenContainersOrderDiffers(t *testing.T) {
 	}
 
 	// Reconcile again - should NOT trigger an update
-	_, err = reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+	_, err = reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 	assertNoError(t, err)
 
 	// Verify no update was triggered
@@ -1715,7 +1715,7 @@ func TestReconcileDeployment_NoUpdateWhenVolumesOrderDiffers(t *testing.T) {
 	instance := &pipelinesv1alpha1.GitopsService{}
 
 	// Create deployment
-	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 	assertNoError(t, err)
 
 	// Get the deployment
@@ -1740,7 +1740,7 @@ func TestReconcileDeployment_NoUpdateWhenVolumesOrderDiffers(t *testing.T) {
 		genAfterManualUpdate := deployment.Generation
 
 		// Reconcile again - should NOT trigger an update
-		_, err = reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+		_, err = reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 		assertNoError(t, err)
 
 		// Verify no update was triggered
@@ -1786,7 +1786,7 @@ func TestReconcileDeployment_NoUpdateWhenTolerationsOrderDiffers(t *testing.T) {
 	reconciler := newReconcileGitOpsService(fakeClient, s)
 
 	// Create deployment
-	_, err := reconciler.reconcileDeployment(gitopsService, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+	_, err := reconciler.reconcileDeployment(gitopsService, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 	assertNoError(t, err)
 
 	// Get the deployment
@@ -1811,7 +1811,7 @@ func TestReconcileDeployment_NoUpdateWhenTolerationsOrderDiffers(t *testing.T) {
 		genAfterManualUpdate := deployment.Generation
 
 		// Reconcile again - should NOT trigger an update
-		_, err = reconciler.reconcileDeployment(gitopsService, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+		_, err = reconciler.reconcileDeployment(gitopsService, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 		assertNoError(t, err)
 
 		// Verify no update was triggered
@@ -1837,7 +1837,7 @@ func TestReconcileDeployment_UpdateWhenActualChange(t *testing.T) {
 	instance := &pipelinesv1alpha1.GitopsService{}
 
 	// Create deployment
-	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+	_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 	assertNoError(t, err)
 
 	// Get the deployment and capture initial ResourceVersion and Generation
@@ -1852,7 +1852,7 @@ func TestReconcileDeployment_UpdateWhenActualChange(t *testing.T) {
 	assertNoError(t, err)
 
 	// Reconcile again - should trigger an update
-	_, err = reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), false)
+	_, err = reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), false)
 	assertNoError(t, err)
 
 	// Verify update was triggered
@@ -2022,7 +2022,7 @@ func TestReconcileDeployment_AddsHashAnnotation(t *testing.T) {
 			"httpd.conf": "config-v1",
 		},
 	}
-	r := &ReconcileGitopsService{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(instance).Build(), Scheme: scheme}
+	r := &ReconcileGitopsService{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(instance).Build(), Scheme: scheme, PluginNamespace: serviceNamespace}
 	_, err := r.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsService), cm, false)
 	assert.NilError(t, err)
 	deployment := &appsv1.Deployment{}
@@ -2055,7 +2055,7 @@ func TestReconcileDeployment_UpdatesHashAnnotationWhenConfigChanges(t *testing.T
 			"httpd.conf": "config-v2",
 		},
 	}
-	r := &ReconcileGitopsService{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(instance).Build(), Scheme: scheme}
+	r := &ReconcileGitopsService{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(instance).Build(), Scheme: scheme, PluginNamespace: serviceNamespace}
 	_, err := r.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsService), cm1, false)
 	assert.NilError(t, err)
 	_, err = r.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsService), cm2, false)
@@ -2113,7 +2113,7 @@ func TestPlugin_reconcileDeployment_PluginImage(t *testing.T) {
 			reconciler := newReconcileGitOpsService(fakeClient, s)
 			instance := &pipelinesv1alpha1.GitopsService{}
 
-			_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(), test.isPF5)
+			_, err := reconciler.reconcileDeployment(instance, newRequest(serviceNamespace, gitopsPluginName), reconciler.pluginConfigMap(serviceNamespace), test.isPF5)
 			assertNoError(t, err)
 
 			deployment := &appsv1.Deployment{}

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -150,6 +150,10 @@ type ReconcileGitopsService struct {
 	DisableDefaultInstall bool
 	//CentralTLSProfile contains MinVersion and CipherSuites
 	CentralTLSProfile configv1.TLSProfileSpec
+
+	// PluginNamespace is the namespace where console plugin resources (Deployment, Service, ConfigMap) are deployed.
+	// This is typically the operator's own namespace (e.g. "openshift-gitops-operator").
+	PluginNamespace string
 }
 
 // +kubebuilder:rbac:groups=config.openshift.io,resources=authentications,verbs=get;list;watch
@@ -301,6 +305,25 @@ func (r *ReconcileGitopsService) Reconcile(ctx context.Context, request reconcil
 		return result, err
 	}
 
+	if r.PluginNamespace != namespace {
+		pluginNS := &corev1.Namespace{}
+		err = r.Client.Get(ctx, types.NamespacedName{Name: r.PluginNamespace}, pluginNS)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				reqLogger.Info("Creating plugin namespace", "Name", r.PluginNamespace)
+				pluginNS = &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: r.PluginNamespace},
+				}
+				err = r.Client.Create(ctx, pluginNS)
+				if err != nil {
+					return reconcile.Result{}, err
+				}
+			} else {
+				return reconcile.Result{}, err
+			}
+		}
+	}
+
 	dynamicPluginStartOCPVersion := os.Getenv(dynamicPluginStartOCPVersionEnv)
 	if dynamicPluginStartOCPVersion == "" {
 		dynamicPluginStartOCPVersion = common.DefaultDynamicPluginStartOCPVersion
@@ -338,7 +361,15 @@ func (r *ReconcileGitopsService) Reconcile(ctx context.Context, request reconcil
 	if clusterVersion.LessThan(pf6MinVersion) {
 		return r.reconcilePlugin(instance, request, true) // PF5: >= 4.18 && < 4.19
 	}
-	return r.reconcilePlugin(instance, request, false) // PF6: >= 4.19
+
+	result, err := r.reconcilePlugin(instance, request, false) // PF6: >= 4.19
+	if err != nil {
+		return result, err
+	}
+
+	r.cleanupOldPluginResources(ctx)
+
+	return result, nil
 }
 
 // Detect the unsupported KAM components across Deployments , Routes , Services and deletes them to perform cleanup as KAM is no longer supported since 1.15

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -288,6 +288,10 @@ func (r *ReconcileGitopsService) Reconcile(ctx context.Context, request reconcil
 
 	r.cleanKAMResources(ctx, reqLogger)
 
+	if err := r.cleanupOldPluginResources(ctx); err != nil {
+		reqLogger.Error(err, "Failed to cleanup old plugin resources")
+	}
+
 	if !r.DisableDefaultInstall {
 		// Create/reconcile the default Argo CD instance, unless default install is disabled
 		if result, err := r.reconcileDefaultArgoCDInstance(instance, reqLogger); err != nil {
@@ -362,14 +366,7 @@ func (r *ReconcileGitopsService) Reconcile(ctx context.Context, request reconcil
 		return r.reconcilePlugin(instance, request, true) // PF5: >= 4.18 && < 4.19
 	}
 
-	result, err := r.reconcilePlugin(instance, request, false) // PF6: >= 4.19
-	if err != nil {
-		return result, err
-	}
-
-	r.cleanupOldPluginResources(ctx)
-
-	return result, nil
+	return r.reconcilePlugin(instance, request, false) // PF6: >= 4.19
 }
 
 // Detect the unsupported KAM components across Deployments , Routes , Services and deletes them to perform cleanup as KAM is no longer supported since 1.15

--- a/controllers/gitopsservice_controller_test.go
+++ b/controllers/gitopsservice_controller_test.go
@@ -1133,8 +1133,9 @@ func addKnownTypesToScheme(scheme *runtime.Scheme) {
 
 func newReconcileGitOpsService(client client.Client, scheme *runtime.Scheme) *ReconcileGitopsService {
 	return &ReconcileGitopsService{
-		Client: client,
-		Scheme: scheme,
+		Client:          client,
+		Scheme:          scheme,
+		PluginNamespace: serviceNamespace,
 	}
 }
 

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -41,7 +41,9 @@ import (
 )
 
 const (
-	clusterVersionName = "version"
+	clusterVersionName       = "version"
+	operatorPodNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	DefaultOperatorNamespace = "openshift-gitops-operator"
 )
 
 var (
@@ -288,4 +290,18 @@ func AddSeccompProfileForOpenShift(client client.Client, podspec *corev1.PodSpec
 			}
 		}
 	}
+}
+
+// GetOperatorNamespace returns the namespace the operator is running in by reading
+// the serviceaccount namespace file. If the file is not found (e.g. running locally),
+// it returns the default operator namespace and a nil error.
+func GetOperatorNamespace() (string, error) {
+	data, err := os.ReadFile(operatorPodNamespacePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultOperatorNamespace, nil
+		}
+		return "", fmt.Errorf("error retrieving operator namespace: %w", err)
+	}
+	return strings.TrimSpace(string(data)), nil
 }

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -146,9 +147,20 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	pluginNamespace := "openshift-gitops-operator"
+	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		if !os.IsNotExist(err) {
+			Expect(err).NotTo(HaveOccurred(), "Error retrieving operator's running namespace")
+		}
+	} else {
+		pluginNamespace = strings.TrimSpace(string(data))
+	}
+
 	err = (&controllers.ReconcileGitopsService{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		PluginNamespace: pluginNamespace,
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -147,15 +146,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	pluginNamespace := "openshift-gitops-operator"
-	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-	if err != nil {
-		if !os.IsNotExist(err) {
-			Expect(err).NotTo(HaveOccurred(), "Error retrieving operator's running namespace")
-		}
-	} else {
-		pluginNamespace = strings.TrimSpace(string(data))
-	}
+	pluginNamespace, err := util.GetOperatorNamespace()
+	Expect(err).NotTo(HaveOccurred(), "Error retrieving operator's running namespace")
 
 	err = (&controllers.ReconcileGitopsService{
 		Client:          mgr.GetClient(),

--- a/test/nondefaulte2e/suite_test.go
+++ b/test/nondefaulte2e/suite_test.go
@@ -132,10 +132,21 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	pluginNamespace := "openshift-gitops-operator"
+	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		if !os.IsNotExist(err) {
+			Expect(err).NotTo(HaveOccurred(), "Error retrieving operator's running namespace")
+		}
+	} else {
+		pluginNamespace = strings.TrimSpace(string(data))
+	}
+
 	err = (&controllers.ReconcileGitopsService{
 		Client:                mgr.GetClient(),
 		Scheme:                mgr.GetScheme(),
 		DisableDefaultInstall: strings.ToLower(os.Getenv(common.DisableDefaultInstallEnvVar)) == "true",
+		PluginNamespace:       pluginNamespace,
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/nondefaulte2e/suite_test.go
+++ b/test/nondefaulte2e/suite_test.go
@@ -132,15 +132,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	pluginNamespace := "openshift-gitops-operator"
-	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-	if err != nil {
-		if !os.IsNotExist(err) {
-			Expect(err).NotTo(HaveOccurred(), "Error retrieving operator's running namespace")
-		}
-	} else {
-		pluginNamespace = strings.TrimSpace(string(data))
-	}
+	pluginNamespace, err := util.GetOperatorNamespace()
+	Expect(err).NotTo(HaveOccurred(), "Error retrieving operator's running namespace")
 
 	err = (&controllers.ReconcileGitopsService{
 		Client:                mgr.GetClient(),

--- a/test/openshift/e2e/ginkgo/sequential/1-085_validate_dynamic_plugin_installation_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-085_validate_dynamic_plugin_installation_test.go
@@ -97,21 +97,21 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			By("verifying the plugin's Deployment, ConfigMap, Secret, Service, and other resources have expected values")
 
-			depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: "openshift-gitops"}}
+			depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: "openshift-gitops-operator"}}
 			Eventually(depl, "3m", "5s").Should(k8sFixture.ExistByName())
 			Eventually(depl, "60s", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
 
-			configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "httpd-cfg", Namespace: "openshift-gitops"}}
+			configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "httpd-cfg", Namespace: "openshift-gitops-operator"}}
 			Eventually(configMap).Should(k8sFixture.ExistByName())
 
 			Expect(configMap).To(
 				And(k8sFixture.HaveLabelWithValue("app", "gitops-plugin"),
 					k8sFixture.HaveLabelWithValue("app.kubernetes.io/part-of", "gitops-plugin")))
 
-			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "console-serving-cert", Namespace: "openshift-gitops"}}
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "console-serving-cert", Namespace: "openshift-gitops-operator"}}
 			Eventually(secret).Should(k8sFixture.ExistByName())
 
-			service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: "openshift-gitops"}}
+			service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: "openshift-gitops-operator"}}
 			Eventually(service).Should(k8sFixture.ExistByName())
 
 			match := false

--- a/test/openshift/e2e/ginkgo/sequential/1-115_validate_imagepullpolicy_console_plugin_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-115_validate_imagepullpolicy_console_plugin_test.go
@@ -92,7 +92,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			})
 
 			By("verifying console plugin deployment has ImagePullPolicy set to Always")
-			pluginDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: argoCD.Namespace}}
+			pluginDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: "openshift-gitops-operator"}}
 			Eventually(pluginDepl).Should(k8sFixture.ExistByName())
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pluginDepl), pluginDepl)
@@ -243,7 +243,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "3m", "5s").Should(BeTrue())
 
 			By("verifying plugin deployment defaults to IfNotPresent")
-			pluginDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: argoCD.Namespace}}
+			pluginDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: "openshift-gitops-operator"}}
 			Eventually(pluginDepl).Should(k8sFixture.ExistByName())
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pluginDepl), pluginDepl)

--- a/test/openshift/e2e/ginkgo/sequential/1-121-validate_resource_constraints_gitopsservice_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-121-validate_resource_constraints_gitopsservice_test.go
@@ -43,8 +43,8 @@ func addDynamicPluginEnv(csv *olmv1alpha1.ClusterServiceVersion, ocVersion strin
 	})
 }
 
-func verifyResourceConstraints(k8sClient client.Client, deplName string, expectedReq, expectedLim corev1.ResourceList) {
-	depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: deplName, Namespace: "openshift-gitops"}}
+func verifyResourceConstraints(k8sClient client.Client, deplName, namespace string, expectedReq, expectedLim corev1.ResourceList) {
+	depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: deplName, Namespace: namespace}}
 	Eventually(func() corev1.ResourceRequirements {
 		_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(depl), depl)
 		containers := depl.Spec.Template.Spec.Containers
@@ -86,7 +86,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 			addDynamicPluginEnv(csv, ocVersion)
 
-			depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: "openshift-gitops"}}
+			depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: "openshift-gitops-operator"}}
 			Eventually(depl, "3m", "5s").Should(k8sFixture.ExistByName())
 			Eventually(depl, "60s", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
 
@@ -150,8 +150,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				corev1.ResourceCPU:    resource.MustParse("300m"),
 				corev1.ResourceMemory: resource.MustParse("400Mi"),
 			}
-			verifyResourceConstraints(k8sClient, "gitops-plugin", expectedReq, expectedLim)
-			verifyResourceConstraints(k8sClient, "cluster", expectedReq, expectedLim)
+			verifyResourceConstraints(k8sClient, "gitops-plugin", "openshift-gitops-operator", expectedReq, expectedLim)
+			verifyResourceConstraints(k8sClient, "cluster", "openshift-gitops", expectedReq, expectedLim)
 		})
 
 		It("validates that GitOpsService can update resource constraints", Label("openshift"), func() {
@@ -167,7 +167,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 			addDynamicPluginEnv(csv, ocVersion)
 
-			depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: "openshift-gitops"}}
+			depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: "openshift-gitops-operator"}}
 			Eventually(depl, "3m", "5s").Should(k8sFixture.ExistByName())
 			Eventually(depl, "60s", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
 
@@ -221,8 +221,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				corev1.ResourceCPU:    resource.MustParse("345m"),
 				corev1.ResourceMemory: resource.MustParse("456Mi"),
 			}
-			verifyResourceConstraints(k8sClient, "gitops-plugin", expectedReq, expectedLim)
-			verifyResourceConstraints(k8sClient, "cluster", expectedReq, expectedLim)
+			verifyResourceConstraints(k8sClient, "gitops-plugin", "openshift-gitops-operator", expectedReq, expectedLim)
+			verifyResourceConstraints(k8sClient, "cluster", "openshift-gitops", expectedReq, expectedLim)
 		})
 
 		It("validates gitops plugin and backend can have different resource constraints", Label("openshift"), func() {
@@ -238,7 +238,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 			addDynamicPluginEnv(csv, ocVersion)
 
-			depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: "openshift-gitops"}}
+			depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: "openshift-gitops-operator"}}
 			Eventually(depl, "3m", "5s").Should(k8sFixture.ExistByName())
 			Eventually(depl, "60s", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
 
@@ -283,7 +283,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				})
 			}()
 			k8sClient, _ := utils.GetE2ETestKubeClient()
-			verifyResourceConstraints(k8sClient, "gitops-plugin",
+			verifyResourceConstraints(k8sClient, "gitops-plugin", "openshift-gitops-operator",
 				corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("223m"),
 					corev1.ResourceMemory: resource.MustParse("334Mi"),
@@ -293,7 +293,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					corev1.ResourceMemory: resource.MustParse("556Mi"),
 				},
 			)
-			verifyResourceConstraints(k8sClient, "cluster",
+			verifyResourceConstraints(k8sClient, "cluster", "openshift-gitops",
 				corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("123m"),
 					corev1.ResourceMemory: resource.MustParse("234Mi"),

--- a/test/openshift/e2e/ginkgo/sequential/1-123_validate_list_order_comparison_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-123_validate_list_order_comparison_test.go
@@ -42,6 +42,7 @@ import (
 const testReconciliationTriggerAnnotation = "test-reconciliation-trigger"
 const gitopsPluginDeploymentName = "gitops-plugin"
 const openshiftGitopsNamespace = "openshift-gitops"
+const openshiftGitopsOperatorNamespace = "openshift-gitops-operator"
 
 // ocpVersionLessThanPluginMin returns true when OCP version is below the plugin-reconcile minimum.
 // Same check as gitopsservice_controller.go (realMajorVersion < startMajorVersion || (realMajorVersion == startMajorVersion && realMinorVersion < startMinorVersion)).
@@ -99,7 +100,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			if CurrentSpecReport().Failed() {
 				kubeClient, _, err := fixtureUtils.GetE2ETestKubeClientWithError()
 				if err == nil {
-					pluginDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: gitopsPluginDeploymentName, Namespace: openshiftGitopsNamespace}}
+					pluginDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: gitopsPluginDeploymentName, Namespace: openshiftGitopsOperatorNamespace}}
 					pluginErr := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(pluginDepl), pluginDepl)
 					deplGen, observedGen := int64(0), int64(0)
 					if pluginErr == nil {
@@ -126,13 +127,13 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			pluginDeployment := &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      gitopsPluginDeploymentName,
-					Namespace: openshiftGitopsNamespace,
+					Namespace: openshiftGitopsOperatorNamespace,
 				},
 			}
 			Eventually(pluginDeployment, "5m", "5s").Should(k8sFixture.ExistByName(),
-				"deployment %s never showed in %s (5m)", gitopsPluginDeploymentName, openshiftGitopsNamespace)
+				"deployment %s never showed in %s (5m)", gitopsPluginDeploymentName, openshiftGitopsOperatorNamespace)
 			Eventually(pluginDeployment, "60s", "5s").Should(deploymentFixture.HaveReadyReplicas(1),
-				"deployment %s in %s not ready after 60s", gitopsPluginDeploymentName, openshiftGitopsNamespace)
+				"deployment %s in %s not ready after 60s", gitopsPluginDeploymentName, openshiftGitopsOperatorNamespace)
 
 			By("capturing initial state before simulating etcd order change")
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pluginDeployment), pluginDeployment)).To(Succeed())
@@ -223,13 +224,13 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			pluginDeployment := &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      gitopsPluginDeploymentName,
-					Namespace: openshiftGitopsNamespace,
+					Namespace: openshiftGitopsOperatorNamespace,
 				},
 			}
 			Eventually(pluginDeployment, "5m", "5s").Should(k8sFixture.ExistByName(),
-				"deployment %s never showed in %s (5m)", gitopsPluginDeploymentName, openshiftGitopsNamespace)
+				"deployment %s never showed in %s (5m)", gitopsPluginDeploymentName, openshiftGitopsOperatorNamespace)
 			Eventually(pluginDeployment, "60s", "5s").Should(deploymentFixture.HaveReadyReplicas(1),
-				"deployment %s in %s not ready after 60s", gitopsPluginDeploymentName, openshiftGitopsNamespace)
+				"deployment %s in %s not ready after 60s", gitopsPluginDeploymentName, openshiftGitopsOperatorNamespace)
 
 			By("capturing initial state before making actual change")
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pluginDeployment), pluginDeployment)).To(Succeed())

--- a/test/openshift/e2e/ginkgo/sequential/1-124_validate_console_plugin_in_operator_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-124_validate_console_plugin_in_operator_namespace_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sequential
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	consolev1 "github.com/openshift/api/console/v1"
+	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
+	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
+	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
+	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
+
+	Context("1-124_validate_console_plugin_in_operator_namespace", func() {
+
+		BeforeEach(func() {
+			fixture.EnsureSequentialCleanSlate()
+		})
+
+		It("verifies that console plugin resources are deployed in the operator namespace, not the default ArgoCD namespace", func() {
+
+			k8sClient, _ := utils.GetE2ETestKubeClient()
+
+			operatorNamespace := "openshift-gitops-operator"
+
+			By("verifying plugin Deployment exists in operator namespace and is ready")
+			pluginDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: operatorNamespace}}
+			Eventually(pluginDepl, "3m", "5s").Should(k8sFixture.ExistByName())
+			Eventually(pluginDepl, "3m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
+
+			By("verifying plugin Service exists in operator namespace")
+			pluginSvc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: operatorNamespace}}
+			Eventually(pluginSvc, "60s", "5s").Should(k8sFixture.ExistByName())
+
+			By("verifying plugin ConfigMap exists in operator namespace")
+			pluginCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "httpd-cfg", Namespace: operatorNamespace}}
+			Eventually(pluginCM, "60s", "5s").Should(k8sFixture.ExistByName())
+
+			By("verifying ConsolePlugin CR backend points to operator namespace")
+			consolePlugin := &consolev1.ConsolePlugin{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin"}}
+			Eventually(consolePlugin, "60s", "5s").Should(k8sFixture.ExistByName())
+			err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(consolePlugin), consolePlugin)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(consolePlugin.Spec.Backend.Service).ToNot(BeNil())
+			Expect(consolePlugin.Spec.Backend.Service.Namespace).To(Equal(operatorNamespace))
+
+			By("verifying plugin resources do NOT exist in openshift-gitops namespace")
+			oldDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: "openshift-gitops"}}
+			Eventually(oldDepl).Should(k8sFixture.NotExistByName())
+
+			oldSvc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: "openshift-gitops"}}
+			Eventually(oldSvc).Should(k8sFixture.NotExistByName())
+
+			oldCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "httpd-cfg", Namespace: "openshift-gitops"}}
+			Eventually(oldCM).Should(k8sFixture.NotExistByName())
+		})
+	})
+})

--- a/test/openshift/e2e/ginkgo/sequential/1-124_validate_console_plugin_in_operator_namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-124_validate_console_plugin_in_operator_namespace_test.go
@@ -22,6 +22,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	consolev1 "github.com/openshift/api/console/v1"
+	gitopsoperatorv1alpha1 "github.com/redhat-developer/gitops-operator/api/v1alpha1"
+	"github.com/redhat-developer/gitops-operator/common"
+	"github.com/redhat-developer/gitops-operator/controllers/util"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
@@ -38,9 +41,21 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
+
+			// The operator only reconciles the console plugin on OCP >= DefaultDynamicPluginStartOCPVersion,
+			// so on older clusters none of the plugin resources asserted below will ever be created.
+			k8sClient, _ := utils.GetE2ETestKubeClient()
+			ocpVersion, _ := util.GetClusterVersion(k8sClient)
+			if ocpVersionLessThanPluginMin(ocpVersion, common.DefaultDynamicPluginStartOCPVersion) {
+				Skip("Plugin reconciliation is disabled when OCP version < " + common.DefaultDynamicPluginStartOCPVersion + "; skipping 1-124 test")
+			}
 		})
 
 		It("verifies that console plugin resources are deployed in the operator namespace, not the default ArgoCD namespace", func() {
+
+			if !fixture.RunningOnOpenShift() {
+				Skip("Console plugin is only deployed on OpenShift clusters")
+			}
 
 			k8sClient, _ := utils.GetE2ETestKubeClient()
 
@@ -76,6 +91,103 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			oldCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "httpd-cfg", Namespace: "openshift-gitops"}}
 			Eventually(oldCM).Should(k8sFixture.NotExistByName())
+		})
+
+		It("cleans up plugin resources from the old namespace when they exist (simulating upgrade from older version)", func() {
+
+			if !fixture.RunningOnOpenShift() {
+				Skip("Console plugin is only deployed on OpenShift clusters")
+			}
+
+			k8sClient, _ := utils.GetE2ETestKubeClient()
+			ctx := context.Background()
+			oldNamespace := "openshift-gitops"
+			operatorNamespace := "openshift-gitops-operator"
+
+			By("waiting for plugin deployment to be ready in operator namespace before proceeding")
+			readyDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: operatorNamespace}}
+			Eventually(readyDepl, "5m", "5s").Should(k8sFixture.ExistByName())
+			Eventually(readyDepl, "3m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
+
+			By("creating fake plugin resources in the old namespace to simulate a pre-upgrade installation")
+			oldDepl := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gitops-plugin",
+					Namespace: oldNamespace,
+					Labels:    map[string]string{"app": "gitops-plugin"},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "gitops-plugin"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "gitops-plugin"}},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "gitops-plugin", Image: "fake-image:latest"},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, oldDepl)).To(Succeed())
+
+			oldSvc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gitops-plugin",
+					Namespace: oldNamespace,
+					Labels:    map[string]string{"app": "gitops-plugin"},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{"app": "gitops-plugin"},
+					Ports:    []corev1.ServicePort{{Port: 9001, Protocol: corev1.ProtocolTCP}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, oldSvc)).To(Succeed())
+
+			oldCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "httpd-cfg",
+					Namespace: oldNamespace,
+					Labels:    map[string]string{"app": "gitops-plugin"},
+				},
+				Data: map[string]string{"test": "data"},
+			}
+			Expect(k8sClient.Create(ctx, oldCM)).To(Succeed())
+
+			By("verifying the old resources were created successfully")
+			Eventually(oldDepl, "30s", "5s").Should(k8sFixture.ExistByName())
+			Eventually(oldSvc, "30s", "5s").Should(k8sFixture.ExistByName())
+			Eventually(oldCM, "30s", "5s").Should(k8sFixture.ExistByName())
+
+			By("triggering reconciliation by updating GitopsService spec")
+			gitopsService := &gitopsoperatorv1alpha1.GitopsService{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			}
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(gitopsService), gitopsService)).To(Succeed())
+			gitopsService.Spec.Tolerations = append(gitopsService.Spec.Tolerations, corev1.Toleration{
+				Key:      "e2e-test-trigger",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			})
+			Expect(k8sClient.Update(ctx, gitopsService)).To(Succeed())
+
+			By("verifying old plugin resources are cleaned up from openshift-gitops")
+			Eventually(oldDepl, "5m", "5s").Should(k8sFixture.NotExistByName())
+			Eventually(oldSvc, "5m", "5s").Should(k8sFixture.NotExistByName())
+			Eventually(oldCM, "5m", "5s").Should(k8sFixture.NotExistByName())
+
+			By("verifying plugin resources still exist in the operator namespace")
+			newDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: operatorNamespace}}
+			Eventually(newDepl, "3m", "5s").Should(k8sFixture.ExistByName())
+			Eventually(newDepl, "3m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
+
+			newSvc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "gitops-plugin", Namespace: operatorNamespace}}
+			Eventually(newSvc, "60s", "5s").Should(k8sFixture.ExistByName())
+
+			newCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "httpd-cfg", Namespace: operatorNamespace}}
+			Eventually(newCM, "60s", "5s").Should(k8sFixture.ExistByName())
+
 		})
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
Moves console plugin resources (Deployment, Service, ConfigMap) from 'openshift-gitops' namespace to the operator's own namespace (openshift-gitops-operator) so the plugin operates independently of the default ArgoCD instance. This is a prerequisite for allowing the default ArgoCD instance to be disabled without breaking the console plugin.

- Made plugin functions support namespaces.
- Added 'PluginNamespace' field to the reconciler, resolved from the operator's serviceaccount namespace
- Added cleanup of old plugin resources from 'openshift-gitops'
- Ensures plugin namespace exists before creating resources
- ConsolePlugin CR backend now points to the operator namespace

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

JIRA -https://redhat.atlassian.net/browse/GITOPS-9846

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
make install 
make run

-  kubectl get deployment gitops-plugin -n openshift-gitops-operator
   NAME            READY   UP-TO-DATE   AVAILABLE   AGE
   gitops-plugin   1/1     1            1           19m

-  kubectl get service gitops-plugin -n openshift-gitops-operator 
   NAME            TYPE         CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
  gitops-plugin   ClusterIP   172.xyz.83   <none>        9001/TCP         19m

-  kubectl get configmap httpd-cfg -n openshift-gitops-operator
    NAME        DATA   AGE
    httpd-cfg   1      20m

- kubectl get consoleplugin gitops-plugin -o jsonpath='{.spec.backend.service.namespace}'
   openshift-gitops-operator
