### PR TITLE
chore(test): Avoid printing test-credentials

### DIFF
--- a/test/openshift/e2e/ginkgo/fixture/gitserver/repo.go
+++ b/test/openshift/e2e/ginkgo/fixture/gitserver/repo.go
@@ -26,7 +26,7 @@ type Repo struct {
 	repoName string
 
 	cloneDir  *os.Root
-	transport Transport
+	clonedOver Transport
 }
 
 // GetRepoHttpURL returns the HTTPS clone URL reachable from inside the cluster.
@@ -54,10 +54,10 @@ func (r Repo) getRepoSshURLLocal() string {
 	return fmt.Sprintf("ssh://%s@127.0.0.1:%d/%s/%s.git", giteaSSHLogin, r.server.localSSHPort, r.server.httpUsername, r.repoName)
 }
 
-func (r *Repo) Clone(t Transport) (cleanup func(), err error) {
-	r.transport = t
+func (r *Repo) Clone(transport Transport) (cleanup func(), err error) {
+	r.clonedOver = transport
 
-	if t == TransportSSH {
+	if transport == TransportSSH {
 		if _, err := r.server.getSSHKeyFile(); err != nil {
 			return nil, err
 		}
@@ -80,11 +80,11 @@ func (r *Repo) Clone(t Transport) (cleanup func(), err error) {
 	}
 
 	cloneURL := r.getRepoSshURLLocal()
-	if t == TransportHTTPS {
+	if transport == TransportHTTPS {
 		cloneURL = r.getRepoHttpURLWithCredentials()
 	}
 
-	GinkgoWriter.Println("Cloning repo:", cloneURL)
+	GinkgoWriter.Println("Cloning repo %q over %s", r.repoName, transport)
 
 	out, err := r.git("clone", cloneURL, ".")
 	if err != nil {
@@ -149,7 +149,7 @@ func (r *Repo) git(args ...string) (string, error) {
 
 	cmd := exec.Command("git", args...) // #nosec G204 // Binary is specified by literal
 	cmd.Dir = r.cloneDir.Name()
-	if r.transport == TransportHTTPS {
+	if r.clonedOver == TransportHTTPS {
 		cmd.Env = append(os.Environ(), "GIT_SSL_NO_VERIFY=true")
 	} else {
 		sshKeyFile, err := r.server.getSSHKeyFile()

--- a/test/openshift/e2e/ginkgo/fixture/gitserver/repo.go
+++ b/test/openshift/e2e/ginkgo/fixture/gitserver/repo.go
@@ -25,7 +25,7 @@ type Repo struct {
 	server   *Server
 	repoName string
 
-	cloneDir  *os.Root
+	cloneDir   *os.Root
 	clonedOver Transport
 }
 
@@ -84,7 +84,7 @@ func (r *Repo) Clone(transport Transport) (cleanup func(), err error) {
 		cloneURL = r.getRepoHttpURLWithCredentials()
 	}
 
-	GinkgoWriter.Println("Cloning repo %q over %s", r.repoName, transport)
+	GinkgoWriter.Printf("Cloning repo %q over %s", r.repoName, transport)
 
 	out, err := r.git("clone", cloneURL, ".")
 	if err != nil {


### PR DESCRIPTION
openshift-ci hides the entire file when the password is in the URL.

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
/kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
