### PR TITLE
fix(e2e): Do not print secret value from secret.Fixture.HaveNonEmptyKeyValue

### DIFF
--- a/test/openshift/e2e/ginkgo/fixture/secret/fixture.go
+++ b/test/openshift/e2e/ginkgo/fixture/secret/fixture.go
@@ -61,9 +61,10 @@ func HaveNonEmptyKeyValue(key string) matcher.GomegaMatcher {
 			return false
 		}
 
-		GinkgoWriter.Println("HaveNonEmptyKeyValue - Key:", key, " Have:", string(a))
-
-		return len(a) > 0
+		// Printing string that looks like secret causes openshift-ci to redact the entire log file, preventing investigating failures in any other tests.
+		empty := len(a) == 0
+		GinkgoWriter.Println("HaveNonEmptyKeyValue - Key:", key, " empty:", empty)
+		return !empty
 	})
 
 }


### PR DESCRIPTION
It confuses openshift-ci secrets redaction

This was triggered by "verifies that the Dex client secret is sourced from a short-lived TokenRequest token and is correctly set in argocd-secret" printing JWT.

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
