### PR TITLE
Fix 1-090_validate_permissions for OLM CSV copies on v1.19.6.

### DIFF
--- a/test/openshift/e2e/ginkgo/parallel/1-090_validate_permissions_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-090_validate_permissions_test.go
@@ -65,8 +65,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: openshift-gitops-operator.v1.16.0
-  namespace: openshift-operators
+  name: openshift-gitops-operator.v1.19.6
+  namespace: openshift-gitops-operator
 spec:
   install:
     spec:
@@ -79,25 +79,6 @@ spec:
           - endpoints
           - events
           - namespaces
-          - pods
-          - secrets
-          - serviceaccounts
-          - services
-          - services/finalizers
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - endpoints
-          - events
           - persistentvolumeclaims
           - pods
           - secrets
@@ -116,21 +97,10 @@ spec:
           - ""
           resources:
           - deployments
+          - podtemplates
           verbs:
           - get
           - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - namespaces
-          - resourcequotas
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - update
           - watch
         - apiGroups:
           - ""
@@ -147,10 +117,13 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - podtemplates
+          - resourcequotas
           verbs:
+          - create
+          - delete
           - get
           - list
+          - update
           - watch
         - apiGroups:
           - apiextensions.k8s.io
@@ -191,22 +164,9 @@ spec:
           resources:
           - daemonsets
           - deployments
-          - replicasets
-          - statefulsets
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
           - podtemplates
           - replicasets
+          - statefulsets
           verbs:
           - create
           - delete
@@ -232,7 +192,7 @@ spec:
         - apiGroups:
           - apps.openshift.io
           resources:
-          - '*'
+          - "*"
           verbs:
           - create
           - delete
@@ -246,21 +206,16 @@ spec:
           resources:
           - analysisruns
           - analysisruns/finalizers
+          - analysistemplates
+          - clusteranalysistemplates
           - experiments
           - experiments/finalizers
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - argoproj.io
-          resources:
-          - analysistemplates
+          - namespacemanagements
+          - namespacemanagements/status
+          - rollouts
+          - rollouts/finalizers
+          - rollouts/scale
+          - rollouts/status
           verbs:
           - create
           - delete
@@ -278,22 +233,10 @@ spec:
           - argocds
           - argocds/finalizers
           - argocds/status
+          - rolloutmanagers
           verbs:
           - create
           - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - argoproj.io
-          resources:
-          - clusteranalysistemplates
-          verbs:
-          - create
-          - delete
-          - deletecollection
           - get
           - list
           - patch
@@ -305,19 +248,7 @@ spec:
           - notificationsconfigurations
           - notificationsconfigurations/finalizers
           verbs:
-          - '*'
-        - apiGroups:
-          - argoproj.io
-          resources:
-          - rolloutmanagers
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
+          - "*"
         - apiGroups:
           - argoproj.io
           resources:
@@ -332,22 +263,6 @@ spec:
           - get
           - patch
           - update
-        - apiGroups:
-          - argoproj.io
-          resources:
-          - rollouts
-          - rollouts/finalizers
-          - rollouts/scale
-          - rollouts/status
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
         - apiGroups:
           - autoscaling
           resources:
@@ -374,21 +289,10 @@ spec:
           - update
           - watch
         - apiGroups:
-          - batch
-          resources:
-          - jobs
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - config.openshift.io
           resources:
           - clusterversions
+          - ingresses
           verbs:
           - get
           - list
@@ -408,17 +312,6 @@ spec:
           - console.openshift.io
           resources:
           - consolelinks
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - console.openshift.io
-          resources:
           - consoleplugins
           verbs:
           - create
@@ -431,18 +324,18 @@ spec:
         - apiGroups:
           - coordination.k8s.io
           resources:
-            - leases
+          - leases
           verbs:
-            - create
-            - get
-            - update
+          - create
+          - get
+          - update
         - apiGroups:
           - elbv2.k8s.aws
           resources:
-            - targetgroupbindings
+          - targetgroupbindings
           verbs:
-            - get
-            - list
+          - get
+          - list
         - apiGroups:
           - extensions
           resources:
@@ -455,6 +348,7 @@ spec:
           - watch
         - apiGroups:
           - getambassador.io
+          - x.getambassador.io
           resources:
           - ambassadormappings
           - mappings
@@ -491,18 +385,7 @@ spec:
           - update
           - watch
         - apiGroups:
-            - networking.k8s.io
-          resources:
-          - ingresses
-          verbs:
-          - create
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-            - networking.k8s.io
+          - networking.k8s.io
           resources:
           - ingresses
           - networkpolicies
@@ -540,18 +423,7 @@ spec:
         - apiGroups:
           - pipelines.openshift.io
           resources:
-          - '*'
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - pipelines.openshift.io
-          resources:
+          - "*"
           - gitopsservices
           verbs:
           - create
@@ -578,21 +450,7 @@ spec:
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
-          - '*'
-          verbs:
-          - bind
-          - create
-          - delete
-          - deletecollection
-          - escalate
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
+          - "*"
           - clusterrolebindings
           - clusterroles
           verbs:
@@ -622,18 +480,7 @@ spec:
         - apiGroups:
           - route.openshift.io
           resources:
-          - '*'
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - route.openshift.io
-          resources:
+          - "*"
           - routes
           - routes/custom-host
           verbs:
@@ -676,18 +523,10 @@ spec:
           - get
           - update
           - watch
-        - apiGroups:
-          - x.getambassador.io
-          resources:
-          - ambassadormappings
-          - mappings
+        - nonResourceURLs:
+          - /metrics
           verbs:
-          - create
-          - delete
           - get
-          - list
-          - update
-          - watch
         - apiGroups:
           - authentication.k8s.io
           resources:
@@ -705,10 +544,10 @@ spec:
 
 			Expect(yaml.UnmarshalStrict([]byte(csvString), expectedCsv)).To(Succeed())
 
-			By("looking for a ClusterServiceVersion for openshift-gitops across all namespaces")
+			By("looking for a ClusterServiceVersion for openshift-gitops in openshift-gitops-operator namespace")
 			gitopsCSVsFound := []olmv1alpha1.ClusterServiceVersion{}
 			var csvList olmv1alpha1.ClusterServiceVersionList
-			Expect(k8sClient.List(ctx, &csvList)).To(Succeed())
+			Expect(k8sClient.List(ctx, &csvList, client.InNamespace("openshift-gitops-operator"))).To(Succeed())
 			for index := range csvList.Items {
 				csv := csvList.Items[index]
 				if strings.Contains(csv.Name, "openshift-gitops-operator") {
@@ -716,7 +555,11 @@ spec:
 				}
 			}
 			By("if more than one possible CSV is found, we will fail.")
-			Expect(gitopsCSVsFound).To(HaveLen(1), fmt.Sprintf("Exactly one CSV should found: %v", gitopsCSVsFound))
+			csvNames := []string{}
+			for _, csv := range gitopsCSVsFound {
+				csvNames = append(csvNames, fmt.Sprintf("%s/%s", csv.Namespace, csv.Name))
+			}
+			Expect(gitopsCSVsFound).To(HaveLen(1), fmt.Sprintf("Exactly one CSV should be found: %v", csvNames))
 
 			actualCsv := &olmv1alpha1.ClusterServiceVersion{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Scope CSV lookup to openshift-gitops-operator and refresh expected cluster permissions so the test no longer fails when OLM copies the CSV into every namespace.

Assisted by: Cursor

**What type of PR is this?**

/kind failing-test

**What does this PR do / why we need it**:

`1-090_validate_permissions` failed on the 1.19.6 upgrade run because it listed GitOps CSVs cluster-wide and expected exactly one match. With AllNamespaces install mode, OLM copies the CSV into every namespace, so the assertion failed.

This change:
- Lists CSVs only in `openshift-gitops-operator`
- Updates the inline expected cluster permissions for 1.19.6
- Improves the failure message to show CSV names/namespaces

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [x] E2E Test

**How to test changes / Special notes to the reviewer**:

Focused rerun against the 1.19.6 upgrade cluster:

```bash
./bin/ginkgo -v --focus="1-090_validate_permissions" -r ./test/openshift/e2e/ginkgo/parallel