### PR TITLE
chore: additional E2E test reliability improvements

### DIFF
--- a/test/openshift/e2e/ginkgo/fixture/agent/fixture.go
+++ b/test/openshift/e2e/ginkgo/fixture/agent/fixture.go
@@ -29,7 +29,7 @@ import (
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/certutil"
+	certutilFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/certutil"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 	osFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/os"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
@@ -158,8 +158,8 @@ func CreateRequiredSecrets(cfg PrincipalSecretsConfig) {
 	}
 	Expect(k8sClient.Create(ctx, jwtSecret)).To(Succeed())
 
-	caKey, caCert, caCertPEM := certutil.GenerateCertificateAuthority(caSubject)
-	caKeyPEM := certutil.EncodePrivateKeyToPEM(caKey)
+	caKey, caCert, caCertPEM := certutilFixture.GenerateCertificateAuthority(caSubject)
+	caKeyPEM := certutilFixture.EncodePrivateKeyToPEM(caKey)
 
 	caSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -176,7 +176,7 @@ func CreateRequiredSecrets(cfg PrincipalSecretsConfig) {
 	Expect(k8sClient.Create(ctx, caSecret)).To(Succeed())
 
 	principalDNS, principalIPs := aggregateSANs(cfg.PrincipalNamespaceName, cfg.PrincipalServiceName, cfg.AdditionalPrincipalSANs)
-	principalCertPEM, principalKeyPEM := certutil.IssueCertificate(caCert, caKey, certutil.CertificateRequest{
+	principalCertPEM, principalKeyPEM := certutilFixture.IssueCertificate(caCert, caKey, certutilFixture.CertificateRequest{
 		CommonName:  cfg.PrincipalServiceName,
 		DNSNames:    principalDNS,
 		IPAddresses: principalIPs,
@@ -185,7 +185,7 @@ func CreateRequiredSecrets(cfg PrincipalSecretsConfig) {
 	createTLSSecret(ctx, k8sClient, cfg.PrincipalNamespaceName, cfg.PrincipalTLSSecretName, principalCertPEM, principalKeyPEM, caCertPEM)
 
 	resourceProxyDNS, resourceProxyIPs := aggregateSANs(cfg.PrincipalNamespaceName, cfg.ResourceProxyServiceName, cfg.AdditionalResourceProxySANs)
-	resourceProxyCertPEM, resourceProxyKeyPEM := certutil.IssueCertificate(caCert, caKey, certutil.CertificateRequest{
+	resourceProxyCertPEM, resourceProxyKeyPEM := certutilFixture.IssueCertificate(caCert, caKey, certutilFixture.CertificateRequest{
 		CommonName:  cfg.ResourceProxyServiceName,
 		DNSNames:    resourceProxyDNS,
 		IPAddresses: resourceProxyIPs,
@@ -218,7 +218,7 @@ func CreateRequiredAgentSecrets(cfg AgentSecretsConfig) {
 	caKey := parsePrivateKey(caKeyPEM)
 
 	clientDNS, clientIPs := aggregateClientSANs(cfg.ClientDNSNames)
-	clientCertPEM, clientKeyPEM := certutil.IssueCertificate(caCert, caKey, certutil.CertificateRequest{
+	clientCertPEM, clientKeyPEM := certutilFixture.IssueCertificate(caCert, caKey, certutilFixture.CertificateRequest{
 		CommonName:  cfg.ClientCommonName,
 		DNSNames:    clientDNS,
 		IPAddresses: clientIPs,

--- a/test/openshift/e2e/ginkgo/fixture/argocd/fixture.go
+++ b/test/openshift/e2e/ginkgo/fixture/argocd/fixture.go
@@ -18,6 +18,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	routeFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/route"
 )
 
 // Update will update an ArgoCD CR. Update will keep trying to update object until it succeeds, or times out.
@@ -267,26 +269,20 @@ func fetchArgoCD(f func(*argov1beta1api.ArgoCD) bool) matcher.GomegaMatcher {
 
 }
 
+// NOTE: this should only be called from sequential tests. If you call it from a parallel test, there is a risk that another test will login to a different Argo CD instance.
 func LogInToDefaultArgoCDInstance() error {
 	k8sClient, _, err := utils.GetE2ETestKubeClientWithError()
 	if err != nil {
 		return err
 	}
 
-	var routeList routev1.RouteList
-	Expect(k8sClient.List(context.Background(), &routeList, client.InNamespace("openshift-gitops"))).To(Succeed())
+	route := &routev1.Route{ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops-server", Namespace: "openshift-gitops"}}
 
-	var route *routev1.Route
-	for idx := range routeList.Items {
-		idxRoute := routeList.Items[idx]
+	Eventually(func() error {
+		return k8sClient.Get(context.Background(), client.ObjectKeyFromObject(route), route)
+	}, "3m", "2s").Should(Succeed())
 
-		if idxRoute.Name == "openshift-gitops-server" {
-			route = &idxRoute
-		}
-	}
-	if route == nil {
-		return fmt.Errorf("unable to locate route")
-	}
+	Eventually(route, "3m", "2s").Should(routeFixture.HaveAdmittedIngress())
 
 	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops-cluster", Namespace: "openshift-gitops"}}
 	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(secret), secret); err != nil {
@@ -307,6 +303,7 @@ func LogInToDefaultArgoCDInstance() error {
 
 }
 
+// NOTE: this should only be called from sequential tests. If you call it from a parallel test, there is a risk that another test will login to a different Argo CD instance.
 func RunArgoCDCLI(args ...string) (string, error) {
 
 	cmdArgs := append([]string{"argocd"}, args...)

--- a/test/openshift/e2e/ginkgo/fixture/fixture.go
+++ b/test/openshift/e2e/ginkgo/fixture/fixture.go
@@ -26,9 +26,9 @@ import (
 
 	"github.com/onsi/gomega/format"
 	gitopsoperatorv1alpha1 "github.com/redhat-developer/gitops-operator/api/v1alpha1"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
+	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
 	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
+	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 	osFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/os"
 	subscriptionFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/subscription"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
@@ -69,7 +69,7 @@ func EnsureParallelCleanSlate() {
 		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(defaultOpenShiftGitOpsArgoCD), defaultOpenShiftGitOpsArgoCD)
 		Expect(err).ToNot(HaveOccurred())
 
-		Eventually(defaultOpenShiftGitOpsArgoCD, "5m", "5s").Should(argocd.BeAvailableWithCustomSleepTime(3 * time.Second))
+		Eventually(defaultOpenShiftGitOpsArgoCD, "5m", "5s").Should(argocdFixture.BeAvailableWithCustomSleepTime(3 * time.Second))
 	}
 	// Unlike sequential clean slate, parallel clean slate cannot assume that there are no other tests running. This limits our ability to clean up old test artifacts.
 }
@@ -119,7 +119,7 @@ func EnsureSequentialCleanSlateWithError() error {
 		defaultOpenShiftGitOpsArgoCD := &argov1beta1api.ArgoCD{
 			ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops", Namespace: "openshift-gitops"},
 		}
-		Eventually(defaultOpenShiftGitOpsArgoCD, "3m", "5s").Should(k8s.ExistByName())
+		Eventually(defaultOpenShiftGitOpsArgoCD, "3m", "5s").Should(k8sFixture.ExistByName())
 
 		// Ensure that default state of ArgoCD CR in openshift-gitops is restored
 		if err := updateWithoutConflict(defaultOpenShiftGitOpsArgoCD, func(obj client.Object) {
@@ -201,7 +201,7 @@ func EnsureSequentialCleanSlateWithError() error {
 
 		// Finally, wait for default openshift-gitops instance to be ready.
 		failure := InterceptGomegaFailure(func() {
-			Eventually(defaultOpenShiftGitOpsArgoCD, "5m", "5s").Should(argocd.BeAvailable())
+			Eventually(defaultOpenShiftGitOpsArgoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
 		})
 		// Output debug information on argo startup failure
 		if failure != nil {
@@ -930,6 +930,17 @@ func OutputDebug(namespaceParams ...any) {
 		GinkgoWriter.Println("'kubectl get deployments -n " + namespace + " -o yaml")
 		GinkgoWriter.Println(kubectlOutput)
 		GinkgoWriter.Println("----------------------------------------------------------------")
+
+		kubectlOutput, err = osFixture.ExecCommandWithOutputParam(false, true, "kubectl", "get", "statefulsets", "-n", namespace)
+		if err != nil {
+			GinkgoWriter.Println("unable to get statefulsets for namespace", err, kubectlOutput)
+		} else {
+			GinkgoWriter.Println("")
+			GinkgoWriter.Println("----------------------------------------------------------------")
+			GinkgoWriter.Println("'kubectl get statefulsets -n " + namespace + ":")
+			GinkgoWriter.Println(kubectlOutput)
+			GinkgoWriter.Println("----------------------------------------------------------------")
+		}
 
 		kubectlOutput, err = osFixture.ExecCommandWithOutputParam(false, true, "kubectl", "get", "events", "-n", namespace)
 		if err != nil {

--- a/test/openshift/e2e/ginkgo/fixture/promoter/fixture.go
+++ b/test/openshift/e2e/ginkgo/fixture/promoter/fixture.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/certutil"
+	certutilFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/certutil"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 )
@@ -49,7 +49,7 @@ func CreateAPIServerTLSSecrets(cfg PromoterAPIServerTLSSecretConfig) {
 
 	By("Creating API Server TLS secrets")
 
-	caKey, caCert, caCertPEM := certutil.GenerateCertificateAuthority(caSubject)
+	caKey, caCert, caCertPEM := certutilFixture.GenerateCertificateAuthority(caSubject)
 	caBundleSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cfg.CABundleSecretName,
@@ -61,7 +61,7 @@ func CreateAPIServerTLSSecrets(cfg PromoterAPIServerTLSSecretConfig) {
 	}
 	Expect(k8sClient.Create(ctx, caBundleSecret)).To(Succeed())
 
-	apiServerCertPEM, apiServerKeyPEM := certutil.IssueCertificate(caCert, caKey, certutil.CertificateRequest{
+	apiServerCertPEM, apiServerKeyPEM := certutilFixture.IssueCertificate(caCert, caKey, certutilFixture.CertificateRequest{
 		CommonName: cfg.APIServerServiceName,
 		DNSNames: []string{
 			cfg.APIServerServiceName,

--- a/test/openshift/e2e/ginkgo/parallel/1-009_validate-manage-other-namespace_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-009_validate-manage-other-namespace_test.go
@@ -28,7 +28,7 @@ import (
 	appFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/application"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/namespace"
+	namespaceFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/namespace"
 	secretFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/secret"
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -71,7 +71,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			Eventually(argoCDInRandomNS, "5m", "5s").Should(argocdFixture.BeAvailable())
 
 			By("modifying the labels of another namespace to add the argocd managed-by label")
-			namespace.Update(nsTest_1_9_custom, func(n *corev1.Namespace) {
+			namespaceFixture.Update(nsTest_1_9_custom, func(n *corev1.Namespace) {
 				n.Labels["argocd.argoproj.io/managed-by"] = argoCDInRandomNS.Namespace
 			})
 
@@ -113,7 +113,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			Eventually(app, "4m", "5s").Should(appFixture.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
 
 			By("removing managed-by label from that other Namespace")
-			namespace.Update(nsTest_1_9_custom, func(n *corev1.Namespace) {
+			namespaceFixture.Update(nsTest_1_9_custom, func(n *corev1.Namespace) {
 				delete(n.Labels, "argocd.argoproj.io/managed-by")
 			})
 

--- a/test/openshift/e2e/ginkgo/parallel/1-023_validate_repo_server_tls_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-023_validate_repo_server_tls_test.go
@@ -86,7 +86,9 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				ac.Spec.Repo.VerifyTLS = true
 			})
 
-			Eventually(func() bool {
+			// Check that the service has what we need, here.
+
+			checkArgoCDServer := func() bool {
 				depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "argocd-server", Namespace: nsTest_1_23_custom.Name}}
 				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(depl), depl); err != nil {
 					GinkgoWriter.Println(err)
@@ -116,7 +118,10 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 					"text",
 				})
 
-			}).Should(BeTrue())
+			}
+
+			Eventually(checkArgoCDServer).Should(BeTrue())
+			Consistently(checkArgoCDServer, "20s", "5s").Should(BeTrue())
 
 			Eventually(argoCDTest_1_23_custom, "5m", "5s").Should(argocdFixture.BeAvailable())
 

--- a/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-030_validate_reencrypt_test.go
@@ -169,6 +169,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				// Print the response body
 				GinkgoWriter.Println(string(body))
 
+				GinkgoWriter.Println(r.Status.Ingress, r.Spec.Host)
+
 				return strings.Contains(string(body), "Your browser does not support JavaScript.")
 
 			}, "90s", "5s").Should(BeTrue())

--- a/test/openshift/e2e/ginkgo/parallel/1-034_validate_webhook_notifications_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-034_validate_webhook_notifications_test.go
@@ -27,11 +27,11 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/configmap"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
+	configmapFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/configmap"
+	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/notificationsconfiguration"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/os"
+	notificationsconfigurationFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/notificationsconfiguration"
+	osFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/os"
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -281,7 +281,7 @@ Xq+NinfrqOLJkIZ/u/PJu4KqN3M=
 			}
 
 			Expect(k8sClient.Create(ctx, depl)).To(Succeed())
-			Eventually(depl, "4m", "5s").Should(deployment.HaveAvailableReplicas(1))
+			Eventually(depl, "4m", "5s").Should(deploymentFixture.HaveAvailableReplicas(1))
 
 			argocd := &argov1beta1api.ArgoCD{
 				ObjectMeta: metav1.ObjectMeta{
@@ -350,7 +350,7 @@ UVwpFuaKz5vTCD36Gmmy/u8y
 			}
 			Eventually(nc).Should(k8sFixture.ExistByName())
 
-			notificationsconfiguration.Update(nc, func(nc *argov1alpha1api.NotificationsConfiguration) {
+			notificationsconfigurationFixture.Update(nc, func(nc *argov1alpha1api.NotificationsConfiguration) {
 
 				nc.Spec.Services = map[string]string{
 					"service.webhook.test-webhook": "url: https://webhook/hooks/example",
@@ -377,7 +377,7 @@ UVwpFuaKz5vTCD36Gmmy/u8y
 				},
 			}
 			Eventually(notifConfigMap).Should(k8sFixture.ExistByName())
-			Eventually(notifConfigMap).Should(configmap.HaveStringDataKeyValueContainsSubstring("template.test-app-created", `{"created":"{{.app.metadata.name}}","type":"{{(call .repo.GetAppDetails).Type}}"}`))
+			Eventually(notifConfigMap).Should(configmapFixture.HaveStringDataKeyValueContainsSubstring("template.test-app-created", `{"created":"{{.app.metadata.name}}","type":"{{(call .repo.GetAppDetails).Type}}"}`))
 
 			By("creating an Argo CD Application that contains a notification annotation, which will trigger the notifications controller")
 			app := &argocdv1alpha1.Application{
@@ -403,14 +403,14 @@ UVwpFuaKz5vTCD36Gmmy/u8y
 			}
 			Expect(k8sClient.Create(ctx, app)).To(Succeed())
 
-			out, err := os.ExecCommand("kubectl", "-n", ns.Name, "logs", "deployment.apps/argocd-notifications-controller")
+			out, err := osFixture.ExecCommand("kubectl", "-n", ns.Name, "logs", "deployment.apps/argocd-notifications-controller")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).ToNot(ContainSubstring("x509"))
 
 			By("waiting for notifications controller to POST to the webhook workload, indicating that the workload event was successfully processed")
 			Eventually(func() bool {
 
-				out, err := os.ExecCommand("kubectl", "-n", ns.Name, "logs", "deployment.apps/webhook")
+				out, err := osFixture.ExecCommand("kubectl", "-n", ns.Name, "logs", "deployment.apps/webhook")
 				if err != nil {
 					GinkgoWriter.Println(err)
 					return false

--- a/test/openshift/e2e/ginkgo/parallel/1-045_validate_repo_exec_timeout_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-045_validate_repo_exec_timeout_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
+	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -74,7 +74,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "argocd-repo-server", Namespace: ns.Name}}
 			Eventually(depl).Should(k8sFixture.ExistByName())
 
-			Eventually(depl).Should(deployment.HaveContainerWithEnvVar("ARGOCD_EXEC_TIMEOUT", "300s", 0))
+			Eventually(depl).Should(deploymentFixture.HaveContainerWithEnvVar("ARGOCD_EXEC_TIMEOUT", "300s", 0))
 		})
 
 	})

--- a/test/openshift/e2e/ginkgo/parallel/1-046_validate_application_tracking_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-046_validate_application_tracking_test.go
@@ -31,11 +31,11 @@ import (
 
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
-	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/application"
+	applicationFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/application"
 	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
 	configmapFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/configmap"
 	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
-	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/namespace"
+	namespaceFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/namespace"
 	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
 )
 
@@ -152,21 +152,21 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			Expect(configMap_test_1_046_argocd_3).Should(configmapFixture.HaveStringDataKeyValue("application.resourceTrackingMethod", "annotation"))
 
 			By("adding managed-by label to test-1-046-argocd-(1/3), managed by Argo CD instances 1, 2 and 3")
-			namespace.Update(source_ns_1_NS, func(n *corev1.Namespace) {
+			namespaceFixture.Update(source_ns_1_NS, func(n *corev1.Namespace) {
 				if n.Labels == nil {
 					n.Labels = map[string]string{}
 				}
 				n.Labels["argocd.argoproj.io/managed-by"] = "test-1-046-argocd-1"
 			})
 
-			namespace.Update(source_ns_2_NS, func(n *corev1.Namespace) {
+			namespaceFixture.Update(source_ns_2_NS, func(n *corev1.Namespace) {
 				if n.Labels == nil {
 					n.Labels = map[string]string{}
 				}
 				n.Labels["argocd.argoproj.io/managed-by"] = "test-1-046-argocd-2"
 			})
 
-			namespace.Update(source_ns_3_NS, func(n *corev1.Namespace) {
+			namespaceFixture.Update(source_ns_3_NS, func(n *corev1.Namespace) {
 				n.Labels["argocd.argoproj.io/managed-by"] = "test-1-046-argocd-3"
 				if n.Annotations == nil {
 					n.Annotations = map[string]string{}
@@ -270,14 +270,14 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			By("verifying that the Applications successfully deployed, and that they have the correct installation-id and tracking-id, based on which Argo CD instance deployed them")
 
-			Eventually(application_test_1_046_argocd_1, "4m", "5s").Should(application.HaveHealthStatusCode(health.HealthStatusHealthy))
-			Eventually(application_test_1_046_argocd_1, "4m", "5s").Should(application.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
+			Eventually(application_test_1_046_argocd_1, "4m", "5s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
+			Eventually(application_test_1_046_argocd_1, "4m", "5s").Should(applicationFixture.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
 
-			Eventually(application_test_1_046_argocd_2, "4m", "5s").Should(application.HaveHealthStatusCode(health.HealthStatusHealthy))
-			Eventually(application_test_1_046_argocd_2, "4m", "5s").Should(application.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
+			Eventually(application_test_1_046_argocd_2, "4m", "5s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
+			Eventually(application_test_1_046_argocd_2, "4m", "5s").Should(applicationFixture.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
 
-			Eventually(application_test_1_046_argocd_3, "4m", "5s").Should(application.HaveHealthStatusCode(health.HealthStatusHealthy))
-			Eventually(application_test_1_046_argocd_3, "4m", "5s").Should(application.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
+			Eventually(application_test_1_046_argocd_3, "4m", "5s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
+			Eventually(application_test_1_046_argocd_3, "4m", "5s").Should(applicationFixture.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
 
 			deployment_source_ns_1 := &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/openshift/e2e/ginkgo/parallel/1-047_validate_custom_env_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-047_validate_custom_env_test.go
@@ -24,9 +24,9 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
+	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/statefulset"
+	statefulsetFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/statefulset"
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -78,13 +78,13 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 				By("verifying the Deployment " + depl.Name + " has expected env var")
 
-				Eventually(depl, "60s", "5s").Should(deployment.HaveContainerWithEnvVar("FOO", "bar", 0))
+				Eventually(depl, "60s", "5s").Should(deploymentFixture.HaveContainerWithEnvVar("FOO", "bar", 0))
 			}
 
 			ss := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "argocd-application-controller", Namespace: ns.Name}}
 			By("verifying the StatefulSet " + ss.Name + " has expected env var")
 			Eventually(ss).Should(k8sFixture.ExistByName())
-			Eventually(ss, "60s", "5s").Should(statefulset.HaveContainerWithEnvVar("FOO", "bar", 0))
+			Eventually(ss, "60s", "5s").Should(statefulsetFixture.HaveContainerWithEnvVar("FOO", "bar", 0))
 
 		})
 

--- a/test/openshift/e2e/ginkgo/parallel/1-048_validate_controller_sharding_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-048_validate_controller_sharding_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/statefulset"
+	statefulsetFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/statefulset"
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -106,7 +106,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			By("checking if ARGOCD_CONTROLLER_SHARDING_ALGORITHM env var is set in the app controller StatefulSet")
 			Eventually(statefulSet).Should(k8sFixture.ExistByName())
-			Eventually(statefulSet, "60s", "5s").Should(statefulset.HaveContainerWithEnvVar("ARGOCD_CONTROLLER_SHARDING_ALGORITHM", "round-robin", 0), "Statefulset should have expected ARGOCD_CONTROLLER_SHARDING_ALGORITHM to be round-robin")
+			Eventually(statefulSet, "60s", "5s").Should(statefulsetFixture.HaveContainerWithEnvVar("ARGOCD_CONTROLLER_SHARDING_ALGORITHM", "round-robin", 0), "Statefulset should have expected ARGOCD_CONTROLLER_SHARDING_ALGORITHM to be round-robin")
 
 			By("unset algorithm and ensure that it is not set")
 			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {

--- a/test/openshift/e2e/ginkgo/parallel/1-055_validate_notification_controller_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-055_validate_notification_controller_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
+	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -109,8 +109,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			}
 			Eventually(notifDepl).Should(k8sFixture.ExistByName())
 
-			Eventually(notifDepl).Should(deployment.HaveConditionTypeStatus(appsv1.DeploymentAvailable, corev1.ConditionTrue))
-			Eventually(notifDepl).Should(deployment.HaveConditionTypeStatus(appsv1.DeploymentProgressing, corev1.ConditionTrue))
+			Eventually(notifDepl).Should(deploymentFixture.HaveConditionTypeStatus(appsv1.DeploymentAvailable, corev1.ConditionTrue))
+			Eventually(notifDepl).Should(deploymentFixture.HaveConditionTypeStatus(appsv1.DeploymentProgressing, corev1.ConditionTrue))
 
 			notifSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/openshift/e2e/ginkgo/parallel/1-096-validate_home_env_argocd_controller_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-096-validate_home_env_argocd_controller_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/statefulset"
+	statefulsetFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/statefulset"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -46,7 +46,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			}
 			Eventually(ss).Should(k8sFixture.ExistByName())
 
-			Expect(ss).Should(statefulset.HaveContainerWithEnvVar("HOME", "/home/argocd", 0))
+			Expect(ss).Should(statefulsetFixture.HaveContainerWithEnvVar("HOME", "/home/argocd", 0))
 
 			By("verifying REDIS_PASSWORD env var is no longer set (replaced by redis-initial-pass volume mount)")
 			container := ss.Spec.Template.Spec.Containers[0]

--- a/test/openshift/e2e/ginkgo/parallel/1-109_validate_reencrypt_termination_policy_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-109_validate_reencrypt_termination_policy_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/route"
+	routeFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/route"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -39,7 +39,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				Termination:                   routev1.TLSTerminationReencrypt,
 			}))
 
-			Eventually(serverRoute, "3m", "5s").Should(route.HaveAdmittedIngress())
+			Eventually(serverRoute, "3m", "5s").Should(routeFixture.HaveAdmittedIngress())
 
 			Expect(serverRoute.Spec.Host).ToNot(BeEmpty())
 

--- a/test/openshift/e2e/ginkgo/parallel/1-118_validate_redis_ssc_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-118_validate_redis_ssc_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/node"
+	nodeFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/node"
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,7 +54,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			fixture.EnsureRunningOnOpenShift() // SSC requires OpenShift
 
 			// This test enables HA redis and thus requires at least 3 nodes
-			node.ExpectHasAtLeastXNodes(3)
+			nodeFixture.ExpectHasAtLeastXNodes(3)
 
 			By("creating basic Argo CD instance with HA enabled and waiting for it to be available")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()

--- a/test/openshift/e2e/ginkgo/parallel/1-126_validate_declarative_webhook_secrets_test.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-126_validate_declarative_webhook_secrets_test.go
@@ -84,16 +84,16 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			Expect(k8sClient.Create(ctx, userSecret)).To(Succeed())
 
 			By("setting spec.webhookSecrets.github.webhookSecretRef on the ArgoCD CR")
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(argoCD), argoCD)).To(Succeed())
-			argoCD.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
-				GitHub: &argov1beta1api.ArgoCDWebhookSecretsGitHub{
-					WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{
-						Name: "github-webhook-credentials",
-						Key:  "token",
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
+					GitHub: &argov1beta1api.ArgoCDWebhookSecretsGitHub{
+						WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{
+							Name: "github-webhook-credentials",
+							Key:  "token",
+						},
 					},
-				},
-			}
-			Expect(k8sClient.Update(ctx, argoCD)).To(Succeed())
+				}
+			})
 
 			By("waiting for argocd-secret to contain webhook.github.secret matching the referenced Secret")
 			Eventually(argocdSecret, "2m", "3s").Should(
@@ -133,16 +133,16 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			Expect(k8sClient.Create(ctx, userSecret)).To(Succeed())
 
 			By("setting spec.webhookSecrets.gitlab.webhookSecretRef on the ArgoCD CR")
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(argoCD), argoCD)).To(Succeed())
-			argoCD.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
-				GitLab: &argov1beta1api.ArgoCDWebhookSecretsGitLab{
-					WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{
-						Name: "gitlab-webhook-credentials",
-						Key:  "secret",
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
+					GitLab: &argov1beta1api.ArgoCDWebhookSecretsGitLab{
+						WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{
+							Name: "gitlab-webhook-credentials",
+							Key:  "secret",
+						},
 					},
-				},
-			}
-			Expect(k8sClient.Update(ctx, argoCD)).To(Succeed())
+				}
+			})
 
 			By("waiting for argocd-secret to contain webhook.gitlab.secret matching the referenced Secret")
 			Eventually(argocdSecret, "2m", "3s").Should(
@@ -186,20 +186,20 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			Expect(k8sClient.Create(ctx, userSecret)).To(Succeed())
 
 			By("setting spec.webhookSecrets.azureDevOps on the ArgoCD CR")
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(argoCD), argoCD)).To(Succeed())
-			argoCD.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
-				AzureDevOps: &argov1beta1api.ArgoCDWebhookSecretsAzureDevOps{
-					UsernameSecretRef: &argov1beta1api.WebhookSecretKeySelector{
-						Name: "ado-webhook-credentials",
-						Key:  "username",
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
+					AzureDevOps: &argov1beta1api.ArgoCDWebhookSecretsAzureDevOps{
+						UsernameSecretRef: &argov1beta1api.WebhookSecretKeySelector{
+							Name: "ado-webhook-credentials",
+							Key:  "username",
+						},
+						PasswordSecretRef: &argov1beta1api.WebhookSecretKeySelector{
+							Name: "ado-webhook-credentials",
+							Key:  "password",
+						},
 					},
-					PasswordSecretRef: &argov1beta1api.WebhookSecretKeySelector{
-						Name: "ado-webhook-credentials",
-						Key:  "password",
-					},
-				},
-			}
-			Expect(k8sClient.Update(ctx, argoCD)).To(Succeed())
+				}
+			})
 
 			By("waiting for both Azure DevOps keys in argocd-secret")
 			Eventually(argocdSecret, "2m", "3s").Should(
@@ -247,16 +247,16 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			})).To(Succeed())
 
 			By("setting spec.webhookSecrets.github and spec.webhookSecrets.gitlab on the ArgoCD CR")
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(argoCD), argoCD)).To(Succeed())
-			argoCD.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
-				GitHub: &argov1beta1api.ArgoCDWebhookSecretsGitHub{
-					WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "gh-creds", Key: "token"},
-				},
-				GitLab: &argov1beta1api.ArgoCDWebhookSecretsGitLab{
-					WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "gl-creds", Key: "secret"},
-				},
-			}
-			Expect(k8sClient.Update(ctx, argoCD)).To(Succeed())
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
+					GitHub: &argov1beta1api.ArgoCDWebhookSecretsGitHub{
+						WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "gh-creds", Key: "token"},
+					},
+					GitLab: &argov1beta1api.ArgoCDWebhookSecretsGitLab{
+						WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "gl-creds", Key: "secret"},
+					},
+				}
+			})
 
 			By("waiting for argocd-secret to contain GitHub and GitLab webhook keys")
 			Eventually(argocdSecret, "2m", "3s").Should(
@@ -310,19 +310,19 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			})).To(Succeed())
 
 			By("setting spec.webhookSecrets for Bitbucket Cloud, Bitbucket Server, and Gogs on the ArgoCD CR")
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(argoCD), argoCD)).To(Succeed())
-			argoCD.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
-				Bitbucket: &argov1beta1api.ArgoCDWebhookSecretsBitbucket{
-					WebhookUUIDSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "bb-cloud-creds", Key: "uuid"},
-				},
-				BitbucketServer: &argov1beta1api.ArgoCDWebhookSecretsBitbucketServer{
-					WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "bb-server-creds", Key: "secret"},
-				},
-				Gogs: &argov1beta1api.ArgoCDWebhookSecretsGogs{
-					WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "gogs-creds", Key: "secret"},
-				},
-			}
-			Expect(k8sClient.Update(ctx, argoCD)).To(Succeed())
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
+					Bitbucket: &argov1beta1api.ArgoCDWebhookSecretsBitbucket{
+						WebhookUUIDSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "bb-cloud-creds", Key: "uuid"},
+					},
+					BitbucketServer: &argov1beta1api.ArgoCDWebhookSecretsBitbucketServer{
+						WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "bb-server-creds", Key: "secret"},
+					},
+					Gogs: &argov1beta1api.ArgoCDWebhookSecretsGogs{
+						WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "gogs-creds", Key: "secret"},
+					},
+				}
+			})
 
 			By("waiting for argocd-secret to contain Bitbucket Cloud, Bitbucket Server, and Gogs webhook keys")
 			Eventually(argocdSecret, "2m", "3s").Should(
@@ -399,13 +399,13 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				StringData: map[string]string{"token": token},
 			})).To(Succeed())
 
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(argoCD), argoCD)).To(Succeed())
-			argoCD.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
-				GitHub: &argov1beta1api.ArgoCDWebhookSecretsGitHub{
-					WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "gh-nil-stanza-creds", Key: "token"},
-				},
-			}
-			Expect(k8sClient.Update(ctx, argoCD)).To(Succeed())
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
+					GitHub: &argov1beta1api.ArgoCDWebhookSecretsGitHub{
+						WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "gh-nil-stanza-creds", Key: "token"},
+					},
+				}
+			})
 
 			Eventually(argocdSecret, "2m", "3s").Should(
 				secretFixture.HaveDataKeyValue(common.ArgoCDKeyGitHubWebhookSecret, []byte(token)),
@@ -452,13 +452,13 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				StringData: map[string]string{"token": token},
 			})).To(Succeed())
 
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(argoCD), argoCD)).To(Succeed())
-			argoCD.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
-				GitHub: &argov1beta1api.ArgoCDWebhookSecretsGitHub{
-					WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "gh-clear-creds", Key: "token"},
-				},
-			}
-			Expect(k8sClient.Update(ctx, argoCD)).To(Succeed())
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
+					GitHub: &argov1beta1api.ArgoCDWebhookSecretsGitHub{
+						WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "gh-clear-creds", Key: "token"},
+					},
+				}
+			})
 
 			By("waiting for argocd-secret to contain webhook.github.secret")
 			Eventually(argocdSecret, "2m", "3s").Should(
@@ -510,16 +510,16 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				StringData: map[string]string{"secret": glSec},
 			})).To(Succeed())
 
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(argoCD), argoCD)).To(Succeed())
-			argoCD.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
-				GitHub: &argov1beta1api.ArgoCDWebhookSecretsGitHub{
-					WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "partial-gh", Key: "token"},
-				},
-				GitLab: &argov1beta1api.ArgoCDWebhookSecretsGitLab{
-					WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "partial-gl", Key: "secret"},
-				},
-			}
-			Expect(k8sClient.Update(ctx, argoCD)).To(Succeed())
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
+					GitHub: &argov1beta1api.ArgoCDWebhookSecretsGitHub{
+						WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "partial-gh", Key: "token"},
+					},
+					GitLab: &argov1beta1api.ArgoCDWebhookSecretsGitLab{
+						WebhookSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "partial-gl", Key: "secret"},
+					},
+				}
+			})
 
 			By("waiting for argocd-secret to contain GitHub and GitLab webhook keys")
 			Eventually(argocdSecret, "2m", "3s").Should(
@@ -574,14 +574,14 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				StringData: map[string]string{"username": u, "password": p},
 			})).To(Succeed())
 
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(argoCD), argoCD)).To(Succeed())
-			argoCD.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
-				AzureDevOps: &argov1beta1api.ArgoCDWebhookSecretsAzureDevOps{
-					UsernameSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "ado-drop-creds", Key: "username"},
-					PasswordSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "ado-drop-creds", Key: "password"},
-				},
-			}
-			Expect(k8sClient.Update(ctx, argoCD)).To(Succeed())
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
+					AzureDevOps: &argov1beta1api.ArgoCDWebhookSecretsAzureDevOps{
+						UsernameSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "ado-drop-creds", Key: "username"},
+						PasswordSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "ado-drop-creds", Key: "password"},
+					},
+				}
+			})
 
 			By("waiting for argocd-secret to contain Azure DevOps webhook username and password")
 			Eventually(argocdSecret, "2m", "3s").Should(
@@ -633,14 +633,14 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				StringData: map[string]string{"username": u, "password": p},
 			})).To(Succeed())
 
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(argoCD), argoCD)).To(Succeed())
-			argoCD.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
-				AzureDevOps: &argov1beta1api.ArgoCDWebhookSecretsAzureDevOps{
-					UsernameSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "ado-atomic-creds", Key: "username"},
-					PasswordSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "ado-atomic-creds", Key: "password"},
-				},
-			}
-			Expect(k8sClient.Update(ctx, argoCD)).To(Succeed())
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.WebhookSecrets = &argov1beta1api.ArgoCDWebhookSecretsSpec{
+					AzureDevOps: &argov1beta1api.ArgoCDWebhookSecretsAzureDevOps{
+						UsernameSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "ado-atomic-creds", Key: "username"},
+						PasswordSecretRef: &argov1beta1api.WebhookSecretKeySelector{Name: "ado-atomic-creds", Key: "password"},
+					},
+				}
+			})
 
 			Eventually(argocdSecret, "2m", "3s").Should(
 				And(

--- a/test/openshift/e2e/ginkgo/parallel/1-141_source_hydrator.go
+++ b/test/openshift/e2e/ginkgo/parallel/1-141_source_hydrator.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/argoproj-labs/argocd-operator/common"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/gitserver"
+	gitserverFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/gitserver"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/health"
@@ -307,7 +307,7 @@ patches:
 		It("hydrate kustomize to another branch via ssh", Label("openshift"), func() {
 			ns, nsCleanup = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
-			server, cleanup := gitserver.StartServer(ctx, k8sClient, ns)
+			server, cleanup := gitserverFixture.StartServer(ctx, k8sClient, ns)
 			gitServerCleanup = cleanup
 
 			argoCD := &argov1beta1api.ArgoCD{
@@ -339,10 +339,10 @@ patches:
 			repo := server.CreateRepo("hydrator-kustomize")
 
 			By("pushing dry source before creating the Application")
-			cleanup, err := repo.Clone(gitserver.TransportSSH)
+			cleanup, err := repo.Clone(gitserverFixture.TransportSSH)
 			Expect(err).NotTo(HaveOccurred())
 			gitRepoCleanup = cleanup
-			dryCommit := gitserver.Commit{
+			dryCommit := gitserverFixture.Commit{
 				Branch: "dry",
 				Files:  kustomizeDrySourceFiles,
 			}
@@ -388,8 +388,8 @@ patches:
 					Equal(argocdv1alpha1.HydrateOperationPhaseHydrated),
 				)
 			}, "1m", "5s").Should(Succeed())
-			Expect(app).Should(appFixture.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
-			Expect(app).Should(appFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
+			Eventually(app, "4m", "5s").Should(appFixture.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
+			Eventually(app, "4m", "5s").Should(appFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
 
 			By("verifying prod overlay patch was applied to the synced ConfigMap")
 			syncedCM := &corev1.ConfigMap{
@@ -413,7 +413,7 @@ patches:
 		It("hydrate helm to another directory via https", Label("openshift"), func() {
 			ns, nsCleanup = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
-			server, cleanup := gitserver.StartServer(ctx, k8sClient, ns)
+			server, cleanup := gitserverFixture.StartServer(ctx, k8sClient, ns)
 			gitServerCleanup = cleanup
 
 			argoCD := &argov1beta1api.ArgoCD{
@@ -446,10 +446,10 @@ patches:
 			repo := server.CreateRepo("hydrator-helm")
 
 			By("pushing dry source before creating the Application")
-			cleanup, err := repo.Clone(gitserver.TransportHTTPS)
+			cleanup, err := repo.Clone(gitserverFixture.TransportHTTPS)
 			Expect(err).NotTo(HaveOccurred())
 			gitRepoCleanup = cleanup
-			dryCommit := gitserver.Commit{
+			dryCommit := gitserverFixture.Commit{
 				Branch: "main",
 				Files:  helmDrySourceFiles,
 			}

--- a/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-006_validate_machine_config_test.go
@@ -25,8 +25,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/application"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
+	applicationFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/application"
+	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
 	statefulsetFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/statefulset"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 
@@ -132,8 +132,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					expectedReadyReplicas = 2
 					expectedReplicas = 2
 				}
-				Eventually(depl).Should(deployment.HaveReplicas(expectedReplicas))
-				Eventually(depl, "2m", "5s").Should(deployment.HaveReadyReplicas(expectedReadyReplicas))
+				Eventually(depl).Should(deploymentFixture.HaveReplicas(expectedReplicas))
+				Eventually(depl, "2m", "5s").Should(deploymentFixture.HaveReadyReplicas(expectedReadyReplicas))
 			}
 
 			ss := &appsv1.StatefulSet{
@@ -147,8 +147,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(ss, "2m", "5s").Should(statefulsetFixture.HaveReadyReplicas(1))
 
 			By("verifying the Application has deployed successfully")
-			Eventually(app, "4m", "5s").Should(application.HaveHealthStatusCode(health.HealthStatusHealthy))
-			Eventually(app, "4m", "5s").Should(application.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
+			Eventually(app, "4m", "5s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
+			Eventually(app, "4m", "5s").Should(applicationFixture.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
 
 			By("updating repo server replicas back to 1")
 			argocdFixture.Update(defaultArgoCD, func(ac *argov1beta1api.ArgoCD) {
@@ -160,8 +160,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "openshift-gitops-repo-server", Namespace: defaultArgoCD.Namespace},
 			}
 			Eventually(repoServerDepl).Should(k8sFixture.ExistByName())
-			Eventually(repoServerDepl).Should(deployment.HaveReplicas(1))
-			Eventually(repoServerDepl, "2m", "5s").Should(deployment.HaveReadyReplicas(1))
+			Eventually(repoServerDepl).Should(deploymentFixture.HaveReplicas(1))
+			Eventually(repoServerDepl, "2m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
 
 		})
 

--- a/test/openshift/e2e/ginkgo/sequential/1-010_validate-ootb-manage-other-namespace_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-010_validate-ootb-manage-other-namespace_test.go
@@ -27,7 +27,7 @@ import (
 	appFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/application"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/namespace"
+	namespaceFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/namespace"
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -133,7 +133,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(app, "4m", "5s").Should(appFixture.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
 
 			By("removing managed-by label from the other namespace")
-			namespace.Update(nsTest_1_10_custom, func(n *corev1.Namespace) {
+			namespaceFixture.Update(nsTest_1_10_custom, func(n *corev1.Namespace) {
 				delete(n.Labels, "argocd.argoproj.io/managed-by")
 			})
 

--- a/test/openshift/e2e/ginkgo/sequential/1-012_validate-managed-by-chain_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-012_validate-managed-by-chain_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package parallel
+package sequential
 
 import (
 	"context"
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
+var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-012_validate-managed-by-chain", func() {
 
@@ -51,7 +51,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 		)
 
 		BeforeEach(func() {
-			fixture.EnsureParallelCleanSlate()
+			fixture.EnsureSequentialCleanSlate()
 			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
 			ctx = context.Background()
 			cleanupfuncs = make([]func(), 0)

--- a/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-018_validate_disable_default_instance_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
+	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 	statefulsetFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/statefulset"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
@@ -94,7 +94,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					ObjectMeta: metav1.ObjectMeta{Name: deplName, Namespace: "openshift-gitops"},
 				}
 				Eventually(depl, "3m", "5s").Should(k8sFixture.ExistByName())
-				Eventually(depl, "5m", "5s").Should(deployment.HaveReadyReplicas(1))
+				Eventually(depl, "5m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
 			}
 
 			Eventually(ss, "3m", "5s").Should(k8sFixture.ExistByName())
@@ -123,10 +123,10 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				},
 			}
 			Eventually(operatorControllerDepl).Should(k8sFixture.ExistByName())
-			Eventually(operatorControllerDepl).Should(deployment.HaveContainerWithEnvVar("DISABLE_DEFAULT_ARGOCD_INSTANCE", "true", 0))
-			Eventually(operatorControllerDepl).Should(deployment.HaveReplicas(1))
-			Eventually(operatorControllerDepl).Should(deployment.HaveAvailableReplicas(1))
-			Eventually(operatorControllerDepl).Should(deployment.HaveReadyReplicas(1))
+			Eventually(operatorControllerDepl).Should(deploymentFixture.HaveContainerWithEnvVar("DISABLE_DEFAULT_ARGOCD_INSTANCE", "true", 0))
+			Eventually(operatorControllerDepl).Should(deploymentFixture.HaveReplicas(1))
+			Eventually(operatorControllerDepl).Should(deploymentFixture.HaveAvailableReplicas(1))
+			Eventually(operatorControllerDepl).Should(deploymentFixture.HaveReadyReplicas(1))
 
 			By("verifying ArgoCD CR no longer exists")
 			openshiftGitopsArgoCD = &v1beta1.ArgoCD{
@@ -167,8 +167,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				}
 				Eventually(depl).Should(k8sFixture.ExistByName())
 
-				Eventually(depl).Should(deployment.HaveReplicas(1))
-				Eventually(depl, "2m", "5s").Should(deployment.HaveReadyReplicas(1))
+				Eventually(depl).Should(deploymentFixture.HaveReplicas(1))
+				Eventually(depl, "2m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
 			}
 
 			ss := &appsv1.StatefulSet{

--- a/test/openshift/e2e/ginkgo/sequential/1-020_validate_redis_ha_nonha_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-020_validate_redis_ha_nonha_test.go
@@ -24,7 +24,7 @@ import (
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
 	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/node"
+	nodeFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/node"
 	statefulsetFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/statefulset"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -45,7 +45,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		It("validates Redis HA and Non-HA", Label("openshift"), func() {
 
 			// This test enables HA, so it needs to be running on a cluster with at least 3 nodes
-			node.ExpectHasAtLeastXNodes(3)
+			nodeFixture.ExpectHasAtLeastXNodes(3)
 
 			By("ensuring the openshift-gitops Argo CD instance is running")
 			gitopsArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()

--- a/test/openshift/e2e/ginkgo/sequential/1-025-validate-managed-by-change_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-025-validate-managed-by-change_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package parallel
+package sequential
 
 import (
 	"context"
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
+var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-025-validate-managed-by-change", func() {
 
@@ -53,7 +53,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 		)
 
 		BeforeEach(func() {
-			fixture.EnsureParallelCleanSlate()
+			fixture.EnsureSequentialCleanSlate()
 			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
 			ctx = context.Background()
 		})

--- a/test/openshift/e2e/ginkgo/sequential/1-040_validate_quoted_RBAC_group_names_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-040_validate_quoted_RBAC_group_names_test.go
@@ -5,12 +5,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	routev1 "github.com/openshift/api/route/v1"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
-	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
-	routeFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/route"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
@@ -39,16 +35,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			defaultArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(defaultArgoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
-
-			By("verifying the argocd-server route in openshift-gitops namespace has been admitted, so avoid short race condition where Argo CD is deployed, but Route isn't available yet, so it can't be used to log in")
-			serverRoute := &routev1.Route{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "openshift-gitops-server",
-					Namespace: "openshift-gitops",
-				},
-			}
-			Eventually(serverRoute).Should(k8sFixture.ExistByName())
-			Eventually(serverRoute).Should(routeFixture.HaveAdmittedIngress())
 
 			By("logging in to Argo CD instance")
 			Expect(argocdFixture.LogInToDefaultArgoCDInstance()).To(Succeed())

--- a/test/openshift/e2e/ginkgo/sequential/1-059_validate_argocd_agent_terminal_streaming_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-059_validate_argocd_agent_terminal_streaming_test.go
@@ -45,7 +45,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -163,7 +162,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			deployPrincipal(ctx, k8sClient, registerCleanup, true)
 
 			By("Enable exec feature in ArgoCD server configuration")
-			enableExecInArgoCD(ctx, k8sClient, argoCDAgentInstanceNamePrincipal, namespaceAgentPrincipal)
+			enableExecInArgoCD(argoCDAgentInstanceNamePrincipal, namespaceAgentPrincipal)
 
 			By("Wait for ArgoCD server to restart with exec enabled")
 			Eventually(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
@@ -319,23 +318,24 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 // enableExecInArgoCD configures the ArgoCD CR to enable the web-based terminal.
 // through spec.extraConfig and grant the admin role exec permission via spec.rbac.policy.
-func enableExecInArgoCD(ctx context.Context, k8sClient client.Client, argocdName, namespace string) {
+func enableExecInArgoCD(argocdName, namespace string) {
 	GinkgoHelper()
 
-	argoCD := &argov1beta1api.ArgoCD{}
-	Expect(k8sClient.Get(ctx, types.NamespacedName{
-		Name:      argocdName,
-		Namespace: namespace,
-	}, argoCD)).To(Succeed())
-
-	if argoCD.Spec.ExtraConfig == nil {
-		argoCD.Spec.ExtraConfig = map[string]string{}
+	argoCD := &argov1beta1api.ArgoCD{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      argocdName,
+			Namespace: namespace,
+		},
 	}
-	argoCD.Spec.ExtraConfig["exec.enabled"] = "true"
-	argoCD.Spec.ExtraConfig["exec.shells"] = "bash,sh,ash,/bin/bash,/bin/sh,/bin/ash"
 
-	execPolicy := "p, role:admin, exec, create, */*, allow"
-	argoCD.Spec.RBAC.Policy = &execPolicy
+	argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+		if ac.Spec.ExtraConfig == nil {
+			ac.Spec.ExtraConfig = map[string]string{}
+		}
+		ac.Spec.ExtraConfig["exec.enabled"] = "true"
+		ac.Spec.ExtraConfig["exec.shells"] = "bash,sh,ash,/bin/bash,/bin/sh,/bin/ash"
 
-	Expect(k8sClient.Update(ctx, argoCD)).To(Succeed())
+		execPolicy := "p, role:admin, exec, create, */*, allow"
+		ac.Spec.RBAC.Policy = &execPolicy
+	})
 }

--- a/test/openshift/e2e/ginkgo/sequential/1-064_validate_tcp_reset_error_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-064_validate_tcp_reset_error_test.go
@@ -24,14 +24,12 @@ import (
 	argocdv1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	routev1 "github.com/openshift/api/route/v1"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	appFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/application"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 	namespaceFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/namespace"
 	osFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/os"
-	routeFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/route"
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -150,16 +148,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			Eventually(guestbookApp, "4m", "5s").Should(appFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
 			Eventually(guestbookApp, "4m", "5s").Should(appFixture.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
-
-			By("verifying the argocd-server route in openshift-gitops namespace has been admitted, to avoid race condition where Argo CD is available but the Route isn't yet")
-			serverRoute := &routev1.Route{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "openshift-gitops-server",
-					Namespace: "openshift-gitops",
-				},
-			}
-			Eventually(serverRoute).Should(k8sFixture.ExistByName())
-			Eventually(serverRoute).Should(routeFixture.HaveAdmittedIngress())
 
 			By("verifying we can log in to Argo CD via CLI")
 			Expect(argocdFixture.LogInToDefaultArgoCDInstance()).To(Succeed())

--- a/test/openshift/e2e/ginkgo/sequential/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package parallel
+package sequential
 
 import (
 	"context"
@@ -41,7 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
+var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-067_validate_redis_secure_comm_no_autotls_ha", func() {
 
@@ -53,7 +53,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 		)
 
 		BeforeEach(func() {
-			fixture.EnsureParallelCleanSlate()
+			fixture.EnsureSequentialCleanSlate()
 
 			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
 			ctx = context.Background()
@@ -85,7 +85,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			expectComponentsAreRunning := func() {
 
-				// In BeAvailable() we wait 15 seconds for ArgoCD CR to be reconciled, this SHOULD be enough time.
+				// In BeAvailable() we wait 10 seconds for ArgoCD CR to be reconciled, this SHOULD be enough time.
 
 				By("waiting for ArgoCD CR to be reconciled and the instance to be ready")
 				Eventually(argoCD, "10m", "10s").Should(argocdFixture.BeAvailable())
@@ -180,8 +180,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				if err != nil {
 					return err
 				}
-				GinkgoWriter.Println("redis conf values:")
-				GinkgoWriter.Println(redisConf)
+
+				fmt.Println("redis conf has length:", len(redisConf))
 
 				for _, line := range expectedRedisConfig {
 					if !strings.Contains(redisConf, line) {
@@ -193,7 +193,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			// First, wait for redis.conf to eventually contain the expected values, then
 			// verify it consistently contains them.
-			Eventually(redisConfHasExpectedValues, "2m", "5s").Should(Succeed())
+			Eventually(redisConfHasExpectedValues, "10m", "5s").Should(Succeed())
 			Consistently(redisConfHasExpectedValues, "30s", "5s").Should(Succeed())
 
 			By("extracting the contents of /data/conf/sentinel.conf and checking it contains expected values")
@@ -219,8 +219,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				if err != nil {
 					return err
 				}
-				GinkgoWriter.Println("sentinel conf values:")
-				GinkgoWriter.Println(sentinelConf)
+
+				fmt.Println("sentinel conf has length:", len(sentinelConf))
 
 				for _, line := range expectedSentinelConfig {
 					matched, err := regexp.MatchString(line, sentinelConf)

--- a/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-071_validate_SCC_HA_test.go
@@ -27,7 +27,7 @@ import (
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 	nodeFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/node"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/pod"
+	podFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/pod"
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -180,11 +180,11 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			redisServer1Pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "argocd-redis-ha-server-1", Namespace: ns.Name}}
 			Eventually(redisServer1Pod, "3m", "1s").Should(k8sFixture.ExistByName())
-			Eventually(redisServer1Pod, "3m", "1s").Should(pod.HavePhase(corev1.PodRunning))
+			Eventually(redisServer1Pod, "3m", "1s").Should(podFixture.HavePhase(corev1.PodRunning))
 
 			redisServer2Pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "argocd-redis-ha-server-2", Namespace: ns.Name}}
 			Eventually(redisServer2Pod, "3m", "1s").Should(k8sFixture.ExistByName())
-			Eventually(redisServer2Pod, "3m", "1s").Should(pod.HavePhase(corev1.PodRunning))
+			Eventually(redisServer2Pod, "3m", "1s").Should(podFixture.HavePhase(corev1.PodRunning))
 
 		})
 

--- a/test/openshift/e2e/ginkgo/sequential/1-084_validate_prune_templates.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-084_validate_prune_templates.go
@@ -10,8 +10,9 @@ import (
 
 	argov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
+	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
+	namespaceFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/namespace"
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 
 	corev1 "k8s.io/api/core/v1"
@@ -44,11 +45,12 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(ns), ns)
 			Expect(err).ToNot(HaveOccurred())
 
-			if ns.Labels == nil {
-				ns.Labels = make(map[string]string)
-			}
-			ns.Labels["argocd.argoproj.io/managed-by"] = "openshift-gitops"
-			Expect(k8sClient.Update(ctx, ns)).To(Succeed())
+			namespaceFixture.Update(ns, func(n *corev1.Namespace) {
+				if ns.Labels == nil {
+					ns.Labels = make(map[string]string)
+				}
+				ns.Labels["argocd.argoproj.io/managed-by"] = "openshift-gitops"
+			})
 
 			By("waiting for the operator to create rolebindings in the managed namespace")
 			argoCDServerRB := &rbacv1.RoleBinding{
@@ -142,8 +144,12 @@ labels:
 			err = os.WriteFile(filepath.Join(workDir, "app-template2.yaml"), []byte(template2), 0600)
 			Expect(err).ToNot(HaveOccurred())
 
+			defaultArgoCD, err := argocdFixture.GetOpenShiftGitOpsNSArgoCD()
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(defaultArgoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+
 			By("logging into the Argo CD CLI")
-			err = argocd.LogInToDefaultArgoCDInstance()
+			err = argocdFixture.LogInToDefaultArgoCDInstance()
 			Expect(err).ToNot(HaveOccurred(), "Failed to login to Argo CD")
 
 			By("Creating ArgoCD Application CR using the typed schema")
@@ -178,7 +184,7 @@ labels:
 			})
 
 			By("syncing the application using the local dir")
-			out, err := argocd.RunArgoCDCLI("app", "sync", appName, "--local", workDir, "--timeout", "100")
+			out, err := argocdFixture.RunArgoCDCLI("app", "sync", appName, "--local", workDir, "--timeout", "100")
 			Expect(err).ToNot(HaveOccurred(), "Failed to sync app with local flag: %s", out)
 
 			By("verifying both templates were created")
@@ -198,7 +204,7 @@ labels:
 			Expect(err).ToNot(HaveOccurred())
 
 			By("syncing the application again this time with the prune flag enabled")
-			out, err = argocd.RunArgoCDCLI("app", "sync", appName, "--local", workDir, "--prune", "--timeout", "100")
+			out, err = argocdFixture.RunArgoCDCLI("app", "sync", appName, "--local", workDir, "--prune", "--timeout", "100")
 			Expect(err).ToNot(HaveOccurred(), "Failed to sync and prune app: %s", out)
 
 			By("verifying the deleted template was pruned from the cluster")

--- a/test/openshift/e2e/ginkgo/sequential/1-085_validate_dynamic_plugin_installation_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-085_validate_dynamic_plugin_installation_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/clusterserviceversion"
+	clusterserviceversionFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/clusterserviceversion"
 	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 	osFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/os"
@@ -86,7 +86,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			By("adding DYNAMIC_PLUGIN_START_OCP_VERSION to CSV operator Deployment env var list")
 
-			clusterserviceversion.Update(csv, func(csv *olmv1alpha1.ClusterServiceVersion) {
+			clusterserviceversionFixture.Update(csv, func(csv *olmv1alpha1.ClusterServiceVersion) {
 
 				envList := csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Env
 				envList = append(envList, corev1.EnvVar{Name: "DYNAMIC_PLUGIN_START_OCP_VERSION", Value: ocVersion})

--- a/test/openshift/e2e/ginkgo/sequential/1-092_validate_workload_status_monitoring_alert.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-092_validate_workload_status_monitoring_alert.go
@@ -11,7 +11,9 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
+	configmapFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/configmap"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
+	namespaceFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/namespace"
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -72,27 +74,25 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			By("labeling the namespace for monitoring")
 			// prometheus will only scrape user workload namespaces that have this label
-			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(nsNamespaced), nsNamespaced)
-			Expect(err).NotTo(HaveOccurred())
-
-			if nsNamespaced.Labels == nil {
-				nsNamespaced.Labels = make(map[string]string)
-			}
-			nsNamespaced.Labels["openshift.io/cluster-monitoring"] = "true"
-			err = k8sClient.Update(ctx, nsNamespaced)
-			Expect(err).NotTo(HaveOccurred())
+			namespaceFixture.Update(nsNamespaced, func(n *corev1.Namespace) {
+				if n.Labels == nil {
+					n.Labels = make(map[string]string)
+				}
+				n.Labels["openshift.io/cluster-monitoring"] = "true"
+			})
 
 			By("enabling user workload monitoring in the cluster monitoring config map")
 			existingCM := &corev1.ConfigMap{}
-			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(uwmConfigMap), existingCM)
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(uwmConfigMap), existingCM)
 
 			cmExisted := (err == nil)
 			var originalData map[string]string
 
 			if cmExisted {
 				originalData = existingCM.Data
-				existingCM.Data = uwmConfigMap.Data
-				Expect(k8sClient.Update(ctx, existingCM)).To(Succeed(), "Failed to update existing UWM ConfigMap")
+				configmapFixture.Update(existingCM, func(cm *corev1.ConfigMap) {
+					cm.Data = uwmConfigMap.Data
+				})
 			} else if errors.IsNotFound(err) {
 				Expect(k8sClient.Create(ctx, uwmConfigMap)).To(Succeed(), "Failed to create UWM ConfigMap")
 			} else {
@@ -102,10 +102,10 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			DeferCleanup(func() {
 				By("restoring or deleting cluster monitoring config")
 				if cmExisted {
-					revertCM := &corev1.ConfigMap{}
-					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(uwmConfigMap), revertCM)).To(Succeed())
-					revertCM.Data = originalData
-					Expect(k8sClient.Update(ctx, revertCM)).To(Succeed())
+					revertCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: uwmConfigMap.Name, Namespace: uwmConfigMap.Namespace}}
+					configmapFixture.Update(revertCM, func(cm *corev1.ConfigMap) {
+						cm.Data = originalData
+					})
 				} else {
 					_ = k8sClient.Delete(ctx, uwmConfigMap)
 				}

--- a/test/openshift/e2e/ginkgo/sequential/1-108_alternate_cluster_roles_cluster_scoped_instance_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-108_alternate_cluster_roles_cluster_scoped_instance_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	appFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/application"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/clusterrole"
+	clusterroleFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/clusterrole"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 	persistentvolumeFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/persistentvolume"
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
@@ -371,7 +371,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}).Should(BeTrue())
 
 			By("adding permissions back to the clusterrole")
-			clusterrole.Update(crAppController, func(cr *rbacv1.ClusterRole) {
+			clusterroleFixture.Update(crAppController, func(cr *rbacv1.ClusterRole) {
 				cr.Rules = []rbacv1.PolicyRule{
 					{
 						Verbs:     []string{"get", "list", "watch"},

--- a/test/openshift/e2e/ginkgo/sequential/1-112_validate_rollout_plugin_support_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-112_validate_rollout_plugin_support_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/configmap"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
+	configmapFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/configmap"
+	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -114,7 +114,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				},
 			}
 			Eventually(depl).Should(k8sFixture.ExistByName())
-			Eventually(depl, "3m", "5s").Should(deployment.HaveReadyReplicas(1))
+			Eventually(depl, "3m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
 
 			metricsService := &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -132,7 +132,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				},
 			}
 			Eventually(rolloutsConfigMap).Should(k8sFixture.ExistByName())
-			Eventually(rolloutsConfigMap).Should(configmap.HaveStringDataKeyValue("metricProviderPlugins", `
+			Eventually(rolloutsConfigMap).Should(configmapFixture.HaveStringDataKeyValue("metricProviderPlugins", `
 - name: argoproj-labs/sample-prometheus
   location: https://github.com/argoproj-labs/sample-rollouts-metric-plugin/releases/download/v0.0.4/metric-plugin-linux-amd64
   sha256: af83581a496cebad569c6ddca4e1b7beef1c6f51573d6cd235cebe4390d3a767`))
@@ -157,7 +157,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
   location: file:/plugins/rollouts-trafficrouter-openshift/openshift-route-plugin
   sha256: ""`
 			}
-			Eventually(rolloutsConfigMap).Should(configmap.HaveStringDataKeyValue("trafficRouterPlugins", expectedTrafficRouterPluginsVal))
+			Eventually(rolloutsConfigMap).Should(configmapFixture.HaveStringDataKeyValue("trafficRouterPlugins", expectedTrafficRouterPluginsVal))
 
 		})
 

--- a/test/openshift/e2e/ginkgo/sequential/1-114_validate_imagepullpolicy_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-114_validate_imagepullpolicy_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
+	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 	statefulsetFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/statefulset"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
@@ -84,7 +84,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					ObjectMeta: metav1.ObjectMeta{Name: deplName, Namespace: ns.Name},
 				}
 				Eventually(depl, "3m", "5s").Should(k8sFixture.ExistByName())
-				Eventually(depl, "2m", "5s").Should(deployment.HaveReadyReplicas(1))
+				Eventually(depl, "2m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
 
 				// Verify all containers in the deployment have the correct imagePullPolicy
 				Expect(depl.Spec.Template.Spec.Containers).ToNot(BeEmpty())
@@ -129,7 +129,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				Eventually(depl).Should(k8sFixture.ExistByName())
 
 				// Eventually the imagePullPolicy should be updated
-				Eventually(deployment.VerifyDeploymentImagePullPolicy(deplName, ns.Name, corev1.PullIfNotPresent), "3m", "5s").Should(BeTrue(),
+				Eventually(deploymentFixture.VerifyDeploymentImagePullPolicy(deplName, ns.Name, corev1.PullIfNotPresent), "3m", "5s").Should(BeTrue(),
 					"Deployment %s should have all containers with ImagePullPolicy set to IfNotPresent", deplName)
 			}
 
@@ -177,7 +177,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				}
 				Eventually(depl).Should(k8sFixture.ExistByName())
 
-				Eventually(deployment.VerifyDeploymentImagePullPolicy(deplName, "openshift-gitops", corev1.PullAlways), "3m", "5s").Should(BeTrue(),
+				Eventually(deploymentFixture.VerifyDeploymentImagePullPolicy(deplName, "openshift-gitops", corev1.PullAlways), "3m", "5s").Should(BeTrue(),
 					"openshift-gitops Deployment %s should have all containers with ImagePullPolicy set to Always", deplName)
 			}
 
@@ -221,7 +221,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				}
 				Eventually(depl).Should(k8sFixture.ExistByName())
 
-				Eventually(deployment.VerifyDeploymentImagePullPolicy(deplName, "openshift-gitops", corev1.PullIfNotPresent), "3m", "5s").Should(BeTrue(),
+				Eventually(deploymentFixture.VerifyDeploymentImagePullPolicy(deplName, "openshift-gitops", corev1.PullIfNotPresent), "3m", "5s").Should(BeTrue(),
 					"openshift-gitops Deployment %s should have all containers with ImagePullPolicy set to default(IfNotPresent)", deplName)
 			}
 
@@ -286,8 +286,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				},
 			}
 			Eventually(operatorControllerDepl).Should(k8sFixture.ExistByName())
-			Eventually(operatorControllerDepl).Should(deployment.HaveAvailableReplicas(1))
-			Eventually(operatorControllerDepl).Should(deployment.HaveReadyReplicas(1))
+			Eventually(operatorControllerDepl).Should(deploymentFixture.HaveAvailableReplicas(1))
+			Eventually(operatorControllerDepl).Should(deploymentFixture.HaveReadyReplicas(1))
 
 			By("verifying first ArgoCD deployment has ImagePullPolicy set to Always")
 			for _, deplName := range deploymentNames {
@@ -296,7 +296,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				}
 				Eventually(depl, "3m", "5s").Should(k8sFixture.ExistByName())
 
-				Eventually(deployment.VerifyDeploymentImagePullPolicy(deplName, ns1.Name, corev1.PullAlways), "3m", "5s").Should(BeTrue(),
+				Eventually(deploymentFixture.VerifyDeploymentImagePullPolicy(deplName, ns1.Name, corev1.PullAlways), "3m", "5s").Should(BeTrue(),
 					"Deployment %s in namespace %s should inherit operator-level imagePullPolicy (Always)", deplName, ns1.Name)
 			}
 
@@ -336,7 +336,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				}
 				Eventually(depl, "3m", "5s").Should(k8sFixture.ExistByName())
 
-				Eventually(deployment.VerifyDeploymentImagePullPolicy(deplName, ns2.Name, corev1.PullAlways), "3m", "5s").Should(BeTrue(),
+				Eventually(deploymentFixture.VerifyDeploymentImagePullPolicy(deplName, ns2.Name, corev1.PullAlways), "3m", "5s").Should(BeTrue(),
 					"Deployment %s in namespace %s should inherit operator-level imagePullPolicy (Always)", deplName, ns2.Name)
 			}
 
@@ -379,7 +379,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				}
 				Eventually(depl, "3m", "5s").Should(k8sFixture.ExistByName())
 
-				Eventually(deployment.VerifyDeploymentImagePullPolicy(deplName, ns3.Name, corev1.PullIfNotPresent), "3m", "5s").Should(BeTrue(),
+				Eventually(deploymentFixture.VerifyDeploymentImagePullPolicy(deplName, ns3.Name, corev1.PullIfNotPresent), "3m", "5s").Should(BeTrue(),
 					"Deployment %s in namespace %s should use explicit imagePullPolicy (IfNotPresent) overriding operator default", deplName, ns3.Name)
 			}
 

--- a/test/openshift/e2e/ginkgo/sequential/1-115_validate_imagepullpolicy_console_plugin_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-115_validate_imagepullpolicy_console_plugin_test.go
@@ -25,7 +25,7 @@ import (
 	gitopsoperatorv1alpha1 "github.com/redhat-developer/gitops-operator/api/v1alpha1"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/clusterserviceversion"
+	clusterserviceversionFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/clusterserviceversion"
 	gitopsserviceFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/gitopsservice"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
@@ -68,7 +68,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(argoCD).Should(k8sFixture.ExistByName())
 			Eventually(argoCD).Should(argocdFixture.BeAvailable())
 
-			csv := clusterserviceversion.Get(ctx, k8sClient)
+			csv := clusterserviceversionFixture.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()
 
@@ -208,7 +208,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(argoCD).Should(k8sFixture.ExistByName())
 			Eventually(argoCD).Should(argocdFixture.BeAvailable())
 
-			csv := clusterserviceversion.Get(ctx, k8sClient)
+			csv := clusterserviceversionFixture.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()
 
@@ -265,7 +265,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		// 		return
 		// 	}
 
-		// 	csv := clusterserviceversion.Get(ctx, k8sClient)
+		// 	csv := clusterserviceversionFixture.Get(ctx, k8sClient)
 		// 	Expect(csv).ToNot(BeNil())
 		// 	defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()
 

--- a/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/onsi/gomega/gcustom"
 	matcher "github.com/onsi/gomega/types"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/clusterserviceversion"
+	clusterserviceversionFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/clusterserviceversion"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -53,33 +53,34 @@ import (
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 )
 
-var (
-	trustedHelmAppSource = &appv1alpha1.ApplicationSource{
-		RepoURL:        "https://stefanprodan.github.io/podinfo",
-		Chart:          "podinfo",
-		TargetRevision: "6.5.3",
-		Helm:           &appv1alpha1.ApplicationSourceHelm{Values: ""},
-	}
-
-	untrustedHelmAppSource = &appv1alpha1.ApplicationSource{
-		RepoURL:        "https://helm.nginx.com/stable",
-		Chart:          "nginx",
-		TargetRevision: "1.1.0",
-		Helm:           &appv1alpha1.ApplicationSourceHelm{Values: "service:\n          type: ClusterIP"},
-	}
-
-	k8sClient    client.Client
-	ctx          context.Context
-	ns           *corev1.Namespace
-	cleanupNs    func()
-	image        string
-	imageVersion string
-
-	clusterSupportsClusterTrustBundles bool
-)
-
 var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 	Context("1-120_repo_server_system_ca_trust", Label("openshift"), func() {
+
+		var (
+			trustedHelmAppSource = &appv1alpha1.ApplicationSource{
+				RepoURL:        "https://stefanprodan.github.io/podinfo",
+				Chart:          "podinfo",
+				TargetRevision: "6.5.3",
+				Helm:           &appv1alpha1.ApplicationSourceHelm{Values: ""},
+			}
+
+			untrustedHelmAppSource = &appv1alpha1.ApplicationSource{
+				RepoURL:        "https://helm.nginx.com/stable",
+				Chart:          "nginx",
+				TargetRevision: "1.1.0",
+				Helm:           &appv1alpha1.ApplicationSourceHelm{Values: "service:\n          type: ClusterIP"},
+			}
+
+			k8sClient    client.Client
+			ctx          context.Context
+			ns           *corev1.Namespace
+			cleanupNs    func()
+			image        string
+			imageVersion string
+
+			clusterSupportsClusterTrustBundles bool
+		)
+
 		BeforeEach(func() {
 			fixture.EnsureSequentialCleanSlate()
 
@@ -89,20 +90,22 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			clusterSupportsClusterTrustBundles = detectClusterTrustBundleSupport(k8sClient, ctx)
 
 			// The differences between the upstream image using Ubuntu, and the downstream one using rhel.
-			image, imageVersion = getArgoCDComponentImageAndVersion()
+			image, imageVersion = getArgoCDComponentImageAndVersion(ctx, k8sClient)
 		})
 
 		AfterEach(func() {
 			fixture.OutputDebugOnFail(ns)
-			cleanupNs()
-			purgeCtbs()
+			if cleanupNs != nil {
+				cleanupNs()
+			}
+			purgeCtbs(ctx, k8sClient, clusterSupportsClusterTrustBundles)
 		})
 
 		It("ensures that missing Secret aborts startup", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with missing Secret")
-			argoCD := argoCDSpec(ns, argov1beta1api.ArgoCDRepoSpec{
+			argoCD := argoCDSpec(image, imageVersion, ns, argov1beta1api.ArgoCDRepoSpec{
 				SystemCATrust: &argov1beta1api.ArgoCDSystemCATrustSpec{
 					Secrets: []corev1.SecretProjection{
 						{LocalObjectReference: corev1.LocalObjectReference{Name: "no-such-secret"}},
@@ -134,7 +137,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(k8sClient.Create(ctx, pluginCm)).To(Succeed())
 
 			By("creating Argo CD instance trusting CTBs")
-			argoCD := argoCDSpec(ns, argov1beta1api.ArgoCDRepoSpec{
+			argoCD := argoCDSpec(image, imageVersion, ns, argov1beta1api.ArgoCDRepoSpec{
 				SystemCATrust: &argov1beta1api.ArgoCDSystemCATrustSpec{
 					DropImageCertificates: true, // So we can test against upstream sites that would otherwise be trusted by the image
 					ClusterTrustBundles: []corev1.ClusterTrustBundleProjection{
@@ -153,8 +156,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
 
-			verifyCorrectlyConfiguredTrust(ns)
-			Expect(repoServerSystemCaTrust(ns)).Should(trustCerts(Equal(2), And(
+			verifyCorrectlyConfiguredTrust(ctx, k8sClient, ns, trustedHelmAppSource, untrustedHelmAppSource)
+			Expect(repoServerSystemCaTrust(k8sClient, ns)).Should(trustCerts(Equal(2), And(
 				ContainSubstring("combined.crt"),
 				ContainSubstring("no-such-ctb.crt"),
 			)))
@@ -174,7 +177,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(k8sClient.Create(ctx, pluginCm)).To(Succeed())
 
 			By("creating Argo CD instance trusting CTBs")
-			argoCD := argoCDSpec(ns, argov1beta1api.ArgoCDRepoSpec{
+			argoCD := argoCDSpec(image, imageVersion, ns, argov1beta1api.ArgoCDRepoSpec{
 				SystemCATrust: &argov1beta1api.ArgoCDSystemCATrustSpec{
 					DropImageCertificates: true, // So we can test against upstream sites that would otherwise be trusted by the image
 					Secrets: []corev1.SecretProjection{{
@@ -205,14 +208,14 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			initContainerLog := getRepoCertGenerationLog(findRunningRepoServerPod(k8sClient, ns))
 			Expect(initContainerLog).Should(ContainSubstring("ca.secret.crt"))
 			Expect(initContainerLog).Should(ContainSubstring("ca.cm.wrong-suffix.crt"))
-			verifyCorrectlyConfiguredTrust(ns)
+			verifyCorrectlyConfiguredTrust(ctx, k8sClient, ns, trustedHelmAppSource, untrustedHelmAppSource)
 		})
 
 		It("ensures that 0 trusted certs with DropImageCertificates trusts nothing", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
-			argoCD := argoCDSpec(ns, argov1beta1api.ArgoCDRepoSpec{
+			argoCD := argoCDSpec(image, imageVersion, ns, argov1beta1api.ArgoCDRepoSpec{
 				// Remount /tmp to make sure the init container can handle that
 				Volumes: []corev1.Volume{{
 					Name:         "user-provided-tmp",
@@ -228,7 +231,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
 
-			Expect(repoServerSystemCaTrust(ns)).Should(trustCerts(Equal(0), Not(BeEmpty())))
+			Expect(repoServerSystemCaTrust(k8sClient, ns)).Should(trustCerts(Equal(0), Not(BeEmpty())))
 
 			trustedHelmApp := createHelmApp(ns, trustedHelmAppSource)
 			Expect(k8sClient.Create(ctx, trustedHelmApp)).To(Succeed())
@@ -244,21 +247,21 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust")
-			argoCD := argoCDSpec(ns, argov1beta1api.ArgoCDRepoSpec{
+			argoCD := argoCDSpec(image, imageVersion, ns, argov1beta1api.ArgoCDRepoSpec{
 				SystemCATrust: &argov1beta1api.ArgoCDSystemCATrustSpec{
 					DropImageCertificates: false, // Keep the image ones
 				},
 			})
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
-			Expect(repoServerSystemCaTrust(ns)).Should(trustCerts(BeNumerically(">", 100), Not(BeEmpty())))
+			Expect(repoServerSystemCaTrust(k8sClient, ns)).Should(trustCerts(BeNumerically(">", 100), Not(BeEmpty())))
 		})
 
 		It("ensures that Secrets and ConfigMaps get reconciled", Label("openshift"), func() {
 			ns, cleanupNs = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 
 			By("creating Argo CD instance with empty system trust, but full of anticipation")
-			argoCD := argoCDSpec(ns, argov1beta1api.ArgoCDRepoSpec{
+			argoCD := argoCDSpec(image, imageVersion, ns, argov1beta1api.ArgoCDRepoSpec{
 				SystemCATrust: &argov1beta1api.ArgoCDSystemCATrustSpec{
 					DropImageCertificates: true, // To make the counting easier
 					Secrets: []corev1.SecretProjection{{
@@ -277,7 +280,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			})
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
-			actualTrust := repoServerSystemCaTrust(ns)
+			actualTrust := repoServerSystemCaTrust(k8sClient, ns)
 			Expect(actualTrust).Should(trustCerts(Equal(0), Not(BeEmpty())))
 
 			By("creating ConfigMap with 1 cert")
@@ -286,7 +289,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			expectReconcile(k8sClient, ns, true, func() {
 				Expect(k8sClient.Create(ctx, cmCert)).To(Succeed())
 			})
-			actualTrust = repoServerSystemCaTrust(ns)
+			actualTrust = repoServerSystemCaTrust(k8sClient, ns)
 			Eventually(actualTrust, "30s", "5s").Should(trustCerts(Equal(1), Not(BeEmpty())))
 
 			By("creating Secret with 1 cert")
@@ -295,7 +298,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			expectReconcile(k8sClient, ns, true, func() {
 				Expect(k8sClient.Create(ctx, secretCert)).To(Succeed())
 			})
-			actualTrust = repoServerSystemCaTrust(ns)
+			actualTrust = repoServerSystemCaTrust(k8sClient, ns)
 			Eventually(actualTrust, "30s", "5s").Should(trustCerts(Equal(2), Not(BeEmpty())))
 
 			By("updating ConfigMap to 2 certs")
@@ -307,7 +310,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					}
 				})
 			})
-			actualTrust = repoServerSystemCaTrust(ns)
+			actualTrust = repoServerSystemCaTrust(k8sClient, ns)
 			Eventually(actualTrust, "30s", "5s").Should(trustCerts(Equal(3), Not(BeEmpty())))
 
 			By("updating Secret to 0 certs")
@@ -319,7 +322,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					secret.StringData = map[string]string{}
 				})
 			})
-			actualTrust = repoServerSystemCaTrust(ns)
+			actualTrust = repoServerSystemCaTrust(k8sClient, ns)
 			Eventually(actualTrust, "30s", "5s").Should(trustCerts(Equal(2), Not(BeEmpty())))
 
 			By("updating ConfigMap to 1 certs")
@@ -330,14 +333,14 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					}
 				})
 			})
-			actualTrust = repoServerSystemCaTrust(ns)
+			actualTrust = repoServerSystemCaTrust(k8sClient, ns)
 			Eventually(actualTrust, "30s", "5s").Should(trustCerts(Equal(1), Not(BeEmpty())))
 
 			By("deleting ConfigMap")
 			expectReconcile(k8sClient, ns, true, func() {
 				Expect(k8sClient.Delete(ctx, cmCert)).To(Succeed())
 			})
-			actualTrust = repoServerSystemCaTrust(ns)
+			actualTrust = repoServerSystemCaTrust(k8sClient, ns)
 			Eventually(actualTrust, "30s", "5s").Should(trustCerts(Equal(0), Not(BeEmpty())))
 		})
 
@@ -352,7 +355,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			_ = k8sClient.Delete(ctx, combinedCtb) // Exists only in case of previous failures, must be deleted before argo starts!
 
 			By("creating Argo CD instance with empty system trust, but full of anticipation")
-			argoCD := argoCDSpec(ns, argov1beta1api.ArgoCDRepoSpec{
+			argoCD := argoCDSpec(image, imageVersion, ns, argov1beta1api.ArgoCDRepoSpec{
 				SystemCATrust: &argov1beta1api.ArgoCDSystemCATrustSpec{
 					DropImageCertificates: true, // To make the counting easier
 					ClusterTrustBundles: []corev1.ClusterTrustBundleProjection{{
@@ -362,7 +365,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			})
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
-			actualTrust := repoServerSystemCaTrust(ns)
+			actualTrust := repoServerSystemCaTrust(k8sClient, ns)
 			Expect(actualTrust).Should(trustCerts(Equal(0), Not(BeEmpty())), actualTrust.diagnose())
 
 			By("creating ClusterTrustBundle with 2 certs")
@@ -370,26 +373,26 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			expectReconcile(k8sClient, ns, true, func() {
 				Expect(k8sClient.Create(ctx, combinedCtb)).To(Succeed())
 			})
-			actualTrust = repoServerSystemCaTrust(ns)
+			actualTrust = repoServerSystemCaTrust(k8sClient, ns)
 			Eventually(actualTrust, "30s", "5s").Should(trustCerts(Equal(2), Not(BeEmpty())), actualTrust.diagnose())
 
 			By("updating ClusterTrustBundle with 1 cert")
 			expectReconcile(k8sClient, ns, true, func() {
-				ctbUpdate(combinedCtb, func(bundle *certificatesv1beta1.ClusterTrustBundle) {
+				ctbUpdate(k8sClient, combinedCtb, func(bundle *certificatesv1beta1.ClusterTrustBundle) {
 					bundle.Spec = certificatesv1beta1.ClusterTrustBundleSpec{
 						SignerName:  bundle.Spec.SignerName,
 						TrustBundle: getCACert("github.com"),
 					}
 				})
 			})
-			actualTrust = repoServerSystemCaTrust(ns)
+			actualTrust = repoServerSystemCaTrust(k8sClient, ns)
 			Eventually(actualTrust, "6m", "15s").Should(trustCerts(Equal(1), Not(BeEmpty())), actualTrust.diagnose())
 
 			By("deleting ClusterTrustBundle")
 			expectReconcile(k8sClient, ns, true, func() {
 				Expect(k8sClient.Delete(ctx, combinedCtb)).To(Succeed())
 			})
-			actualTrust = repoServerSystemCaTrust(ns)
+			actualTrust = repoServerSystemCaTrust(k8sClient, ns)
 			Eventually(actualTrust, "6m", "15s").Should(trustCerts(Equal(0), Not(BeEmpty())), actualTrust.diagnose())
 		})
 
@@ -404,7 +407,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			labelVal := rand.String(5)
 			signerName := "acme.com/signer"
 			By("creating Argo CD instance with system trust")
-			argoCD := argoCDSpec(ns, argov1beta1api.ArgoCDRepoSpec{
+			argoCD := argoCDSpec(image, imageVersion, ns, argov1beta1api.ArgoCDRepoSpec{
 				SystemCATrust: &argov1beta1api.ArgoCDSystemCATrustSpec{
 					DropImageCertificates: true, // To make the counting easier
 					// Test CTB update detection based on CTB binding specified by labels - no real signers involved
@@ -431,7 +434,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			expectReconcile(k8sClient, ns, true, func() {
 				Expect(k8sClient.Create(ctx, oneCtb)).To(Succeed())
 			})
-			actualTrust := repoServerSystemCaTrust(ns)
+			actualTrust := repoServerSystemCaTrust(k8sClient, ns)
 			Eventually(actualTrust, "30s", "5s").Should(trustCerts(Equal(1), Not(BeEmpty())), actualTrust.diagnose())
 
 			By("adding ClusterTrustBundle with other cert")
@@ -442,7 +445,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			expectReconcile(k8sClient, ns, true, func() {
 				Expect(k8sClient.Create(ctx, twoCtb)).To(Succeed())
 			})
-			actualTrust = repoServerSystemCaTrust(ns)
+			actualTrust = repoServerSystemCaTrust(k8sClient, ns)
 			Eventually(actualTrust, "30s", "5s").Should(trustCerts(Equal(2), Not(BeEmpty())), actualTrust.diagnose())
 
 			By("updating Argo CD to read from ClusterTrustBundle that does not exist")
@@ -457,7 +460,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					}
 				})
 			})
-			actualTrust = repoServerSystemCaTrust(ns)
+			actualTrust = repoServerSystemCaTrust(k8sClient, ns)
 			Consistently(actualTrust, "10s", "5s").Should(trustCerts(Equal(0), Not(BeEmpty())), actualTrust.diagnose())
 
 			By("creating unrelated ClusterTrustBundle")
@@ -465,13 +468,13 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			expectReconcile(k8sClient, ns, false, func() {
 				Expect(k8sClient.Create(ctx, fourCtb)).To(Succeed())
 			})
-			actualTrust = repoServerSystemCaTrust(ns)
+			actualTrust = repoServerSystemCaTrust(k8sClient, ns)
 			Consistently(actualTrust, "10s", "5s").Should(trustCerts(Equal(0), Not(BeEmpty())), actualTrust.diagnose())
 		})
 	})
 })
 
-func ctbUpdate(obj *certificatesv1beta1.ClusterTrustBundle, modify func(*certificatesv1beta1.ClusterTrustBundle)) {
+func ctbUpdate(k8sClient client.Client, obj *certificatesv1beta1.ClusterTrustBundle, modify func(*certificatesv1beta1.ClusterTrustBundle)) {
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Retrieve the latest version of the object
 		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)
@@ -487,7 +490,7 @@ func ctbUpdate(obj *certificatesv1beta1.ClusterTrustBundle, modify func(*certifi
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func argoCDSpec(ns *corev1.Namespace, repoSpec argov1beta1api.ArgoCDRepoSpec) *argov1beta1api.ArgoCD {
+func argoCDSpec(image, imageVersion string, ns *corev1.Namespace, repoSpec argov1beta1api.ArgoCDRepoSpec) *argov1beta1api.ArgoCD {
 	return &argov1beta1api.ArgoCD{
 		ObjectMeta: metav1.ObjectMeta{Name: "argocd", Namespace: ns.Name},
 		Spec: argov1beta1api.ArgoCDSpec{
@@ -730,7 +733,7 @@ func (pt *podTrust) diagnose() string {
 	)
 }
 
-func repoServerSystemCaTrust(ns *corev1.Namespace) *podTrust {
+func repoServerSystemCaTrust(k8sClient client.Client, ns *corev1.Namespace) *podTrust {
 	return &podTrust{ns: ns, k8sClient: k8sClient}
 }
 
@@ -746,7 +749,7 @@ func expectReconcile(k8sClient client.Client, ns *corev1.Namespace, reconcile bo
 	action()
 
 	if reconcile {
-		Eventually(podNameFunc, "30s", "5s").
+		Eventually(podNameFunc, "120s", "5s").
 			WithOffset(1).
 			Should(Not(Equal(oldPodName)), "expected pod to reconcile")
 	} else {
@@ -855,7 +858,7 @@ func findRunningRepoServerPod(k8sClient client.Client, ns *corev1.Namespace) *co
 	return pod
 }
 
-func verifyCorrectlyConfiguredTrust(ns *corev1.Namespace) {
+func verifyCorrectlyConfiguredTrust(ctx context.Context, k8sClient client.Client, ns *corev1.Namespace, trustedHelmAppSource, untrustedHelmAppSource *appv1alpha1.ApplicationSource) {
 	untrustedHelmApp := createHelmApp(ns, untrustedHelmAppSource)
 	Expect(k8sClient.Create(ctx, untrustedHelmApp)).To(Succeed())
 
@@ -889,7 +892,7 @@ func verifyCorrectlyConfiguredTrust(ns *corev1.Namespace) {
 }
 
 // purgeCtbs deletes all of the cluster-wide resource, that can get leaked on test failure/abort.
-func purgeCtbs() {
+func purgeCtbs(ctx context.Context, k8sClient client.Client, clusterSupportsClusterTrustBundles bool) {
 	if clusterSupportsClusterTrustBundles {
 		expr := client.MatchingLabels{"argocd-operator-test": "repo_server_system_ca_trust"}
 		Expect(k8sClient.DeleteAllOf(ctx, &certificatesv1beta1.ClusterTrustBundle{}, expr)).To(Succeed())
@@ -899,8 +902,8 @@ func purgeCtbs() {
 // getArgoCDComponentImageAndVersion ensures rhel based image is used for testing this.
 // If this is installed as a full-blown operator, use its images.
 // If not, inject bleeding-edge pre-release rhel-based images.
-func getArgoCDComponentImageAndVersion() (string, string) {
-	csv := clusterserviceversion.Get(ctx, k8sClient)
+func getArgoCDComponentImageAndVersion(ctx context.Context, k8sClient client.Client) (string, string) {
+	csv := clusterserviceversionFixture.Get(ctx, k8sClient)
 	if csv != nil {
 		for _, image := range csv.Spec.RelatedImages {
 			if image.Name == "argocd_image" {

--- a/test/openshift/e2e/ginkgo/sequential/1-120_validate_running_must_gather.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-120_validate_running_must_gather.go
@@ -123,6 +123,12 @@ func gather() string {
 		true, true,
 		"oc", "adm", "must-gather", "--image", mustGatherImage(), "--dest-dir", destDir,
 	)
+
+	if err != nil && strings.Contains(stdout, "unable to pull image: ImagePullBackOff: Back-off pulling image \"quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-must-gather") {
+		_ = os.RemoveAll(destDir)
+		Skip("skip the case where image can't be retrieved from quay.io: failure to retrieve the image prevents further testing, it should not fail the image itself")
+	}
+
 	Expect(err).ToNot(HaveOccurred())
 
 	errorLines := make([]string, 0)

--- a/test/openshift/e2e/ginkgo/sequential/1-121-validate_resource_constraints_gitopsservice_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-121-validate_resource_constraints_gitopsservice_test.go
@@ -9,7 +9,7 @@ import (
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	gitopsoperatorv1alpha1 "github.com/redhat-developer/gitops-operator/api/v1alpha1"
 	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture"
-	"github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/clusterserviceversion"
+	clusterserviceversionFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/clusterserviceversion"
 	deploymentFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/deployment"
 	gitopsserviceFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/gitopsservice"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
@@ -36,7 +36,7 @@ func getOCPVersion() string {
 }
 
 func addDynamicPluginEnv(csv *olmv1alpha1.ClusterServiceVersion, ocVersion string) {
-	clusterserviceversion.Update(csv, func(csv *olmv1alpha1.ClusterServiceVersion) {
+	clusterserviceversionFixture.Update(csv, func(csv *olmv1alpha1.ClusterServiceVersion) {
 		envList := csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Env
 		envList = append(envList, corev1.EnvVar{Name: "DYNAMIC_PLUGIN_START_OCP_VERSION", Value: ocVersion})
 		csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers[0].Env = envList
@@ -74,7 +74,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("validates that GitOpsService can take in custom resource constraints", Label("openshift"), func() {
-			csv := clusterserviceversion.Get(ctx, k8sClient)
+			csv := clusterserviceversionFixture.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()
 
@@ -155,7 +155,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("validates that GitOpsService can update resource constraints", Label("openshift"), func() {
-			csv := clusterserviceversion.Get(ctx, k8sClient)
+			csv := clusterserviceversionFixture.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()
 
@@ -226,7 +226,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		})
 
 		It("validates gitops plugin and backend can have different resource constraints", Label("openshift"), func() {
-			csv := clusterserviceversion.Get(ctx, k8sClient)
+			csv := clusterserviceversionFixture.Get(ctx, k8sClient)
 			Expect(csv).ToNot(BeNil())
 			defer func() { Expect(fixture.RemoveDynamicPluginFromCSV(ctx, k8sClient)).To(Succeed()) }()
 

--- a/test/openshift/e2e/ginkgo/sequential/1-121_validate_custom_labels_rollouts.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-121_validate_custom_labels_rollouts.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package parallel
+package sequential
 
 import (
 	"context"
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
+var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-121_validate_custom_labels_rollouts", func() {
 
@@ -44,7 +44,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 		)
 
 		BeforeEach(func() {
-			fixture.EnsureParallelCleanSlate()
+			fixture.EnsureSequentialCleanSlate()
 			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
 			ctx = context.Background()
 

--- a/test/openshift/e2e/ginkgo/sequential/1-132_validate_sensitive_annotation_masking_test.go
+++ b/test/openshift/e2e/ginkgo/sequential/1-132_validate_sensitive_annotation_masking_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package parallel
+package sequential
 
 import (
 	"context"
@@ -32,6 +32,7 @@ import (
 	argocdFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/argocd"
 	configmapFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/configmap"
 	k8sFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/k8s"
+	secretFixture "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/secret"
 	fixtureUtils "github.com/redhat-developer/gitops-operator/test/openshift/e2e/ginkgo/fixture/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,7 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
+var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-132_validate_sensitive_annotation_masking_test", func() {
 
@@ -61,7 +62,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 		)
 
 		BeforeEach(func() {
-			fixture.EnsureParallelCleanSlate()
+			fixture.EnsureSequentialCleanSlate() // This test runs in sequential because it uses Argo CD CLI login
 			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
 			ctx = context.Background()
 		})
@@ -146,7 +147,16 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 					"--skip-test-tls",
 				)
 				if loginErr != nil {
+					// In the failing case, output the error, and also the current contents of the Route
 					GinkgoWriter.Println("CLI login error:", loginErr, "output:", output)
+
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(argoCDRoute), argoCDRoute)
+					if err != nil {
+						GinkgoWriter.Println("Unable to retrieve Route", err)
+						return false
+					}
+					GinkgoWriter.Println("Route contents:", argoCDRoute.Spec.Host, "|", argoCDRoute.Status.Ingress)
+
 					return false
 				}
 				return strings.Contains(output, "logged in successfully")
@@ -185,12 +195,12 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			By("simulating OpenShift behavior: adding openshift.io/token-secret.value to the live secret")
 			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "dockercfg-token-secret", Namespace: appNS.Name}}
 			Eventually(secret).Should(k8sFixture.ExistByName())
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
-			if secret.Annotations == nil {
-				secret.Annotations = map[string]string{}
-			}
-			secret.Annotations[tokenAnnotationKey] = sensitiveToken
-			Expect(k8sClient.Update(ctx, secret)).To(Succeed())
+			secretFixture.Update(secret, func(s *corev1.Secret) {
+				if s.Annotations == nil {
+					s.Annotations = map[string]string{}
+				}
+				s.Annotations[tokenAnnotationKey] = sensitiveToken
+			})
 
 			By("forcing a single ArgoCD refresh so the live state is re-evaluated")
 			// --grpc-web suppresses the gRPC-over-HTTP2 warning emitted by newer ArgoCD CLIs


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What does this PR do / why we need it**:

- Add admitted ingress check for openshift-gitops `Route`  when we are logging in to Argo CD
- Fixed cases where we were calling `k8sClient.Update` (prone to race conditions) and replaced it with `fixture.Update`
- For '1-120-must-gather', skip the test if image can't be retrieved from quay.io.
- Moved a few more tests to sequential 
    - Any test that logs in to Argo CD via Argo CD CLI needs to be sequential
    - For others it wasn't incorrect to put them in parallel, but the code tested is affected by multiple simultaneous `ArgoCD` CRs, so it's safer to including them in sequential. It also helps further debug if they fail again.
- Misc cleanup
    - In cases where fixture package alias was missing, I added it
    - In `test/openshift/e2e/ginkgo/sequential/1-120_repo_server_system_ca_trust.go`, moved the variables out of package scope

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Test acceptance criteria**:

* [ ] Unit Test
* [X] E2E Test

**How to test changes / Special notes to the reviewer**:
